### PR TITLE
feat(windows): multi-session terminal (#31)

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -101,14 +101,18 @@ add_library(lithe_windows_app STATIC
     app/services/project_detection_service.cpp
     app/services/ai_commit_service.cpp
     app/services/windows_update_service.cpp
+    app/services/terminal_model.cpp
+    app/services/terminal_session.cpp
 )
 target_include_directories(lithe_windows_app PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/app/features"
+    "${CMAKE_CURRENT_SOURCE_DIR}/app/services"
+    "${CMAKE_CURRENT_SOURCE_DIR}/app/algorithms"
     "${CMAKE_CURRENT_SOURCE_DIR}/core"
     "${CMAKE_CURRENT_SOURCE_DIR}/adapters"
 )
 target_compile_features(lithe_windows_app PUBLIC cxx_std_23)
-target_link_libraries(lithe_windows_app PUBLIC lithe_windows_core)
+target_link_libraries(lithe_windows_app PUBLIC lithe_windows_core lithe_windows_algorithms)
 
 set(LITHE_RUST_CORE_LIBRARY "" CACHE FILEPATH "Path to the Rust lithe-core static library")
 
@@ -138,6 +142,26 @@ target_include_directories(lithe_windows_algorithms_tests PRIVATE
 )
 target_link_libraries(lithe_windows_algorithms_tests PRIVATE lithe_windows_algorithms)
 add_test(NAME lithe_windows_algorithms COMMAND lithe_windows_algorithms_tests)
+
+# Platform-independent terminal feature-model test. Compiles the model and
+# session sources directly against the (pure-stdlib) algorithms target and a
+# fake transport, so it builds and runs on non-Windows without Qt, Win32, or the
+# Rust core. The real ConPTY behavior stays covered by the Windows-CI-only
+# lithe_windows_terminal_transport_tests target below.
+add_executable(lithe_windows_terminal_model_tests
+    tests/terminal_model_test.cpp
+    app/services/terminal_model.cpp
+    app/services/terminal_session.cpp
+)
+target_compile_features(lithe_windows_terminal_model_tests PRIVATE cxx_std_23)
+target_include_directories(lithe_windows_terminal_model_tests PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests"
+    "${CMAKE_CURRENT_SOURCE_DIR}/app/services"
+    "${CMAKE_CURRENT_SOURCE_DIR}/app/algorithms"
+    "${CMAKE_CURRENT_SOURCE_DIR}/adapters"
+)
+target_link_libraries(lithe_windows_terminal_model_tests PRIVATE lithe_windows_algorithms)
+add_test(NAME lithe_windows_terminal_model COMMAND lithe_windows_terminal_model_tests)
 
 add_executable(lithe_windows_app_tests
     tests/windows_app_test.cpp
@@ -328,6 +352,10 @@ if(LITHE_BUILD_QT_UI)
         qt/workbench_ui_state.h
         qt/workbench_window.cpp
         qt/workbench_window.h
+        qt/terminal_panel.cpp
+        qt/terminal_panel.h
+        qt/terminal_view.cpp
+        qt/terminal_view.h
         packaging/lithe.rc
     )
     target_link_libraries(lithe_windows_qt PRIVATE
@@ -469,6 +497,26 @@ if(LITHE_BUILD_QT_UI)
     set_tests_properties(lithe_windows_workbench_tool_window PROPERTIES
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
     )
+    add_executable(lithe_windows_terminal_panel_tests
+        tests/terminal_panel_test.cpp
+        qt/terminal_panel.cpp
+        qt/terminal_panel.h
+        qt/terminal_view.cpp
+        qt/terminal_view.h
+    )
+    target_compile_features(lithe_windows_terminal_panel_tests PRIVATE cxx_std_23)
+    target_include_directories(lithe_windows_terminal_panel_tests PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/qt"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests"
+    )
+    target_link_libraries(lithe_windows_terminal_panel_tests PRIVATE
+        lithe_windows_app
+        Qt6::Widgets
+    )
+    add_test(NAME lithe_windows_terminal_panel COMMAND lithe_windows_terminal_panel_tests)
+    set_tests_properties(lithe_windows_terminal_panel PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    )
     if(LITHE_RUST_CORE_LIBRARY)
         target_link_libraries(lithe_windows_qt PRIVATE "${LITHE_RUST_CORE_LIBRARY}")
         if(WIN32)
@@ -512,6 +560,7 @@ endif()
 set(LITHE_WINDOWS_TEST_TARGETS
     lithe_windows_phase0_tests
     lithe_windows_algorithms_tests
+    lithe_windows_terminal_model_tests
     lithe_windows_app_tests
     lithe_windows_workbench_ui_state_tests
     lithe_windows_workbench_layout_persistence_tests
@@ -540,6 +589,9 @@ if(TARGET lithe_windows_workbench_code_editor_tests)
 endif()
 if(TARGET lithe_windows_workbench_tool_window_tests)
     list(APPEND LITHE_WINDOWS_TEST_TARGETS lithe_windows_workbench_tool_window_tests)
+endif()
+if(TARGET lithe_windows_terminal_panel_tests)
+    list(APPEND LITHE_WINDOWS_TEST_TARGETS lithe_windows_terminal_panel_tests)
 endif()
 if(TARGET lithe_windows_ui_theme_tests)
     list(APPEND LITHE_WINDOWS_TEST_TARGETS lithe_windows_ui_theme_tests)

--- a/windows/adapters/ports.h
+++ b/windows/adapters/ports.h
@@ -70,6 +70,7 @@ public:
     using OutputHandler = std::function<void(const std::string&)>;
     using ErrorHandler = std::function<void(const std::string&)>;
     using ExitHandler = std::function<void()>;
+    using LifecycleHandler = std::function<void(const ProcessLifecycleEvent&)>;
 
     virtual ~TerminalTransport() = default;
     virtual void start(const ProcessRequest& request) = 0;
@@ -80,6 +81,10 @@ public:
     virtual void setOutputHandler(OutputHandler handler) = 0;
     virtual void setErrorHandler(ErrorHandler handler) = 0;
     virtual void setExitHandler(ExitHandler handler) = 0;
+    // Emits starting/running/stopping/finished/failed transitions. Each event
+    // carries the owning ProcessRequest::operationID so the consumer can drop
+    // stale callbacks after a restart relaunches under a new operationID.
+    virtual void setLifecycleHandler(LifecycleHandler handler) = 0;
 };
 
 // Implementations belong in this directory and may use Win32 APIs. Core

--- a/windows/adapters/win32_terminal_transport.cpp
+++ b/windows/adapters/win32_terminal_transport.cpp
@@ -248,6 +248,7 @@ struct Win32TerminalTransport::Impl {
     OutputHandler output;
     ErrorHandler error;
     ExitHandler exit;
+    LifecycleHandler lifecycle;
 #ifdef _WIN32
     HPCON console = nullptr;
     HANDLE process = nullptr;
@@ -279,6 +280,11 @@ void Win32TerminalTransport::setExitHandler(ExitHandler handler) {
     impl_->exit = std::move(handler);
 }
 
+void Win32TerminalTransport::setLifecycleHandler(LifecycleHandler handler) {
+    std::lock_guard lock(impl_->mutex);
+    impl_->lifecycle = std::move(handler);
+}
+
 void Win32TerminalTransport::start(const ProcessRequest& request) {
     std::lock_guard lifecycleLock(impl_->lifecycleMutex);
     stopImpl();
@@ -286,31 +292,65 @@ void Win32TerminalTransport::start(const ProcessRequest& request) {
     impl_->exited.store(false, std::memory_order_release);
     impl_->running.store(false, std::memory_order_release);
 #ifndef _WIN32
-    (void)request;
     impl_->running.store(false, std::memory_order_release);
     ErrorHandler error;
     ExitHandler exit;
+    LifecycleHandler lifecycleHandler;
     {
         std::lock_guard lock(impl_->mutex);
         error = impl_->error;
         exit = impl_->exit;
+        lifecycleHandler = impl_->lifecycle;
     }
     if (error) error("Win32 terminal adapter requires Windows");
     if (exit) exit();
+    if (lifecycleHandler) {
+        ProcessLifecycleEvent event;
+        event.operationID = request.operationID;
+        event.state = ProcessLifecycleState::Failed;
+        event.message = "Win32 terminal adapter requires Windows";
+        lifecycleHandler(event);
+    }
 #else
     impl_->worker = std::thread([state = impl_.get(), request] {
-        auto reportError = [state](const std::string& message) {
-            ErrorHandler handler;
-            { std::lock_guard lock(state->mutex); handler = state->error; }
-            if (handler) handler(message);
+        const std::string operationID = request.operationID;
+        auto emitLifecycle = [state, operationID](
+                ProcessLifecycleState next,
+                const std::optional<std::int32_t>& exitCode,
+                const std::string& message) {
+            LifecycleHandler handler;
+            { std::lock_guard lock(state->mutex); handler = state->lifecycle; }
+            if (handler) {
+                ProcessLifecycleEvent event;
+                event.operationID = operationID;
+                event.state = next;
+                event.exitCode = exitCode;
+                event.message = message;
+                handler(event);
+            }
         };
-        auto reportExit = [state] {
-            if (state->exited.exchange(true, std::memory_order_acq_rel)) return;
+        // Finalizes a launch exactly once: flips the exit latch, marks the
+        // transport not-running, and fires the legacy exit handler. Returns
+        // true for the single caller that wins the race so it can emit the
+        // matching terminal lifecycle event (Finished or Failed).
+        auto finalize = [state]() -> bool {
+            if (state->exited.exchange(true, std::memory_order_acq_rel)) return false;
             state->running.store(false, std::memory_order_release);
             ExitHandler handler;
             { std::lock_guard lock(state->mutex); handler = state->exit; }
             if (handler) handler();
+            return true;
         };
+        auto reportError = [state, &emitLifecycle, &finalize](const std::string& message) {
+            ErrorHandler handler;
+            { std::lock_guard lock(state->mutex); handler = state->error; }
+            if (handler) handler(message);
+            if (finalize()) emitLifecycle(ProcessLifecycleState::Failed, std::nullopt, message);
+        };
+        auto reportExit = [&emitLifecycle, &finalize] {
+            if (finalize()) emitLifecycle(ProcessLifecycleState::Finished, std::nullopt, std::string{});
+        };
+        emitLifecycle(ProcessLifecycleState::Starting, std::nullopt, std::string{});
         auto close = [](HANDLE& handle) {
             if (handle != nullptr) {
                 CloseHandle(handle);
@@ -475,6 +515,7 @@ void Win32TerminalTransport::start(const ProcessRequest& request) {
             parentInput = nullptr;
         }
         state->running.store(true, std::memory_order_release);
+        emitLifecycle(ProcessLifecycleState::Running, std::nullopt, std::string{});
         if (state->stopping.load(std::memory_order_acquire)) TerminateJobObject(job, 130);
 
         const HANDLE outputPipe = parentOutput;

--- a/windows/adapters/win32_terminal_transport.h
+++ b/windows/adapters/win32_terminal_transport.h
@@ -19,6 +19,7 @@ public:
     void setOutputHandler(OutputHandler handler) override;
     void setErrorHandler(ErrorHandler handler) override;
     void setExitHandler(ExitHandler handler) override;
+    void setLifecycleHandler(LifecycleHandler handler) override;
 
 private:
     struct Impl;

--- a/windows/app/services/terminal_model.cpp
+++ b/windows/app/services/terminal_model.cpp
@@ -1,0 +1,212 @@
+#include "terminal_model.h"
+
+#include <utility>
+
+namespace lithe::windows::app {
+
+TerminalModel::TerminalModel(TransportFactory factory)
+    : factory_(std::move(factory)) {
+}
+
+TerminalModel::~TerminalModel() {
+    shutdown();
+}
+
+std::string TerminalModel::allocateId() {
+    return "t" + std::to_string(nextId_++);
+}
+
+std::string TerminalModel::create(const TerminalShellSpec& shell,
+                                  const std::string& workingDirectory,
+                                  const std::map<std::string, std::string>& environment) {
+    std::string id;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        id = allocateId();
+    }
+
+    auto transport = factory_();
+    if (!transport) return {};
+
+    auto session = std::make_unique<TerminalSession>(id, std::move(transport));
+    attachHandlers(*session);
+    // The initial operationID is the session id; restart() derives a fresh one.
+    session->launch(shell, workingDirectory, environment, id);
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        sessions_[id] = std::move(session);
+        currentId_ = id;
+    }
+    notifyListChanged();
+    return id;
+}
+
+bool TerminalModel::select(const std::string& id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!sessions_.contains(id)) return false;
+    if (currentId_ == id) return true;
+    currentId_ = id;
+    return true;
+}
+
+void TerminalModel::close(const std::string& id) {
+    std::unique_ptr<TerminalSession> removed;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = sessions_.find(id);
+        if (it == sessions_.end()) return;
+        removed = std::move(it->second);
+        sessions_.erase(it);
+        if (currentId_ == id) {
+            currentId_.clear();
+            if (!sessions_.empty()) currentId_ = sessions_.begin()->first;
+        }
+    }
+    // Drop the session outside the lock; its destructor stops the transport and
+    // joins the worker thread before freeing any handler state.
+    removed.reset();
+    notifyListChanged();
+}
+
+void TerminalModel::closeAll() {
+    // Bump the epoch first so any callback already in flight on a transport
+    // worker thread is dropped before it can reach the (soon-removed) session.
+    ++epoch_;
+
+    std::map<std::string, std::unique_ptr<TerminalSession>> drained;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        drained = std::move(sessions_);
+        currentId_.clear();
+    }
+    drained.clear();
+    notifyListChanged();
+}
+
+void TerminalModel::shutdown() {
+    ++epoch_;
+    std::map<std::string, std::unique_ptr<TerminalSession>> drained;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        drained = std::move(sessions_);
+        currentId_.clear();
+    }
+    drained.clear();
+}
+
+bool TerminalModel::send(const std::string& id, const std::string& input) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = sessions_.find(id);
+    if (it == sessions_.end()) return false;
+    it->second->send(input);
+    return true;
+}
+
+bool TerminalModel::interrupt(const std::string& id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = sessions_.find(id);
+    if (it == sessions_.end()) return false;
+    it->second->interrupt();
+    return true;
+}
+
+bool TerminalModel::clear(const std::string& id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = sessions_.find(id);
+    if (it == sessions_.end()) return false;
+    it->second->clear();
+    return true;
+}
+
+bool TerminalModel::restart(const std::string& id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = sessions_.find(id);
+    if (it == sessions_.end()) return false;
+    it->second->restart();
+    return true;
+}
+
+std::vector<std::string> TerminalModel::sessionIds() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::string> ids;
+    ids.reserve(sessions_.size());
+    for (const auto& [id, session] : sessions_) {
+        (void)session;
+        ids.push_back(id);
+    }
+    return ids;
+}
+
+std::optional<std::string> TerminalModel::currentId() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (currentId_.empty()) return std::nullopt;
+    return currentId_;
+}
+
+const TerminalSession* TerminalModel::find(const std::string& id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = sessions_.find(id);
+    return it == sessions_.end() ? nullptr : it->second.get();
+}
+
+TerminalSession* TerminalModel::find(const std::string& id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = sessions_.find(id);
+    return it == sessions_.end() ? nullptr : it->second.get();
+}
+
+void TerminalModel::setSinks(OutputSink output, ErrorSink error, StateSink state, SessionListSink listChanged) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    outputSink_ = std::move(output);
+    errorSink_ = std::move(error);
+    stateSink_ = std::move(state);
+    listSink_ = std::move(listChanged);
+}
+
+void TerminalModel::attachHandlers(TerminalSession& session) {
+    // Captured by value: a workspace switch / shutdown bumps epoch_, after which
+    // any callback still in flight on a transport worker is dropped here, before
+    // it can be marshaled into the (possibly torn-down) Qt panel.
+    const auto capturedEpoch = epoch_.load();
+    auto wrapOutput = [this, capturedEpoch](const std::string& id, const std::string& bytes) {
+        if (epoch_.load() != capturedEpoch) return;
+        OutputSink sink;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            sink = outputSink_;
+        }
+        if (sink) sink(id, bytes);
+    };
+    auto wrapError = [this, capturedEpoch](const std::string& id, const std::string& message) {
+        if (epoch_.load() != capturedEpoch) return;
+        ErrorSink sink;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            sink = errorSink_;
+        }
+        if (sink) sink(id, message);
+    };
+    auto wrapState = [this, capturedEpoch](const std::string& id, TerminalSession::State state,
+                                           const std::optional<int>& exitCode) {
+        if (epoch_.load() != capturedEpoch) return;
+        StateSink sink;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            sink = stateSink_;
+        }
+        if (sink) sink(id, state, exitCode);
+    };
+    session.setSinks(wrapOutput, wrapError, wrapState);
+}
+
+void TerminalModel::notifyListChanged() {
+    SessionListSink sink;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        sink = listSink_;
+    }
+    if (sink) sink();
+}
+
+} // namespace lithe::windows::app

--- a/windows/app/services/terminal_model.h
+++ b/windows/app/services/terminal_model.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "ports.h"
+#include "terminal_session.h"
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace lithe::windows::app {
+
+// Owns the set of terminal sessions, the active session id, and a terminal
+// epoch used to drop callbacks that outlive a workspace switch or shutdown.
+//
+// The model is the only thing the Qt layer talks to for terminals: it creates
+// transports through the injected factory (so tests pass a fake), routes every
+// session callback through the epoch check, and exposes scoped new/select/close/
+// switch + Clear/Interrupt/Restart. Pure application logic: no Qt, no Win32.
+class TerminalModel {
+public:
+    using TransportFactory = std::function<std::unique_ptr<TerminalTransport>()>;
+
+    using OutputSink = TerminalSession::OutputSink;
+    using ErrorSink = TerminalSession::ErrorSink;
+    using StateSink = TerminalSession::StateSink;
+    using SessionListSink = std::function<void()>;
+
+    explicit TerminalModel(TransportFactory factory);
+    ~TerminalModel();
+
+    TerminalModel(const TerminalModel&) = delete;
+    TerminalModel& operator=(const TerminalModel&) = delete;
+    TerminalModel(TerminalModel&&) = delete;
+    TerminalModel& operator=(TerminalModel&&) = delete;
+
+    // Creates a session, launches it, and selects it. Returns the new id.
+    std::string create(const TerminalShellSpec& shell,
+                       const std::string& workingDirectory,
+                       const std::map<std::string, std::string>& environment);
+
+    bool select(const std::string& id);
+    void close(const std::string& id);
+    // Stops and removes every session. Used on close-project / workspace switch.
+    void closeAll();
+    // Stops everything and invalidates outstanding callbacks. Used on app exit.
+    void shutdown();
+
+    // Scoped actions; return false if the id is unknown. Actions affect only
+    // the targeted session.
+    bool send(const std::string& id, const std::string& input);
+    bool interrupt(const std::string& id);
+    bool clear(const std::string& id);
+    bool restart(const std::string& id);
+
+    std::vector<std::string> sessionIds() const;
+    std::optional<std::string> currentId() const;
+    // Best-effort lookup for immediate inspection (e.g. rendering). Lifetime is
+    // tied to the model; do not retain across mutations.
+    const TerminalSession* find(const std::string& id) const;
+    TerminalSession* find(const std::string& id);
+    std::uint64_t epoch() const noexcept { return epoch_.load(); }
+
+    void setSinks(OutputSink output, ErrorSink error, StateSink state, SessionListSink listChanged);
+
+private:
+    std::string allocateId();
+    void attachHandlers(TerminalSession& session);
+    void notifyListChanged();
+
+    TransportFactory factory_;
+    mutable std::mutex mutex_;
+    std::map<std::string, std::unique_ptr<TerminalSession>> sessions_;
+    std::string currentId_;
+    std::uint64_t nextId_ = 1;
+    std::atomic<std::uint64_t> epoch_{0};
+
+    OutputSink outputSink_;
+    ErrorSink errorSink_;
+    StateSink stateSink_;
+    SessionListSink listSink_;
+};
+
+} // namespace lithe::windows::app

--- a/windows/app/services/terminal_session.cpp
+++ b/windows/app/services/terminal_session.cpp
@@ -1,0 +1,234 @@
+#include "terminal_session.h"
+
+#include <filesystem>
+#include <utility>
+
+namespace lithe::windows::app {
+
+namespace {
+
+std::string shellBasename(const std::string& executablePath) {
+    try {
+        const auto path = std::filesystem::path(executablePath);
+        const auto leaf = path.filename().u8string();
+        if (!leaf.empty()) {
+            return {reinterpret_cast<const char*>(leaf.data()), leaf.size()};
+        }
+    } catch (...) {
+        // Fall through to the manual split below if path parsing throws.
+    }
+    auto pos = executablePath.find_last_of("\\/");
+    return pos == std::string::npos ? executablePath : executablePath.substr(pos + 1);
+}
+
+} // namespace
+
+TerminalSession::TerminalSession(std::string id, std::unique_ptr<TerminalTransport> transport)
+    : id_(std::move(id)), transport_(std::move(transport)) {
+}
+
+TerminalSession::~TerminalSession() {
+    if (transport_) transport_->stop();
+}
+
+const std::string& TerminalSession::operationID() const noexcept {
+    return operationID_;
+}
+
+TerminalSession::State TerminalSession::state() const noexcept {
+    return state_;
+}
+
+std::optional<int> TerminalSession::exitCode() const noexcept {
+    return exitCode_;
+}
+
+std::size_t TerminalSession::generation() const noexcept {
+    return static_cast<std::size_t>(generation_);
+}
+
+std::string TerminalSession::render(std::size_t maxCharacters) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return buffer_.render(maxCharacters);
+}
+
+void TerminalSession::launch(const TerminalShellSpec& shell,
+                             const std::string& workingDirectory,
+                             const std::map<std::string, std::string>& environment,
+                             std::string operationID) {
+    ProcessRequest request;
+    request.operationID = operationID;
+    request.executablePath = shell.executablePath;
+    request.arguments = shell.arguments;
+    request.workingDirectory = workingDirectory.empty()
+        ? std::optional<std::string>{} : std::optional<std::string>{workingDirectory};
+    request.environment = environment;
+    // An interactive shell must keep its stdin open for the lifetime of the
+    // session; closing it would terminate the shell.
+    request.keepsStandardInputOpen = true;
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        shell_ = shell;
+        workingDirectory_ = workingDirectory;
+        environment_ = environment;
+        operationID_ = std::move(operationID);
+        ++generation_;
+        state_ = State::Starting;
+        exitCode_.reset();
+        title_ = makeTitle(workingDirectory_, shell);
+        bindTransportHandlers(generation_, operationID_);
+    }
+
+    transport_->start(request);
+}
+
+void TerminalSession::send(const std::string& input) {
+    transport_->send(input);
+}
+
+void TerminalSession::interrupt() {
+    // ETX (Ctrl+C) is the conventional interrupt byte for a pseudo-console.
+    transport_->send(std::string{'\x03'});
+}
+
+void TerminalSession::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    buffer_.reset();
+}
+
+void TerminalSession::stop() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (state_ == State::Finished || state_ == State::Failed) {
+            // Already terminal; a duplicate stop must remain a no-op.
+            return;
+        }
+        state_ = State::Stopping;
+    }
+    transport_->stop();
+}
+
+void TerminalSession::restart() {
+    TerminalShellSpec shell;
+    std::string workingDirectory;
+    std::map<std::string, std::string> environment;
+    std::string nextOperationID;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!shell_) {
+            // Nothing to restart; never invent a shell spec.
+            return;
+        }
+        shell = *shell_;
+        workingDirectory = workingDirectory_;
+        environment = environment_;
+        nextOperationID = operationID_ + "-restart";
+    }
+
+    stop();
+    launch(shell, workingDirectory, environment, std::move(nextOperationID));
+}
+
+void TerminalSession::setSinks(OutputSink output, ErrorSink error, StateSink state) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    sinks_ = {std::move(output), std::move(error), std::move(state)};
+}
+
+void TerminalSession::bindTransportHandlers(std::uint64_t generation, std::string operationID) {
+    // Captured by value: a restart re-binds with a fresh generation, so
+    // callbacks tagged with the previous generation are dropped below.
+    transport_->setOutputHandler(
+        [this, generation](const std::string& bytes) { onOutput(generation, bytes); });
+    transport_->setErrorHandler(
+        [this, generation](const std::string& message) { onError(generation, message); });
+    transport_->setExitHandler([this, generation]() { onExit(generation); });
+    transport_->setLifecycleHandler(
+        [this, generation, operationID](const ProcessLifecycleEvent& event) {
+            onLifecycle(generation, operationID, event);
+        });
+}
+
+void TerminalSession::onOutput(std::uint64_t generation, const std::string& bytes) {
+    OutputSink sink;
+    std::string id = id_;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (generation_ != generation) return; // stale launch
+        buffer_.append(bytes);
+        sink = sinks_.output;
+    }
+    if (sink) sink(id, bytes);
+}
+
+void TerminalSession::onError(std::uint64_t generation, const std::string& message) {
+    ErrorSink sink;
+    std::string id = id_;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (generation_ != generation) return;
+        sink = sinks_.error;
+    }
+    if (sink) sink(id, message);
+}
+
+void TerminalSession::onExit(std::uint64_t generation) {
+    // The lifecycle event is authoritative for exit; this no-arg hook only fires
+    // for transports that did not emit a Finished lifecycle event.
+    StateSink sink;
+    std::string id = id_;
+    State state = State::Finished;
+    std::optional<int> exit;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (generation_ != generation) return;
+        if (state_ == State::Finished) return;
+        state_ = State::Finished;
+        state = state_;
+        exit = exitCode_;
+        sink = sinks_.state;
+    }
+    if (sink) sink(id, state, exit);
+}
+
+void TerminalSession::onLifecycle(std::uint64_t generation,
+                                  const std::string& operationID,
+                                  const ProcessLifecycleEvent& event) {
+    if (!event.operationID.empty() && event.operationID != operationID) return;
+    State next = State::Finished;
+    switch (event.state) {
+        case ProcessLifecycleState::Starting: next = State::Starting; break;
+        case ProcessLifecycleState::Running: next = State::Running; break;
+        case ProcessLifecycleState::Stopping: next = State::Stopping; break;
+        case ProcessLifecycleState::Finished: next = State::Finished; break;
+        case ProcessLifecycleState::Failed: next = State::Failed; break;
+    }
+    std::optional<int> exit = event.exitCode ? std::optional<int>{*event.exitCode} : std::nullopt;
+    StateSink sink;
+    std::string id = id_;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (generation_ != generation) return; // stale launch
+        state_ = next;
+        if (exit.has_value()) exitCode_ = exit;
+        sink = sinks_.state;
+    }
+    if (sink) sink(id, next, exit);
+}
+
+std::string TerminalSession::makeTitle(const std::string& workingDirectory,
+                                       const TerminalShellSpec& shell) {
+    const auto shellName = shellBasename(shell.executablePath);
+    if (workingDirectory.empty()) return shellName;
+    try {
+        const auto leaf = std::filesystem::path(workingDirectory).filename().u8string();
+        if (!leaf.empty()) {
+            return shellName + " — " + std::string(reinterpret_cast<const char*>(leaf.data()), leaf.size());
+        }
+    } catch (...) {
+        // Ignore; fall back to the full working directory.
+    }
+    return shellName + " — " + workingDirectory;
+}
+
+} // namespace lithe::windows::app

--- a/windows/app/services/terminal_session.h
+++ b/windows/app/services/terminal_session.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "ports.h"
+#include "terminal_buffer.h"
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace lithe::windows::app {
+
+// Shell command line used to start a terminal session.
+struct TerminalShellSpec {
+    std::string executablePath;
+    std::vector<std::string> arguments;
+};
+
+// A single terminal session. Owns its ConPTY transport and a bounded output
+// buffer, tracks lifecycle state, and drops callbacks that belong to a previous
+// launch (so a restart's late output/exit never reaches the UI). Pure
+// application logic: depends only on the TerminalTransport port and the
+// TerminalBuffer algorithm, never on Qt or Win32 types.
+class TerminalSession {
+public:
+    using State = ProcessLifecycleState;
+
+    using OutputSink = std::function<void(const std::string& sessionId, const std::string& bytes)>;
+    using ErrorSink = std::function<void(const std::string& sessionId, const std::string& error)>;
+    using StateSink = std::function<void(const std::string& sessionId,
+                                         State state,
+                                         const std::optional<int>& exitCode)>;
+
+    TerminalSession(std::string id, std::unique_ptr<TerminalTransport> transport);
+    ~TerminalSession();
+
+    TerminalSession(const TerminalSession&) = delete;
+    TerminalSession& operator=(const TerminalSession&) = delete;
+    TerminalSession(TerminalSession&&) = delete;
+    TerminalSession& operator=(TerminalSession&&) = delete;
+
+    const std::string& id() const noexcept { return id_; }
+    const std::string& title() const noexcept { return title_; }
+    State state() const noexcept;
+    std::optional<int> exitCode() const noexcept;
+    const std::string& workingDirectory() const noexcept { return workingDirectory_; }
+    const std::string& operationID() const noexcept;
+    std::size_t generation() const noexcept;
+
+    // Snapshot of the bounded buffer for rendering. The argument caps the
+    // returned string length so the UI never copies an unbounded payload.
+    std::string render(std::size_t maxCharacters) const;
+
+    // Starts the shell. The operationID identifies this launch on the wire so
+    // lifecycle/output callbacks tagged with a different id can be dropped.
+    void launch(const TerminalShellSpec& shell,
+                const std::string& workingDirectory,
+                const std::map<std::string, std::string>& environment,
+                std::string operationID);
+
+    void send(const std::string& input);
+    // Sends the standard interrupt byte (Ctrl+C) to the shell's input.
+    void interrupt();
+    // Resets the visible buffer only; the shell keeps running.
+    void clear();
+    void stop();
+    // Stops the current launch and relaunches the same shell in the same
+    // working directory under a fresh operationID. Late callbacks from the
+    // previous launch are dropped via the generation check.
+    void restart();
+
+    void setSinks(OutputSink output, ErrorSink error, StateSink state);
+
+private:
+    struct Callbacks {
+        OutputSink output;
+        ErrorSink error;
+        StateSink state;
+    };
+
+    std::string id_;
+    std::string title_;
+    std::unique_ptr<TerminalTransport> transport_;
+    algorithms::TerminalBuffer buffer_;
+
+    mutable std::mutex mutex_;
+    std::string workingDirectory_;
+    std::map<std::string, std::string> environment_;
+    std::optional<TerminalShellSpec> shell_;
+    std::string operationID_;
+    std::uint64_t generation_ = 0;
+    State state_ = State::Finished;
+    std::optional<int> exitCode_;
+    Callbacks sinks_;
+
+    void bindTransportHandlers(std::uint64_t generation, std::string operationID);
+    void onOutput(std::uint64_t generation, const std::string& bytes);
+    void onError(std::uint64_t generation, const std::string& message);
+    void onExit(std::uint64_t generation);
+    void onLifecycle(std::uint64_t generation,
+                     const std::string& operationID,
+                     const ProcessLifecycleEvent& event);
+    static std::string makeTitle(const std::string& workingDirectory, const TerminalShellSpec& shell);
+};
+
+} // namespace lithe::windows::app

--- a/windows/qt/terminal_panel.cpp
+++ b/windows/qt/terminal_panel.cpp
@@ -1,0 +1,258 @@
+#include "terminal_panel.h"
+
+#include "terminal_model.h"
+#include "terminal_session.h"
+#include "terminal_view.h"
+
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+#include <optional>
+#include <string>
+
+TerminalPanel::TerminalPanel(QWidget* parent)
+    : QWidget(parent),
+      shellBox_(new QComboBox(this)),
+      newButton_(new QPushButton(TerminalPanel::tr("New"), this)),
+      closeButton_(new QPushButton(TerminalPanel::tr("Close"), this)),
+      clearButton_(new QPushButton(TerminalPanel::tr("Clear"), this)),
+      interruptButton_(new QPushButton(TerminalPanel::tr("Interrupt"), this)),
+      restartButton_(new QPushButton(TerminalPanel::tr("Restart"), this)),
+      tabs_(new QTabWidget(this)) {
+    newButton_->setToolTip(TerminalPanel::tr("Open a new terminal session"));
+    closeButton_->setToolTip(TerminalPanel::tr("Close the current terminal session"));
+    clearButton_->setToolTip(TerminalPanel::tr("Clear the current session output"));
+    interruptButton_->setToolTip(TerminalPanel::tr("Send Ctrl+C to the current session"));
+    restartButton_->setToolTip(TerminalPanel::tr("Restart the current session"));
+
+    tabs_->setTabsClosable(true);
+    tabs_->setMovable(false);
+
+    auto* toolbar = new QHBoxLayout;
+    toolbar->setContentsMargins(0, 0, 0, 0);
+    toolbar->addWidget(shellBox_);
+    toolbar->addWidget(newButton_);
+    toolbar->addWidget(closeButton_);
+    toolbar->addStretch();
+    toolbar->addWidget(clearButton_);
+    toolbar->addWidget(interruptButton_);
+    toolbar->addWidget(restartButton_);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->addLayout(toolbar);
+    layout->addWidget(tabs_);
+
+    connect(newButton_, &QPushButton::clicked, this, &TerminalPanel::newSession);
+    connect(closeButton_, &QPushButton::clicked, this, &TerminalPanel::closeCurrent);
+    connect(clearButton_, &QPushButton::clicked, this, &TerminalPanel::clearCurrent);
+    connect(interruptButton_, &QPushButton::clicked, this, &TerminalPanel::interruptCurrent);
+    connect(restartButton_, &QPushButton::clicked, this, &TerminalPanel::restartCurrent);
+    connect(tabs_, &QTabWidget::currentChanged, this, &TerminalPanel::handleTabChanged);
+    connect(tabs_, &QTabWidget::tabCloseRequested, this, &TerminalPanel::handleTabCloseRequested);
+}
+
+TerminalPanel::~TerminalPanel() {
+    // Drop our sinks before the QObject goes away so the model never invokes a
+    // freed panel. The model's own epoch also guards in-flight callbacks.
+    if (model_ != nullptr) {
+        model_->setSinks({}, {}, {}, {});
+    }
+}
+
+void TerminalPanel::setModel(lithe::windows::app::TerminalModel* model) {
+    model_ = model;
+    attachModelSinks();
+    syncSessions();
+}
+
+void TerminalPanel::setWorkspace(const QString& workingDirectory,
+                                 const std::map<std::string, std::string>& environment) {
+    workingDirectory_ = workingDirectory;
+    environment_ = environment;
+}
+
+void TerminalPanel::setAvailableShells(const QStringList& executablePaths) {
+    shells_ = executablePaths;
+    shellBox_->clear();
+    shellBox_->addItems(executablePaths);
+    if (shellBox_->count() > 0) shellBox_->setCurrentIndex(0);
+}
+
+int TerminalPanel::sessionCount() const {
+    return tabs_->count();
+}
+
+QString TerminalPanel::currentSessionId() const {
+    TerminalView* view = viewAt(tabs_->currentIndex());
+    return view == nullptr ? QString() : view->sessionId();
+}
+
+QString TerminalPanel::renderedText(const QString& sessionId) const {
+    TerminalView* view = viewAt(indexOfSession(sessionId));
+    return view == nullptr ? QString() : view->text();
+}
+
+QString TerminalPanel::newSession() {
+    if (model_ == nullptr) return {};
+    const QString executable = shellBox_->count() > 0 ? shellBox_->currentText() : shells_.value(0);
+    if (executable.isEmpty()) return {};
+    lithe::windows::app::TerminalShellSpec shell;
+    shell.executablePath = executable.toStdString();
+    const auto id = model_->create(shell, workingDirectory_.toStdString(), environment_);
+    if (id.empty()) return {};
+    ensureTab(QString::fromStdString(id));
+    return QString::fromStdString(id);
+}
+
+void TerminalPanel::closeCurrent() {
+    const QString id = currentSessionId();
+    if (id.isEmpty() || model_ == nullptr) return;
+    model_->close(id.toStdString());
+    syncSessions();
+}
+
+void TerminalPanel::selectSession(const QString& sessionId) {
+    const int index = indexOfSession(sessionId);
+    if (index >= 0) tabs_->setCurrentIndex(index);
+}
+
+void TerminalPanel::clearCurrent() {
+    const QString id = currentSessionId();
+    if (id.isEmpty() || model_ == nullptr) return;
+    model_->clear(id.toStdString());
+    refreshView(id);
+}
+
+void TerminalPanel::interruptCurrent() {
+    const QString id = currentSessionId();
+    if (id.isEmpty() || model_ == nullptr) return;
+    model_->interrupt(id.toStdString());
+}
+
+void TerminalPanel::restartCurrent() {
+    const QString id = currentSessionId();
+    if (id.isEmpty() || model_ == nullptr) return;
+    model_->restart(id.toStdString());
+    refreshView(id);
+}
+
+void TerminalPanel::handleTabChanged(int index) {
+    if (model_ == nullptr || index < 0) return;
+    TerminalView* view = viewAt(index);
+    if (view == nullptr) return;
+    model_->select(view->sessionId().toStdString());
+    view->refresh();
+}
+
+void TerminalPanel::handleTabCloseRequested(int index) {
+    if (model_ == nullptr) return;
+    TerminalView* view = viewAt(index);
+    if (view == nullptr) return;
+    model_->close(view->sessionId().toStdString());
+    syncSessions();
+}
+
+void TerminalPanel::refreshView(const QString& sessionId) {
+    const int index = indexOfSession(sessionId);
+    if (index < 0) return;
+    tabs_->setTabText(index, tabTitleFor(sessionId));
+    TerminalView* view = viewAt(index);
+    if (view != nullptr) view->refresh();
+}
+
+void TerminalPanel::syncSessions() {
+    if (model_ == nullptr) return;
+    const auto ids = model_->sessionIds();
+    for (int i = tabs_->count() - 1; i >= 0; --i) {
+        TerminalView* view = viewAt(i);
+        const QString tabId = view == nullptr ? QString() : view->sessionId();
+        bool found = false;
+        for (const auto& modelId : ids) {
+            if (modelId == tabId.toStdString()) { found = true; break; }
+        }
+        if (!found) {
+            QWidget* page = tabs_->widget(i);
+            tabs_->removeTab(i);
+            page->deleteLater();
+        }
+    }
+    for (const auto& modelId : ids) {
+        ensureTab(QString::fromStdString(modelId));
+    }
+    const auto current = model_->currentId();
+    if (current.has_value()) {
+        const int index = indexOfSession(QString::fromStdString(*current));
+        if (index >= 0 && index != tabs_->currentIndex()) tabs_->setCurrentIndex(index);
+    }
+}
+
+void TerminalPanel::attachModelSinks() {
+    if (model_ == nullptr) return;
+    model_->setSinks(
+        [this](const std::string& id, const std::string&) {
+            QMetaObject::invokeMethod(this, "refreshView", Qt::QueuedConnection,
+                                      Q_ARG(QString, QString::fromStdString(id)));
+        },
+        [this](const std::string& id, const std::string&) {
+            QMetaObject::invokeMethod(this, "refreshView", Qt::QueuedConnection,
+                                      Q_ARG(QString, QString::fromStdString(id)));
+        },
+        [this](const std::string& id, lithe::windows::app::TerminalSession::State,
+               const std::optional<int>&) {
+            QMetaObject::invokeMethod(this, "refreshView", Qt::QueuedConnection,
+                                      Q_ARG(QString, QString::fromStdString(id)));
+        },
+        [this]() {
+            QMetaObject::invokeMethod(this, "syncSessions", Qt::QueuedConnection);
+        });
+}
+
+int TerminalPanel::indexOfSession(const QString& sessionId) const {
+    for (int i = 0; i < tabs_->count(); ++i) {
+        TerminalView* view = viewAt(i);
+        if (view != nullptr && view->sessionId() == sessionId) return i;
+    }
+    return -1;
+}
+
+TerminalView* TerminalPanel::viewAt(int index) const {
+    if (index < 0 || index >= tabs_->count()) return nullptr;
+    return qobject_cast<TerminalView*>(tabs_->widget(index));
+}
+
+QString TerminalPanel::tabTitleFor(const QString& sessionId) const {
+    if (model_ == nullptr) return sessionId;
+    const auto* session = model_->find(sessionId.toStdString());
+    if (session == nullptr) return sessionId;
+    QString base = QString::fromStdString(session->title());
+    if (base.isEmpty()) base = sessionId;
+    switch (session->state()) {
+        case lithe::windows::ProcessLifecycleState::Starting: return base + " …";
+        case lithe::windows::ProcessLifecycleState::Running: return base;
+        case lithe::windows::ProcessLifecycleState::Stopping: return base + TerminalPanel::tr(" (stopping)");
+        case lithe::windows::ProcessLifecycleState::Finished: return base + TerminalPanel::tr(" (exited)");
+        case lithe::windows::ProcessLifecycleState::Failed: return base + TerminalPanel::tr(" (failed)");
+    }
+    return base;
+}
+
+void TerminalPanel::ensureTab(const QString& sessionId) {
+    if (indexOfSession(sessionId) >= 0) {
+        refreshView(sessionId);
+        return;
+    }
+    auto* view = new TerminalView(this);
+    view->bind(model_, sessionId);
+    const int index = tabs_->addTab(view, tabTitleFor(sessionId));
+    if (model_ != nullptr) {
+        const auto current = model_->currentId();
+        if (current.has_value() && QString::fromStdString(*current) == sessionId) {
+            tabs_->setCurrentIndex(index);
+        }
+    }
+    if (tabs_->currentIndex() < 0) tabs_->setCurrentIndex(index);
+}

--- a/windows/qt/terminal_panel.h
+++ b/windows/qt/terminal_panel.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "terminal_model.h"
+
+#include <QMap>
+#include <QString>
+#include <QStringList>
+#include <QWidget>
+
+#include <map>
+#include <string>
+
+class QTabWidget;
+class QComboBox;
+class QPushButton;
+class TerminalView;
+
+namespace lithe::windows::app {
+class TerminalModel;
+}
+
+// Multi-session terminal UI: a tab per session plus a small action toolbar
+// (new / close / clear / interrupt / restart) and a shell selector. Owns no
+// terminal state — it renders from the TerminalModel and forwards every action
+// back to it. Model callbacks arrive on transport worker threads, so each sink
+// marshals onto the Qt thread via a queued connection before touching widgets.
+class TerminalPanel : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit TerminalPanel(QWidget* parent = nullptr);
+    ~TerminalPanel();
+
+    void setModel(lithe::windows::app::TerminalModel* model);
+    void setWorkspace(const QString& workingDirectory,
+                      const std::map<std::string, std::string>& environment);
+    void setAvailableShells(const QStringList& executablePaths);
+
+    int sessionCount() const;
+    QString currentSessionId() const;
+    // Snapshot of the rendered output for a session — used by tests and by the
+    // status indicator; returns an empty string if the session is unknown.
+    QString renderedText(const QString& sessionId) const;
+
+public slots:
+    // Creates a session for the currently selected shell, selects it, and
+    // returns its id (empty string on failure).
+    QString newSession();
+    void selectSession(const QString& sessionId);
+    void closeCurrent();
+    void clearCurrent();
+    void interruptCurrent();
+    void restartCurrent();
+
+private slots:
+    void handleTabChanged(int index);
+    void handleTabCloseRequested(int index);
+    void refreshView(const QString& sessionId);
+    void syncSessions();
+
+private:
+    lithe::windows::app::TerminalModel* model_ = nullptr;
+    QString workingDirectory_;
+    std::map<std::string, std::string> environment_;
+    QStringList shells_;
+
+    QComboBox* shellBox_;
+    QPushButton* newButton_;
+    QPushButton* closeButton_;
+    QPushButton* clearButton_;
+    QPushButton* interruptButton_;
+    QPushButton* restartButton_;
+    QTabWidget* tabs_;
+
+    void attachModelSinks();
+    int indexOfSession(const QString& sessionId) const;
+    TerminalView* viewAt(int index) const;
+    QString tabTitleFor(const QString& sessionId) const;
+    void ensureTab(const QString& sessionId);
+};

--- a/windows/qt/terminal_view.cpp
+++ b/windows/qt/terminal_view.cpp
@@ -1,0 +1,59 @@
+#include "terminal_view.h"
+
+#include "terminal_model.h"
+#include "terminal_session.h"
+
+#include <QFont>
+#include <QFontDatabase>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QVBoxLayout>
+
+TerminalView::TerminalView(QWidget* parent)
+    : QWidget(parent), output_(new QPlainTextEdit(this)), input_(new QLineEdit(this)) {
+    output_->setReadOnly(true);
+    output_->setLineWrapMode(QPlainTextEdit::NoWrap);
+    output_->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+    input_->setPlaceholderText(TerminalView::tr("Enter terminal command"));
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+    layout->addWidget(output_);
+    layout->addWidget(input_);
+
+    connect(input_, &QLineEdit::returnPressed, this, &TerminalView::submitInput);
+}
+
+void TerminalView::bind(lithe::windows::app::TerminalModel* model, const QString& sessionId) {
+    model_ = model;
+    sessionId_ = sessionId;
+    refresh();
+}
+
+void TerminalView::refresh() {
+    if (!model_ || sessionId_.isEmpty()) {
+        output_->clear();
+        return;
+    }
+    const auto* session = model_->find(sessionId_.toStdString());
+    if (session == nullptr) {
+        output_->clear();
+        return;
+    }
+    // Cap the rendered snapshot so a runaway buffer never copies an unbounded
+    // payload into the widget on each refresh.
+    output_->setPlainText(QString::fromStdString(session->render(65536)));
+}
+
+QString TerminalView::text() const {
+    return output_->toPlainText();
+}
+
+void TerminalView::submitInput() {
+    if (!model_ || sessionId_.isEmpty()) return;
+    const auto text = input_->text();
+    input_->clear();
+    if (text.isEmpty()) return;
+    model_->send(sessionId_.toStdString(), (text + "\r\n").toStdString());
+}

--- a/windows/qt/terminal_view.h
+++ b/windows/qt/terminal_view.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "terminal_model.h"
+
+#include <QString>
+#include <QWidget>
+
+class QPlainTextEdit;
+class QLineEdit;
+
+namespace lithe::windows::app {
+class TerminalModel;
+}
+
+// Renders a single terminal session: a read-only bounded output area backed by
+// the model's TerminalBuffer, plus a line input. The view itself holds no
+// terminal state — refresh() reads a snapshot from the model so the model
+// remains the single source of truth (the UI only renders and forwards input).
+class TerminalView : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit TerminalView(QWidget* parent = nullptr);
+
+    void bind(lithe::windows::app::TerminalModel* model, const QString& sessionId);
+    void refresh();
+    QString sessionId() const { return sessionId_; }
+    QString text() const;
+
+private slots:
+    void submitInput();
+
+private:
+    lithe::windows::app::TerminalModel* model_ = nullptr;
+    QString sessionId_;
+    QPlainTextEdit* output_;
+    QLineEdit* input_;
+};

--- a/windows/qt/workbench_window.cpp
+++ b/windows/qt/workbench_window.cpp
@@ -399,7 +399,10 @@ WorkbenchWindow::WorkbenchWindow(std::unique_ptr<DirectoryChangeSource> watcher,
       languageServer_(std::make_unique<app::JavaLanguageServerClient>(
           runtimeService_, *storage_, *languageServerSession_, &archiveReader_)),
       watcher_(std::move(watcher)),
-      terminal_(std::make_unique<Win32TerminalTransport>()) {
+      terminalModel_(std::make_unique<app::TerminalModel>(
+          []() -> std::unique_ptr<TerminalTransport> {
+              return std::make_unique<Win32TerminalTransport>();
+          })) {
     if (qApp != nullptr) qApp->installEventFilter(this);
     setWindowTitle(uiText(QStringLiteral("Lithe")));
     setWindowIcon(QIcon(QStringLiteral(":/lithe.ico")));
@@ -614,23 +617,8 @@ WorkbenchWindow::WorkbenchWindow(std::unique_ptr<DirectoryChangeSource> watcher,
     });
     debugPollTimer_->start();
 
-    terminalPanel_ = new QWidget(toolWindow_);
-    auto* terminalLayout = new QVBoxLayout(terminalPanel_);
-    terminalLayout->setContentsMargins(0, 0, 0, 0);
-    terminalOutput_ = new QPlainTextEdit(terminalPanel_);
-    terminalOutput_->setReadOnly(true);
-    terminalOutput_->setLineWrapMode(QPlainTextEdit::NoWrap);
-    terminalOutput_->setMaximumHeight(190);
-    terminalOutput_->setPlaceholderText(uiText(QStringLiteral("Terminal output")));
-    terminalLayout->addWidget(terminalOutput_);
-    terminalInput_ = new QLineEdit(terminalPanel_);
-    terminalInput_->setPlaceholderText(uiText(QStringLiteral("Enter terminal command")));
-    connect(terminalInput_, &QLineEdit::returnPressed, this, [this] {
-        if (!terminal_ || !terminal_->isRunning()) return;
-        terminal_->send(terminalInput_->text().toUtf8().toStdString() + "\r\n");
-        terminalInput_->clear();
-    });
-    terminalLayout->addWidget(terminalInput_);
+    terminalPanel_ = new TerminalPanel(toolWindow_);
+    terminalPanel_->setModel(terminalModel_.get());
     toolWindow_->setPanel(BottomToolKind::Terminal, terminalPanel_);
 
     connect(editor_, &QPlainTextEdit::textChanged, this, [this] {
@@ -882,26 +870,6 @@ WorkbenchWindow::WorkbenchWindow(std::unique_ptr<DirectoryChangeSource> watcher,
             applyJavaLifecycle(event);
         }, Qt::QueuedConnection);
     });
-    terminal_->setOutputHandler([this](const std::string& output) {
-        QMetaObject::invokeMethod(this, [this, output] {
-            if (terminalOutput_ == nullptr) return;
-            terminalOutput_->moveCursor(QTextCursor::End);
-            terminalOutput_->insertPlainText(fromUtf8(output));
-        }, Qt::QueuedConnection);
-    });
-    terminal_->setErrorHandler([this](const std::string& error) {
-        QMetaObject::invokeMethod(this, [this, error] {
-            if (terminalOutput_ == nullptr) return;
-            terminalOutput_->moveCursor(QTextCursor::End);
-            terminalOutput_->insertPlainText(fromUtf8(error));
-        }, Qt::QueuedConnection);
-    });
-    terminal_->setExitHandler([this] {
-        QMetaObject::invokeMethod(this, [this] {
-            statusBar()->showMessage(uiText(QStringLiteral("Terminal exited")), 3000);
-        }, Qt::QueuedConnection);
-    });
-
     languageServer_->setStateHandler([this](bool ready, const std::string& message) {
         QMetaObject::invokeMethod(this, [this, ready, message] {
             applyLanguageServerState(ready, message);
@@ -928,7 +896,8 @@ WorkbenchWindow::~WorkbenchWindow() {
     if (qApp != nullptr) qApp->removeEventFilter(this);
     if (aiWorker_.joinable()) aiWorker_.join();
     if (updateWorker_.joinable()) updateWorker_.join();
-    stopTerminal();
+    if (terminalPanel_ != nullptr) terminalPanel_->setModel(nullptr);
+    if (terminalModel_) terminalModel_->shutdown();
     if (languageServer_) languageServer_->stop();
     stopDebugger();
     stopJavaRun();
@@ -1778,6 +1747,7 @@ void WorkbenchWindow::openWorkspaceRoot(const QString& selectedRoot) {
         QFileInfo(QDir::fromNativeSeparators(selectedRoot)).absoluteFilePath());
     if (root.isEmpty() || !QFileInfo(root).isDir()) return;
     ++workspaceEpoch_;
+    if (terminalModel_) terminalModel_->closeAll();
     coordinator_->setWorkspaceVisibility(appSettings_.hiddenDirectoryNames,
                                           appSettings_.hiddenFilePatterns);
     historyFeature_->setVisibilityRules(appSettings_.hiddenDirectoryNames,
@@ -1799,6 +1769,7 @@ void WorkbenchWindow::openWorkspaceRoot(const QString& selectedRoot) {
     shelfFeature_->resetForWorkspace();
     mavenJavaFeature_->resetForWorkspace();
     workspaceRoot_ = root;
+    applyTerminalWorkspace();
     QTimer::singleShot(0, this, &WorkbenchWindow::restoreWorkbenchLayout);
     activePath_.clear();
     selectedShelf_.clear();
@@ -4551,43 +4522,30 @@ void WorkbenchWindow::synchronizeLanguageServerDocument() {
 }
 
 void WorkbenchWindow::startTerminal() {
-    if (workspaceRoot_.isEmpty() || !terminal_) return;
+    if (workspaceRoot_.isEmpty() || terminalPanel_ == nullptr || !terminalModel_) return;
     showToolWindow(BottomToolKind::Terminal);
     terminalPanel_->setVisible(true);
-    if (terminal_->isRunning()) {
-        terminalInput_->setFocus();
-        return;
+    applyTerminalWorkspace();
+    if (terminalPanel_->sessionCount() == 0) {
+        terminalPanel_->newSession();
     }
-    terminalOutput_->clear();
-    const auto environment = runtimeLocator_.environment();
-    std::string shell = appSettings_.terminalShellPath;
-    if (shell.empty()) {
-        shell = "cmd.exe";
-        for (const auto& [key, value] : environment) {
-            if (key.size() == 7 && std::equal(key.begin(), key.end(), "ComSpec",
-                    [](char left, char right) {
-                        return std::tolower(static_cast<unsigned char>(left)) ==
-                               std::tolower(static_cast<unsigned char>(right));
-                    })) {
-                shell = value;
-                break;
-            }
-        }
-    }
-    ProcessRequest request;
-    request.operationID = "windows-terminal-" +
-        std::to_string(static_cast<unsigned long long>(QDateTime::currentMSecsSinceEpoch()));
-    request.executablePath = shell;
-    request.workingDirectory = workspaceRoot_.toStdString();
-    request.environment = environment;
-    terminal_->start(request);
-    terminalInput_->setFocus();
     statusBar()->showMessage(uiText(QStringLiteral("Terminal started")), 3000);
 }
 
 void WorkbenchWindow::stopTerminal() {
-    if (terminal_) terminal_->stop();
-    if (terminalPanel_) terminalPanel_->setVisible(false);
+    if (terminalPanel_ == nullptr || !terminalModel_) return;
+    terminalPanel_->closeCurrent();
+    if (terminalPanel_->sessionCount() == 0) terminalPanel_->setVisible(false);
+}
+
+void WorkbenchWindow::applyTerminalWorkspace() {
+    if (terminalPanel_ == nullptr) return;
+    terminalPanel_->setWorkspace(workspaceRoot_, runtimeLocator_.environment());
+    QStringList shells;
+    const auto configured = QString::fromStdString(appSettings_.terminalShellPath).trimmed();
+    if (!configured.isEmpty()) shells << configured;
+    if (!shells.contains(QStringLiteral("cmd.exe"))) shells << QStringLiteral("cmd.exe");
+    terminalPanel_->setAvailableShells(shells);
 }
 
 void WorkbenchWindow::saveDocument() {

--- a/windows/qt/workbench_window.h
+++ b/windows/qt/workbench_window.h
@@ -29,6 +29,8 @@
 #include "win32_runtime_locator.h"
 #include "win32_secure_store.h"
 #include "win32_terminal_transport.h"
+#include "terminal_model.h"
+#include "terminal_panel.h"
 #include "windows_update_service.h"
 
 #include <QMainWindow>
@@ -141,6 +143,7 @@ private slots:
     void findJavaUsages();
     void startTerminal();
     void stopTerminal();
+    void applyTerminalWorkspace();
 
 private:
     bool eventFilter(QObject* watched, QEvent* event) override;
@@ -287,9 +290,7 @@ private:
     QListWidget* debugVariables_ = nullptr;
     QListWidget* debugThreads_ = nullptr;
     QListWidget* debugStack_ = nullptr;
-    QWidget* terminalPanel_ = nullptr;
-    QPlainTextEdit* terminalOutput_ = nullptr;
-    QLineEdit* terminalInput_ = nullptr;
+    TerminalPanel* terminalPanel_ = nullptr;
     QWidget* diffReviewPanel_ = nullptr;
     QListWidget* diffOverview_ = nullptr;
     QTimer* workspaceRefreshTimer_ = nullptr;
@@ -316,7 +317,7 @@ private:
     bool languageServerDocumentOpen_ = false;
     bool diffIsCommitReview_ = false;
     std::chrono::steady_clock::time_point lastShiftPress_{};
-    std::unique_ptr<Win32TerminalTransport> terminal_;
+    std::unique_ptr<app::TerminalModel> terminalModel_;
     std::thread aiWorker_;
     std::thread updateWorker_;
     std::atomic<bool> aiGenerating_{false};

--- a/windows/tests/fake_terminal_transport.h
+++ b/windows/tests/fake_terminal_transport.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "ports.h"
+
+#include <string>
+#include <vector>
+
+namespace lithe::windows::tests {
+
+// A drop-in TerminalTransport for platform-independent feature/Qt tests. It
+// records inputs, stores the handlers the session/model bind on it, and exposes
+// helpers to drive scripted output, lifecycle, exit, and error callbacks
+// deterministically from the test thread. Mirrors the FakeProcess pattern used
+// for ProcessSession tests.
+class FakeTerminalTransport final : public TerminalTransport {
+public:
+    ProcessRequest request;
+    std::vector<std::string> sends;
+    int resizeColumns = 0;
+    int resizeRows = 0;
+    int startCallCount = 0;
+    int stopCallCount = 0;
+    OutputHandler output;
+    ErrorHandler error;
+    ExitHandler exit;
+    LifecycleHandler lifecycle;
+    bool running = false;
+
+    void start(const ProcessRequest& value) override {
+        request = value;
+        ++startCallCount;
+        running = true;
+    }
+    void send(const std::string& input) override { sends.push_back(input); }
+    void stop() override {
+        ++stopCallCount;
+        running = false;
+    }
+    bool isRunning() const override { return running; }
+    void resize(int columns, int rows) override {
+        resizeColumns = columns;
+        resizeRows = rows;
+    }
+    void setOutputHandler(OutputHandler handler) override { output = std::move(handler); }
+    void setErrorHandler(ErrorHandler handler) override { error = std::move(handler); }
+    void setExitHandler(ExitHandler handler) override { exit = std::move(handler); }
+    void setLifecycleHandler(LifecycleHandler handler) override { lifecycle = std::move(handler); }
+
+    // --- test driving helpers ---
+    void feed(const std::string& bytes) { if (output) output(bytes); }
+    void emitError(const std::string& message) { if (error) error(message); }
+    void emitExit() { if (exit) exit(); }
+    void emitState(ProcessLifecycleState state,
+                   const std::optional<std::int32_t>& exitCode = std::nullopt,
+                   const std::string& operationID = {}) {
+        if (lifecycle) {
+            ProcessLifecycleEvent event;
+            event.operationID = operationID.empty() ? request.operationID : operationID;
+            event.state = state;
+            event.exitCode = exitCode;
+            lifecycle(event);
+        }
+    }
+};
+
+} // namespace lithe::windows::tests

--- a/windows/tests/terminal_model_test.cpp
+++ b/windows/tests/terminal_model_test.cpp
@@ -1,0 +1,220 @@
+#include "fake_terminal_transport.h"
+#include "terminal_model.h"
+
+#include <cassert>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace {
+
+using lithe::windows::ProcessLifecycleState;
+using lithe::windows::app::TerminalModel;
+using lithe::windows::app::TerminalShellSpec;
+using lithe::windows::tests::FakeTerminalTransport;
+
+TerminalShellSpec cmdShell() {
+    return TerminalShellSpec{"C:/Windows/System32/cmd.exe", {"/Q"}};
+}
+
+bool contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+bool vectorContains(const std::vector<std::string>& values, const std::string& needle) {
+    for (const auto& value : values) {
+        if (value == needle) return true;
+    }
+    return false;
+}
+
+struct Harness {
+    std::vector<FakeTerminalTransport*> fakes;
+    std::unique_ptr<TerminalModel> model;
+
+    Harness() {
+        model = std::make_unique<TerminalModel>([this]() -> std::unique_ptr<lithe::windows::TerminalTransport> {
+            auto* raw = new FakeTerminalTransport();
+            fakes.push_back(raw);
+            return std::unique_ptr<lithe::windows::TerminalTransport>(raw);
+        });
+    }
+};
+
+void testCreateSelectAndCurrent() {
+    Harness h;
+    const auto a = h.model->create(cmdShell(), "C:/proj", {});
+    const auto b = h.model->create(cmdShell(), "C:/other", {});
+    assert(a == "t1");
+    assert(b == "t2");
+    assert(h.model->currentId() == "t2");
+    assert(h.model->select("t1"));
+    assert(h.model->currentId() == "t1");
+    assert(!h.model->select("does-not-exist"));
+}
+
+void testOutputIsolationBetweenSessions() {
+    Harness h;
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.fakes[0]->feed("hello-A");
+    h.fakes[1]->feed("world-B");
+
+    assert(contains(h.model->find("t1")->render(4096), "hello-A"));
+    assert(!contains(h.model->find("t1")->render(4096), "world-B"));
+    assert(contains(h.model->find("t2")->render(4096), "world-B"));
+    assert(!contains(h.model->find("t2")->render(4096), "hello-A"));
+}
+
+void testBufferSurvivesSwitch() {
+    Harness h;
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.fakes[0]->feed("first");
+    h.model->select("t2");
+    h.fakes[0]->feed("second");
+    h.model->select("t1");
+
+    const auto rendered = h.model->find("t1")->render(4096);
+    assert(contains(rendered, "first"));
+    assert(contains(rendered, "second"));
+}
+
+void testLifecycleStates() {
+    Harness h;
+    h.model->create(cmdShell(), "C:/proj", {});
+    assert(h.model->find("t1")->state() == ProcessLifecycleState::Starting);
+    h.fakes[0]->emitState(ProcessLifecycleState::Running);
+    assert(h.model->find("t1")->state() == ProcessLifecycleState::Running);
+    h.fakes[0]->emitState(ProcessLifecycleState::Finished, 0);
+    assert(h.model->find("t1")->state() == ProcessLifecycleState::Finished);
+    assert(h.model->find("t1")->exitCode().has_value());
+    assert(*h.model->find("t1")->exitCode() == 0);
+}
+
+void testFailedStart() {
+    Harness h;
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.fakes[0]->emitState(ProcessLifecycleState::Failed);
+    assert(h.model->find("t1")->state() == ProcessLifecycleState::Failed);
+}
+
+void testScopedClearAndInterrupt() {
+    Harness h;
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.fakes[0]->feed("keep-or-clear");
+    h.fakes[1]->feed("keep");
+
+    assert(h.model->clear("t1"));
+    assert(h.model->find("t1")->render(4096).empty());
+    assert(contains(h.model->find("t2")->render(4096), "keep"));
+
+    assert(h.model->interrupt("t1"));
+    assert(vectorContains(h.fakes[0]->sends, std::string{'\x03'}));
+    assert(h.fakes[1]->sends.empty());
+
+    assert(!h.model->clear("nope"));
+    assert(!h.model->interrupt("nope"));
+}
+
+void testRestartRelaunchesOnlyTargetAndDropsStaleOutput() {
+    Harness h;
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.fakes[0]->feed("before-restart");
+
+    const auto generationBefore = h.model->find("t1")->generation();
+    // Capture the output handler bound during the first launch (generation 1).
+    const auto staleOutput = h.fakes[0]->output;
+    const auto t1StartsBefore = h.fakes[0]->startCallCount;
+    const auto t2StartsBefore = h.fakes[1]->startCallCount;
+
+    assert(h.model->restart("t1"));
+
+    assert(h.model->find("t1")->generation() > generationBefore);
+    assert(h.fakes[0]->startCallCount == t1StartsBefore + 1);
+    assert(h.fakes[1]->startCallCount == t2StartsBefore); // untouched
+
+    // Late output from the previous launch is dropped via the generation guard.
+    staleOutput("STALE-BYTES");
+    // Fresh output through the rebound handler flows into the buffer.
+    h.fakes[0]->feed("FRESH-BYTES");
+
+    const auto rendered = h.model->find("t1")->render(4096);
+    assert(contains(rendered, "FRESH-BYTES"));
+    assert(!contains(rendered, "STALE-BYTES"));
+}
+
+void testCloseAndDuplicateCloseIsSafe() {
+    Harness h;
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.model->create(cmdShell(), "C:/proj", {});
+
+    h.model->close("t1");
+    assert(h.model->find("t1") == nullptr);
+    assert(h.model->find("t2") != nullptr);
+    // Closing a non-existent session must be a safe no-op.
+    h.model->close("t1");
+    h.model->close("never-existed");
+    assert(vectorContains(h.model->sessionIds(), std::string{"t2"}));
+}
+
+void testCloseAllClearsAndBumpsEpoch() {
+    Harness h;
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.model->create(cmdShell(), "C:/proj", {});
+    const auto epochBefore = h.model->epoch();
+
+    h.model->closeAll();
+
+    assert(h.model->sessionIds().empty());
+    assert(!h.model->currentId().has_value());
+    assert(h.model->epoch() > epochBefore);
+}
+
+void testShutdownClears() {
+    Harness h;
+    h.model->create(cmdShell(), "C:/proj", {});
+    h.model->shutdown();
+    assert(h.model->sessionIds().empty());
+}
+
+void testHeavyOutputStaysBounded() {
+    Harness h;
+    h.model->create(cmdShell(), "C:/proj", {});
+    // Feed far more lines than TerminalBuffer::MaximumRows (2000). The buffer
+    // must evict the oldest rows so memory stays bounded; a render snapshot
+    // must never exceed its cap.
+    std::string chunk;
+    chunk.reserve(6000 * 8);
+    for (int i = 0; i < 6000; ++i) {
+        chunk += "L";
+        chunk += std::to_string(i);
+        chunk += "\n";
+    }
+    h.fakes[0]->feed(chunk);
+    const auto rendered = h.model->find("t1")->render(65536);
+    assert(rendered.size() <= 65536);
+    // Recent content survived; earliest content was evicted.
+    assert(contains(rendered, "L5999"));
+    assert(!contains(rendered, "L0"));
+    assert(!contains(rendered, "L100"));
+}
+
+} // namespace
+
+int main() {
+    testCreateSelectAndCurrent();
+    testOutputIsolationBetweenSessions();
+    testBufferSurvivesSwitch();
+    testLifecycleStates();
+    testFailedStart();
+    testScopedClearAndInterrupt();
+    testRestartRelaunchesOnlyTargetAndDropsStaleOutput();
+    testCloseAndDuplicateCloseIsSafe();
+    testCloseAllClearsAndBumpsEpoch();
+    testShutdownClears();
+    testHeavyOutputStaysBounded();
+    return 0;
+}

--- a/windows/tests/terminal_panel_test.cpp
+++ b/windows/tests/terminal_panel_test.cpp
@@ -1,0 +1,172 @@
+#include "fake_terminal_transport.h"
+#include "terminal_model.h"
+#include "terminal_panel.h"
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QString>
+#include <QStringList>
+
+#include <cassert>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using lithe::windows::ProcessLifecycleState;
+using lithe::windows::TerminalTransport;
+using lithe::windows::app::TerminalModel;
+using lithe::windows::app::TerminalShellSpec;
+using lithe::windows::tests::FakeTerminalTransport;
+
+bool contains(const QString& haystack, const QString& needle) {
+    return haystack.indexOf(needle) >= 0;
+}
+
+void pump() {
+    // Drain queued meta-calls the model sinks marshaled onto the UI thread.
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
+}
+
+struct Harness {
+    std::vector<FakeTerminalTransport*> fakes;
+    std::unique_ptr<TerminalModel> model;
+    std::unique_ptr<TerminalPanel> panel;
+
+    Harness() {
+        model = std::make_unique<TerminalModel>([this]() -> std::unique_ptr<TerminalTransport> {
+            auto* raw = new FakeTerminalTransport();
+            fakes.push_back(raw);
+            return std::unique_ptr<TerminalTransport>(raw);
+        });
+        panel = std::make_unique<TerminalPanel>();
+        panel->setModel(model.get());
+        panel->setWorkspace("C:/proj", {});
+        panel->setAvailableShells(QStringList{"C:/Windows/System32/cmd.exe"});
+    }
+
+    FakeTerminalTransport* fakeFor(const QString& id) const {
+        // Fakes are pushed in creation order; ids are t1, t2, ... in that order.
+        const auto ids = model->sessionIds();
+        for (std::size_t i = 0; i < ids.size(); ++i) {
+            if (ids[i] == id.toStdString() && i < fakes.size()) return fakes[i];
+        }
+        return nullptr;
+    }
+};
+
+void testNewSessionAddsTab() {
+    Harness h;
+    assert(h.panel->sessionCount() == 0);
+    const auto id = h.panel->newSession();
+    assert(!id.isEmpty());
+    assert(h.panel->sessionCount() == 1);
+    assert(h.panel->currentSessionId() == id);
+}
+
+void testOutputReachesActiveView() {
+    Harness h;
+    const auto id = h.panel->newSession();
+    h.fakeFor(id)->emitState(ProcessLifecycleState::Running);
+    h.fakeFor(id)->feed("hello-panel");
+    pump();
+    assert(contains(h.panel->renderedText(id), "hello-panel"));
+}
+
+void testOutputIsolationBetweenTabs() {
+    Harness h;
+    const auto a = h.panel->newSession();
+    const auto b = h.panel->newSession();
+    h.fakeFor(a)->feed("alpha");
+    h.fakeFor(b)->feed("beta");
+    pump();
+    assert(contains(h.panel->renderedText(a), "alpha"));
+    assert(!contains(h.panel->renderedText(a), "beta"));
+    assert(contains(h.panel->renderedText(b), "beta"));
+    assert(!contains(h.panel->renderedText(b), "alpha"));
+}
+
+void testSwitchPreservesContent() {
+    Harness h;
+    const auto a = h.panel->newSession();
+    const auto b = h.panel->newSession();
+    h.fakeFor(a)->feed("kept-across-switch");
+    pump();
+    // Switch to b then back to a; a's content must survive both switches.
+    h.panel->selectSession(b);
+    pump();
+    assert(h.panel->currentSessionId() == b);
+    h.panel->selectSession(a);
+    pump();
+    assert(h.panel->currentSessionId() == a);
+    assert(contains(h.panel->renderedText(a), "kept-across-switch"));
+}
+
+void testClearOnlyAffectsCurrentSession() {
+    Harness h;
+    const auto a = h.panel->newSession();
+    const auto b = h.panel->newSession();
+    h.fakeFor(a)->feed("to-clear");
+    h.fakeFor(b)->feed("keep");
+    pump();
+    // Make a the current session and clear it.
+    h.panel->selectSession(a);
+    h.panel->clearCurrent();
+    pump();
+    assert(h.panel->renderedText(a).isEmpty());
+    assert(contains(h.panel->renderedText(b), "keep"));
+}
+
+void testInterruptSendsInterruptByteOnlyToCurrent() {
+    Harness h;
+    const auto a = h.panel->newSession();
+    const auto b = h.panel->newSession();
+    h.panel->selectSession(a);
+    h.panel->interruptCurrent();
+    const std::string expected{'\x03'};
+    bool aInterrupted = false;
+    for (const auto& send : h.fakeFor(a)->sends) if (send == expected) aInterrupted = true;
+    assert(aInterrupted);
+    assert(h.fakeFor(b)->sends.empty());
+}
+
+void testCloseRemovesTab() {
+    Harness h;
+    const auto a = h.panel->newSession();
+    const auto b = h.panel->newSession();
+    assert(h.panel->sessionCount() == 2);
+    h.panel->selectSession(b);
+    h.panel->closeCurrent();
+    pump();
+    assert(h.panel->sessionCount() == 1);
+    assert(h.panel->currentSessionId() == a);
+}
+
+void testRestartRelaunchesCurrent() {
+    Harness h;
+    const auto a = h.panel->newSession();
+    const auto startsBefore = h.fakeFor(a)->startCallCount;
+    h.panel->selectSession(a);
+    h.panel->restartCurrent();
+    pump();
+    assert(h.fakeFor(a)->startCallCount == startsBefore + 1);
+    assert(h.model->find(a.toStdString()) != nullptr);
+    assert(h.model->find(a.toStdString())->generation() >= 2);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    QApplication app(argc, argv);
+    testNewSessionAddsTab();
+    testOutputReachesActiveView();
+    testOutputIsolationBetweenTabs();
+    testSwitchPreservesContent();
+    testClearOnlyAffectsCurrentSession();
+    testInterruptSendsInterruptByteOnlyToCurrent();
+    testCloseRemovesTab();
+    testRestartRelaunchesCurrent();
+    return 0;
+}


### PR DESCRIPTION
Single hardcoded ConPTY session → TerminalModel managing N sessions, rendered by a new tabbed TerminalPanel.

- Port / transport: TerminalTransport gains lifecycle states (Starting/Running/Failed/Finished) + operationID, so restarts drop stale callbacks. Job-Object teardown unchanged.
- Model (app/services/terminal_{model,session}): per-session ConPTY + bounded buffer + launch-generation guard; scoped new/select/close/switch + Clear/Interrupt(\x03)/Restart; closeAll() on workspace switch, shutdown() on exit.
- Qt (terminal_{panel,view}, workbench_window): tabbed UI + shell selector + scoped actions; teardown wired into workspace switch and destructor.

Verified locally (MinGW, offscreen): model test 11/11, panel test 8/8, boundary script ✓.
Pending Windows CI (MSVC+Qt+Rust): workbench_window.cpp build, full CMake, real-ConPTY multi-session teardown.