### PR TITLE
feat(macos): add macOS 13 compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Lithe",
     platforms: [
-        .macOS(.v14)
+        .macOS(.v13)
     ],
     products: [
         .executable(name: "Lithe", targets: ["Lithe"])

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -23,7 +23,7 @@
     <key>CFBundleVersion</key>
     <string>3</string>
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>13.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSPrincipalClass</key>

--- a/Sources/Lithe/Theme/LitheTheme.swift
+++ b/Sources/Lithe/Theme/LitheTheme.swift
@@ -197,7 +197,7 @@ private struct LithePointerModifier: ViewModifier {
                 isHovered = isInside
                 updateCursor(isPointing: isInside && isEnabled)
             }
-            .onChange(of: isEnabled) {
+            .onChange(of: isEnabled) { _ in
                 updateCursor(isPointing: isHovered && isEnabled)
             }
             .onDisappear {

--- a/Sources/Lithe/Views/ChangesSidebarView.swift
+++ b/Sources/Lithe/Views/ChangesSidebarView.swift
@@ -57,7 +57,7 @@ struct ChangesSidebarView: View {
         }
         .background(LitheTheme.sidebar)
         .onAppear { selectRequestedStashIfNeeded() }
-        .onChange(of: model.requestedStashReference) { _, _ in
+        .onChange(of: model.requestedStashReference) { _ in
             selectRequestedStashIfNeeded()
         }
         .confirmationDialog(

--- a/Sources/Lithe/Views/CloneRepositoryView.swift
+++ b/Sources/Lithe/Views/CloneRepositoryView.swift
@@ -78,7 +78,7 @@ struct CloneRepositoryView: View {
         .onAppear {
             focusedField = .remote
         }
-        .onChange(of: remoteURL) { _, value in
+        .onChange(of: remoteURL) { value in
             guard folderName.isEmpty else { return }
             folderName = defaultFolderName(from: value)
         }

--- a/Sources/Lithe/Views/Components/LitheKeyboardCompatibility.swift
+++ b/Sources/Lithe/Views/Components/LitheKeyboardCompatibility.swift
@@ -1,0 +1,53 @@
+import AppKit
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func litheOnReturn(perform action: @escaping (_ isShiftPressed: Bool) -> Void) -> some View {
+        if #available(macOS 14.0, *) {
+            onKeyPress(keys: [.return]) { press in
+                action(press.modifiers.contains(.shift))
+                return .handled
+            }
+        } else {
+            onSubmit {
+                action(NSEvent.modifierFlags.contains(.shift))
+            }
+        }
+    }
+}
+
+struct LitheContentUnavailableView: View {
+    let title: LocalizedStringKey
+    let systemImage: String
+    let description: Text?
+
+    init(
+        _ title: LocalizedStringKey,
+        systemImage: String,
+        description: Text? = nil
+    ) {
+        self.title = title
+        self.systemImage = systemImage
+        self.description = description
+    }
+
+    @ViewBuilder
+    var body: some View {
+        if #available(macOS 14.0, *) {
+            ContentUnavailableView(title, systemImage: systemImage, description: description)
+        } else {
+            VStack(spacing: 8) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 28))
+                Text(title)
+                    .font(.headline)
+                description?
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+            }
+            .foregroundStyle(.secondary)
+            .padding(24)
+        }
+    }
+}

--- a/Sources/Lithe/Views/DatabaseSQLWorkspaceView.swift
+++ b/Sources/Lithe/Views/DatabaseSQLWorkspaceView.swift
@@ -408,7 +408,7 @@ private struct DatabaseHistoryView: View {
             Rectangle().fill(LitheTheme.divider).frame(height: 1)
 
             if entries.isEmpty {
-                ContentUnavailableView("No query history", systemImage: "clock.arrow.circlepath")
+                LitheContentUnavailableView("No query history", systemImage: "clock.arrow.circlepath")
             } else {
                 List(entries) { entry in
                     Button {
@@ -624,7 +624,7 @@ struct DatabaseSQLWorkspaceView: View {
                 }
             }
         } else {
-            ContentUnavailableView("No Query Tab", systemImage: "terminal")
+            LitheContentUnavailableView("No Query Tab", systemImage: "terminal")
         }
     }
 
@@ -642,10 +642,10 @@ struct DatabaseSQLWorkspaceView: View {
                     }
                 }
         } else if let affected = model.databaseFeature.selectedSQLTab?.rowsAffected {
-            ContentUnavailableView("Statement completed", systemImage: "checkmark.circle", description: Text("Rows affected: \(affected)"))
+            LitheContentUnavailableView("Statement completed", systemImage: "checkmark.circle", description: Text("Rows affected: \(affected)"))
                 .foregroundStyle(LitheTheme.secondaryText)
         } else {
-            ContentUnavailableView("Query Results", systemImage: "tablecells", description: Text("Run a SELECT, SHOW, DESCRIBE, or EXPLAIN statement to inspect results."))
+            LitheContentUnavailableView("Query Results", systemImage: "tablecells", description: Text("Run a SELECT, SHOW, DESCRIBE, or EXPLAIN statement to inspect results."))
                 .foregroundStyle(LitheTheme.secondaryText)
         }
     }
@@ -830,7 +830,7 @@ private struct DatabaseStructureView: View {
                 Text("Dropping \(change.name) cannot be undone by the table editor. A recovery snapshot should be taken before this operation.")
             }
         } else {
-            ContentUnavailableView("No Table Selected", systemImage: "list.bullet.rectangle", description: Text("Choose a table to inspect its columns, indexes, and foreign keys."))
+            LitheContentUnavailableView("No Table Selected", systemImage: "list.bullet.rectangle", description: Text("Choose a table to inspect its columns, indexes, and foreign keys."))
                 .foregroundStyle(LitheTheme.secondaryText)
         }
     }

--- a/Sources/Lithe/Views/DatabaseSchemaDiffView.swift
+++ b/Sources/Lithe/Views/DatabaseSchemaDiffView.swift
@@ -47,7 +47,7 @@ struct DatabaseSchemaDiffView: View {
             if let diff {
                 diffContent(diff)
             } else {
-                ContentUnavailableView(
+                LitheContentUnavailableView(
                     "No Schema Comparison",
                     systemImage: "arrow.left.arrow.right",
                     description: Text("Choose two connections to inspect structural differences.")
@@ -92,7 +92,7 @@ struct DatabaseSchemaDiffView: View {
             Rectangle().fill(LitheTheme.divider).frame(height: 1)
 
             if diff.items.isEmpty {
-                ContentUnavailableView("Schemas Match", systemImage: "checkmark.circle", description: Text("No structural changes are required."))
+                LitheContentUnavailableView("Schemas Match", systemImage: "checkmark.circle", description: Text("No structural changes are required."))
                     .foregroundStyle(LitheTheme.success)
             } else {
                 List(diff.items) { item in

--- a/Sources/Lithe/Views/DatabaseSidebarView.swift
+++ b/Sources/Lithe/Views/DatabaseSidebarView.swift
@@ -252,7 +252,7 @@ struct DatabaseSidebarView: View {
         .fileImporter(isPresented: $showsDBXImporter, allowedContentTypes: [.json]) { result in
             importDBXFile(result)
         }
-        .onChange(of: model.databaseFeature.selectedProfileID) { _, selectedID in
+        .onChange(of: model.databaseFeature.selectedProfileID) { selectedID in
             if let selectedID { expandedProfileIDs = [selectedID] }
         }
     }
@@ -1797,7 +1797,7 @@ struct DatabaseConnectionEditor: View {
             .frame(height: 58)
             .background(LitheTheme.toolHeader)
         }
-        .onChange(of: kind) { _, newKind in
+        .onChange(of: kind) { newKind in
             guard profile == nil else { return }
             switch newKind {
             case .mysql: port = "3306"; username = "root"; database = ""; path = ""

--- a/Sources/Lithe/Views/DatabaseSpecializedWorkspaceViews.swift
+++ b/Sources/Lithe/Views/DatabaseSpecializedWorkspaceViews.swift
@@ -28,7 +28,7 @@ struct RedisWorkspaceView: View {
         .task(id: feature.selectedProfileID) {
             await feature.loadRedisKeys(pattern: pattern)
         }
-        .onChange(of: feature.redisSelectedKey) { _, detail in
+        .onChange(of: feature.redisSelectedKey) { detail in
             guard let detail else {
                 stringDraft = ""; hashDraft = "{}"; ttlDraft = ""; renameDraft = ""
                 return
@@ -355,7 +355,7 @@ struct NacosWorkspaceView: View {
             await feature.loadNacosConfigs(dataId: dataIDSearch, group: groupSearch)
             await feature.loadNacosServices(serviceName: serviceSearch, group: serviceGroupSearch)
         }
-        .onChange(of: feature.nacosSelectedConfig) { _, detail in
+        .onChange(of: feature.nacosSelectedConfig) { detail in
             guard let detail else { return }
             draftDataID = detail.dataId; draftGroup = detail.group; draftType = detail.type ?? ""; draftContent = detail.content
         }

--- a/Sources/Lithe/Views/DatabaseTableView.swift
+++ b/Sources/Lithe/Views/DatabaseTableView.swift
@@ -52,7 +52,7 @@ struct DatabaseTableView: View {
             }
         }
         .background(LitheTheme.editor)
-        .onChange(of: model.databaseFeature.selectedTable) { _, _ in
+        .onChange(of: model.databaseFeature.selectedTable) { _ in
             discard()
             appliedFilters = []
             appliedSort = []
@@ -60,7 +60,7 @@ struct DatabaseTableView: View {
             filterJoin = .and
             filterConditions = [.init()]
         }
-        .onChange(of: model.databaseFeature.columns) { _, columns in
+        .onChange(of: model.databaseFeature.columns) { columns in
             if filterConditions.count == 1, filterConditions[0].column.isEmpty {
                 filterConditions[0].column = columns.first ?? ""
             }
@@ -489,7 +489,7 @@ struct DatabaseTableView: View {
                         alignment: .topLeading
                     )
                 }
-                .onChange(of: jumpTargetColumn) { _, column in
+                .onChange(of: jumpTargetColumn) { column in
                     guard let column else { return }
                     withAnimation { proxy.scrollTo("column-\(column)", anchor: .center) }
                     jumpTargetColumn = nil

--- a/Sources/Lithe/Views/DiffHorizontalScrollSupport.swift
+++ b/Sources/Lithe/Views/DiffHorizontalScrollSupport.swift
@@ -70,7 +70,7 @@ struct DiffHorizontalScroller: View {
         .opacity(maximumOffset > 0.5 ? 1 : 0)
         .allowsHitTesting(maximumOffset > 0.5)
         .accessibilityLabel("Synchronized diff horizontal scroll")
-        .onChange(of: maximumOffset) { _, newMaximum in
+        .onChange(of: maximumOffset) { newMaximum in
             offset = min(max(offset, 0), newMaximum)
         }
     }

--- a/Sources/Lithe/Views/DiffPaneView.swift
+++ b/Sources/Lithe/Views/DiffPaneView.swift
@@ -32,7 +32,7 @@ struct DiffPaneView: View {
                 }
             }
         }
-        .onChange(of: rows.map(\.id)) { _, _ in
+        .onChange(of: rows.map(\.id)) { _ in
             expandedRegionIDs.removeAll()
             pinnedRowIDs.removeAll()
             scrollTarget = nil
@@ -69,7 +69,7 @@ struct DiffPaneView: View {
                 ) { region in
                     expandedRegionIDs.insert(region.id)
                 }
-                .onChange(of: scrollTarget) { _, target in
+                .onChange(of: scrollTarget) { target in
                     guard let target else { return }
                     withAnimation(.easeInOut(duration: 0.18)) {
                         proxy.scrollTo(target, anchor: .center)

--- a/Sources/Lithe/Views/DiffReviewView.swift
+++ b/Sources/Lithe/Views/DiffReviewView.swift
@@ -34,17 +34,17 @@ struct DiffReviewView: View {
             }
         }
         .background(LitheTheme.editor)
-        .onChange(of: model.diffRows.count) { _, _ in
+        .onChange(of: model.diffRows.count) { _ in
             selectedDifferenceIndex = 0
             selectedDiffSearchIndex = 0
             expandedCollapseRegionIDs.removeAll()
             mapTargetRowID = nil
         }
-        .onChange(of: change.id) { _, _ in
+        .onChange(of: change.id) { _ in
             expandedCollapseRegionIDs.removeAll()
             mapTargetRowID = nil
         }
-        .onChange(of: diffSearchQuery) { _, _ in
+        .onChange(of: diffSearchQuery) { _ in
             selectedDiffSearchIndex = 0
         }
     }
@@ -466,12 +466,11 @@ struct DiffReviewView: View {
                 .font(.system(size: 11.5))
                 .frame(width: 145)
                 .focused($diffSearchFocused)
-                .onKeyPress(keys: [.return]) { press in
+                .litheOnReturn { isShiftPressed in
                     navigateDiffSearch(
-                        by: press.modifiers.contains(.shift) ? -1 : 1,
+                        by: isShiftPressed ? -1 : 1,
                         proxy: proxy
                     )
-                    return .handled
                 }
 
             Text(diffSearchLabel)

--- a/Sources/Lithe/Views/DiffSplitPaneView.swift
+++ b/Sources/Lithe/Views/DiffSplitPaneView.swift
@@ -105,7 +105,7 @@ struct DiffSplitPaneView<RowOverlay: View>: View {
                 )
             }
         }
-        .onChange(of: contentWidth) { _, _ in
+        .onChange(of: contentWidth) { _ in
             horizontalOffset = min(horizontalOffset, maximumHorizontalOffset)
         }
     }

--- a/Sources/Lithe/Views/EditorAreaView.swift
+++ b/Sources/Lithe/Views/EditorAreaView.swift
@@ -63,7 +63,7 @@ struct EditorAreaView: View {
             }
         }
         .background(LitheTheme.editor)
-        .onChange(of: model.openDocuments.map(\.id)) { _, ids in
+        .onChange(of: model.openDocuments.map(\.id)) { ids in
             if let splitDocumentID, !ids.contains(splitDocumentID) {
                 self.splitDocumentID = nil
             }

--- a/Sources/Lithe/Views/FindBarView.swift
+++ b/Sources/Lithe/Views/FindBarView.swift
@@ -22,13 +22,12 @@ struct FindBarView: View {
                 .textFieldStyle(.plain)
                 .font(.system(size: 12.5))
                 .focused($focused)
-                .onKeyPress(keys: [.return]) { press in
-                    if press.modifiers.contains(.shift) {
+                .litheOnReturn { isShiftPressed in
+                    if isShiftPressed {
                         model.navigateFind(offset: -1)
                     } else {
                         model.navigateFind(offset: 1)
                     }
-                    return .handled
                 }
 
             Text(matchLabel)

--- a/Sources/Lithe/Views/GitCommitDiffReviewView.swift
+++ b/Sources/Lithe/Views/GitCommitDiffReviewView.swift
@@ -43,7 +43,7 @@ struct GitCommitDiffReviewView: View {
             }
         }
         .background(LitheTheme.editor)
-        .onChange(of: model.diffRows.count) { _, _ in
+        .onChange(of: model.diffRows.count) { _ in
             selectedDifferenceIndex = 0
         }
     }

--- a/Sources/Lithe/Views/GitLogView.swift
+++ b/Sources/Lithe/Views/GitLogView.swift
@@ -678,7 +678,7 @@ struct GitLogView: View {
                         }
                     }
                     .litheScrollViewChrome(hideHorizontal: true)
-                    .onChange(of: model.selectedGitCommit?.hash) {
+                    .onChange(of: model.selectedGitCommit?.hash) { _ in
                         guard let hash = model.selectedGitCommit?.hash else { return }
                         withAnimation(.easeOut(duration: 0.16)) {
                             proxy.scrollTo(hash, anchor: .center)

--- a/Sources/Lithe/Views/JavaRunConfigurationEditorView.swift
+++ b/Sources/Lithe/Views/JavaRunConfigurationEditorView.swift
@@ -51,7 +51,7 @@ struct JavaRunConfigurationEditorView: View {
         .frame(width: 520, height: 470)
         .background(LitheTheme.window)
         .preferredColorScheme(.dark)
-        .onChange(of: options) {
+        .onChange(of: options) { _ in
             feature.updateOptions(options, for: configuration)
         }
     }

--- a/Sources/Lithe/Views/MarkdownPreviewView.swift
+++ b/Sources/Lithe/Views/MarkdownPreviewView.swift
@@ -72,10 +72,10 @@ struct MarkdownPreviewView: View {
         .onAppear {
             scheduleRender(immediate: true)
         }
-        .onChange(of: document.text) { _, _ in
+        .onChange(of: document.text) { _ in
             scheduleRender(immediate: false)
         }
-        .onChange(of: document.url) { _, _ in
+        .onChange(of: document.url) { _ in
             scheduleRender(immediate: true)
         }
         .onDisappear {

--- a/Sources/Lithe/Views/MavenView.swift
+++ b/Sources/Lithe/Views/MavenView.swift
@@ -32,7 +32,7 @@ struct MavenView: View {
                 resetTreeState()
             }
         }
-        .onChange(of: feature.project?.id) {
+        .onChange(of: feature.project?.id) { _ in
             resetTreeState()
         }
     }

--- a/Sources/Lithe/Views/OutputTextView.swift
+++ b/Sources/Lithe/Views/OutputTextView.swift
@@ -59,7 +59,7 @@ struct OutputTextView: View {
                 onOpenLocation(location.url, location.line, location.column)
                 return .handled
             })
-            .onChange(of: output) {
+            .onChange(of: output) { _ in
                 guard isAtBottom else { return }
                 withAnimation(.easeOut(duration: 0.15)) {
                     proxy.scrollTo(Self.contentID, anchor: .bottom)

--- a/Sources/Lithe/Views/ProjectReplaceView.swift
+++ b/Sources/Lithe/Views/ProjectReplaceView.swift
@@ -24,13 +24,13 @@ struct ProjectReplaceView: View {
         }
         .frame(minWidth: 780, minHeight: 560)
         .background(LitheTheme.window)
-        .onChange(of: model.projectReplaceQuery) {
+        .onChange(of: model.projectReplaceQuery) { _ in
             clearPreview()
         }
-        .onChange(of: model.projectReplaceText) {
+        .onChange(of: model.projectReplaceText) { _ in
             clearPreview()
         }
-        .onChange(of: model.projectReplaceOptions) {
+        .onChange(of: model.projectReplaceOptions) { _ in
             clearPreview()
         }
     }

--- a/Sources/Lithe/Views/RunView.swift
+++ b/Sources/Lithe/Views/RunView.swift
@@ -38,7 +38,7 @@ struct RunView: View {
             }
         }
         .background(LitheTheme.editor)
-        .onChange(of: feature.moduleSessions) {
+        .onChange(of: feature.moduleSessions) { _ in
             if let selectedSessionID,
                !feature.moduleSessions.contains(where: { $0.id == selectedSessionID }) {
                 self.selectedSessionID = nil

--- a/Sources/Lithe/Views/SearchEverywhereView.swift
+++ b/Sources/Lithe/Views/SearchEverywhereView.swift
@@ -105,8 +105,8 @@ struct SearchEverywhereView: View {
             installKeyMonitor()
         }
         .onDisappear { removeKeyMonitor() }
-        .onChange(of: model.searchEverywhereQuery) { selectedIndex = 0 }
-        .onChange(of: scope) { selectedIndex = 0 }
+        .onChange(of: model.searchEverywhereQuery) { _ in selectedIndex = 0 }
+        .onChange(of: scope) { _ in selectedIndex = 0 }
         .task(id: "\(model.searchEverywhereQuery)|\(searchOptions.cacheKey)") {
             try? await Task.sleep(for: .milliseconds(180))
             guard !Task.isCancelled else { return }

--- a/Sources/Lithe/Views/SearchSidebarView.swift
+++ b/Sources/Lithe/Views/SearchSidebarView.swift
@@ -120,7 +120,7 @@ struct SearchSidebarView: View {
         }
         .onAppear { searchFocused = true }
         // 侧栏已经打开时再次按 Cmd+Shift+F，靠令牌变化把焦点移回输入框。
-        .onChange(of: model.searchSidebarFocusRequest) { searchFocused = true }
+        .onChange(of: model.searchSidebarFocusRequest) { _ in searchFocused = true }
     }
 
     private var fileMaskField: some View {

--- a/Sources/Lithe/Views/SettingsView.swift
+++ b/Sources/Lithe/Views/SettingsView.swift
@@ -48,12 +48,12 @@ struct SettingsView: View {
             model.refreshAIConfigurations()
             syncAIProviderDraft()
         }
-        .onChange(of: settings.hiddenDirectoryNames) { syncVisibilityDrafts() }
-        .onChange(of: settings.hiddenFilePatterns) { syncVisibilityDrafts() }
-        .onChange(of: projectRuntime.settings.javaHomePath) { javaHomeDraft = projectRuntime.settings.javaHomePath }
-        .onChange(of: projectRuntime.settings.mavenHomePath) { mavenHomeDraft = projectRuntime.settings.mavenHomePath }
-        .onChange(of: projectRuntime.settings.mavenJavaHomePath) { mavenJavaHomeDraft = projectRuntime.settings.mavenJavaHomePath }
-        .onChange(of: settings.commitMessageAI.activeProviderID) { syncAIProviderDraft() }
+        .onChange(of: settings.hiddenDirectoryNames) { _ in syncVisibilityDrafts() }
+        .onChange(of: settings.hiddenFilePatterns) { _ in syncVisibilityDrafts() }
+        .onChange(of: projectRuntime.settings.javaHomePath) { _ in javaHomeDraft = projectRuntime.settings.javaHomePath }
+        .onChange(of: projectRuntime.settings.mavenHomePath) { _ in mavenHomeDraft = projectRuntime.settings.mavenHomePath }
+        .onChange(of: projectRuntime.settings.mavenJavaHomePath) { _ in mavenJavaHomeDraft = projectRuntime.settings.mavenJavaHomePath }
+        .onChange(of: settings.commitMessageAI.activeProviderID) { _ in syncAIProviderDraft() }
         .onDisappear(perform: commitRuntimeDrafts)
     }
 
@@ -385,7 +385,7 @@ struct SettingsView: View {
                 .labelsHidden()
                 .frame(width: 180)
                 .lithePointer()
-                .onChange(of: settings.terminalShell) {
+                .onChange(of: settings.terminalShell) { _ in
                     guard model.activeTerminalSession?.isRunning == true else { return }
                     let path = settings.terminalShellPath
                         ?? ProcessInfo.processInfo.environment["SHELL"]

--- a/Sources/Lithe/Views/WorkbenchView.swift
+++ b/Sources/Lithe/Views/WorkbenchView.swift
@@ -203,13 +203,13 @@ struct WorkbenchView: View {
         .onAppear {
             restoreLayout()
         }
-        .onChange(of: sidebarWidth) { _, _ in
+        .onChange(of: sidebarWidth) { _ in
             saveLayout()
         }
-        .onChange(of: topPaneHeight) { _, _ in
+        .onChange(of: topPaneHeight) { _ in
             saveLayout()
         }
-        .onChange(of: model.workspaceURL?.standardizedFileURL.path) { _, _ in
+        .onChange(of: model.workspaceURL?.standardizedFileURL.path) { _ in
             didRestoreLayout = false
             restoreLayout()
         }
@@ -240,7 +240,7 @@ struct WorkbenchView: View {
                 .onAppear {
                     proxy.scrollTo(projectSessions.activeSessionID, anchor: .center)
                 }
-                .onChange(of: projectSessions.activeSessionID) { _, id in
+                .onChange(of: projectSessions.activeSessionID) { id in
                     withAnimation(.easeOut(duration: 0.12)) {
                         proxy.scrollTo(id, anchor: .center)
                     }

--- a/scripts/build-rust-core.sh
+++ b/scripts/build-rust-core.sh
@@ -14,7 +14,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 cd "$ROOT_DIR"
-export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-13.0}"
 export CARGO_TARGET_DIR="${LITHE_RUST_TARGET_DIR:-$ROOT_DIR/rust/target/macos}"
 if [[ -n "$TARGET" ]]; then
     TARGET_LIBDIR="$(rustc --print target-libdir --target "$TARGET")"

--- a/scripts/verify-rust-core.sh
+++ b/scripts/verify-rust-core.sh
@@ -27,7 +27,7 @@ MACOS_SDK="$(xcrun --sdk macosx --show-sdk-path)"
 swiftc scripts/RustCoreBridgeVerification.swift \
     Sources/LitheRustCore/bridge.c \
     -sdk "$MACOS_SDK" \
-    -target "${TRIPLE}14.0" \
+    -target "${TRIPLE}13.0" \
     -Xlinker -force_load \
     -Xlinker "$RUST_LIBRARY" \
     -o "$BRIDGE_BINARY"


### PR DESCRIPTION
## Summary

- lower the Swift, app bundle, and Rust Core deployment targets to macOS 13
- use the macOS 13-compatible SwiftUI `onChange` signature
- preserve macOS 14 key handling and empty-state UI with macOS 13 fallbacks
- cover the database workspace compatibility points present on `preview/0.2.0`

## Verification

- `MACOSX_DEPLOYMENT_TARGET=13.0 ./scripts/build-macos.sh --triple arm64-apple-macosx`
- `MACOSX_DEPLOYMENT_TARGET=13.0 swift test --disable-sandbox --parallel --num-workers 1 -Xswiftc -Xfrontend -Xswiftc -disable-round-trip-debug-types` (88 tests passed)
- final executable reports `minos 13.0`

## Follow-up

The local Rust 1.97.1 standard library emits linker warnings indicating it was built for macOS 26. The release toolchain and a real macOS 13 machine still need runtime validation before publicly declaring full support.