### PR TITLE
fix(search): restore Search Everywhere scrolling

### DIFF
--- a/Sources/Lithe/Views/SearchEverywhereView.swift
+++ b/Sources/Lithe/Views/SearchEverywhereView.swift
@@ -93,7 +93,6 @@ struct SearchEverywhereView: View {
                 }
             }
             .frame(width: 860)
-            .fixedSize(horizontal: false, vertical: true)
             .frame(maxHeight: 560, alignment: .top)
             .lithePopupChrome()
             .padding(.top, 84)
@@ -218,16 +217,23 @@ struct SearchEverywhereView: View {
                 placeholder("No matches in \(scope.rawValue)")
             }
         } else {
-            ScrollView(.vertical) {
-                LazyVStack(spacing: 0) {
-                    ForEach(Array(visibleItems.enumerated()), id: \.offset) { index, item in
-                        itemRow(item, index: index)
+            ScrollViewReader { proxy in
+                ScrollView(.vertical) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(visibleItems.enumerated()), id: \.offset) { index, item in
+                            itemRow(item, index: index)
+                                .id(index)
+                        }
+                        if isTruncated {
+                            moreRow
+                        }
                     }
-                    if isTruncated {
-                        moreRow
-                    }
+                    .padding(.vertical, 4)
                 }
-                .padding(.vertical, 4)
+                .onChange(of: selectedIndex) { index in
+                    guard visibleItems.indices.contains(index) else { return }
+                    proxy.scrollTo(index, anchor: .center)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #44

修复双 Shift 搜索列表无法下拉的问题。

Changes:
- remove the vertical fixed-size constraint that prevented the results ScrollView from receiving a bounded viewport
- scroll the selected result into view when navigating with the arrow keys

Validation:
- swift test --disable-sandbox (106 tests passed)