### PR TITLE
fix(macos): return to welcome screen when closing project

### DIFF
--- a/Sources/Lithe/LitheApp.swift
+++ b/Sources/Lithe/LitheApp.swift
@@ -4,6 +4,21 @@ import SwiftUI
 @MainActor
 final class LitheAppDelegate: NSObject, NSApplicationDelegate {
     weak var projectSessions: ProjectSessionManager?
+    var mainWindow: NSWindow?
+
+    func registerMainWindow(_ window: NSWindow) {
+        mainWindow = window
+    }
+
+    func applicationShouldHandleReopen(
+        _ sender: NSApplication,
+        hasVisibleWindows: Bool
+    ) -> Bool {
+        guard !hasVisibleWindows, let mainWindow else { return true }
+        mainWindow.makeKeyAndOrderFront(nil)
+        sender.activate(ignoringOtherApps: true)
+        return false
+    }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         guard let projectSessions else { return .terminateNow }

--- a/Sources/Lithe/Views/RootView.swift
+++ b/Sources/Lithe/Views/RootView.swift
@@ -139,8 +139,8 @@ struct RootView: View {
 private struct WindowCloseGuard: NSViewRepresentable {
     let projectSessions: ProjectSessionManager
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(projectSessions: projectSessions)
+    func makeCoordinator() -> LitheWindowCoordinator {
+        LitheWindowCoordinator(projectSessions: projectSessions)
     }
 
     func makeNSView(context: Context) -> NSView {
@@ -157,24 +157,51 @@ private struct WindowCloseGuard: NSViewRepresentable {
             context.coordinator.attach(to: view.window)
         }
     }
+}
 
-    @MainActor
-    final class Coordinator: NSObject, NSWindowDelegate {
-        var projectSessions: ProjectSessionManager
-        weak var window: NSWindow?
+@MainActor
+protocol ProjectWindowSessionHandling: AnyObject {
+    var hasActiveProject: Bool { get }
+    func closeActiveProject()
+}
 
-        init(projectSessions: ProjectSessionManager) {
-            self.projectSessions = projectSessions
+extension ProjectSessionManager: ProjectWindowSessionHandling {
+    var hasActiveProject: Bool {
+        activeModel.workspaceURL != nil
+    }
+}
+
+@MainActor
+final class LitheWindowCoordinator: NSObject, NSWindowDelegate {
+    var projectSessions: any ProjectWindowSessionHandling
+    weak var window: NSWindow?
+    private let registerWindow: @MainActor (NSWindow) -> Void
+
+    init(
+        projectSessions: any ProjectWindowSessionHandling,
+        registerWindow: @escaping @MainActor (NSWindow) -> Void = { window in
+            (NSApplication.shared.delegate as? LitheAppDelegate)?.registerMainWindow(window)
         }
+    ) {
+        self.projectSessions = projectSessions
+        self.registerWindow = registerWindow
+    }
 
-        func attach(to window: NSWindow?) {
-            guard let window, self.window !== window else { return }
-            self.window = window
-            window.delegate = self
-        }
+    func attach(to window: NSWindow?) {
+        guard let window, self.window !== window else { return }
+        self.window = window
+        window.delegate = self
+        registerWindow(window)
+    }
 
-        func windowShouldClose(_ sender: NSWindow) -> Bool {
-            LitheAppDelegate.confirmUnsavedDocuments(for: projectSessions)
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        if projectSessions.hasActiveProject {
+            projectSessions.closeActiveProject()
+        } else {
+            // Keep the SwiftUI scene alive so a Dock reopen event can bring
+            // the welcome window back instead of leaving a headless process.
+            sender.orderOut(nil)
         }
+        return false
     }
 }

--- a/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -6,6 +6,54 @@ import Testing
 @Suite("Lithe core logic")
 struct LitheCoreLogicTests {
     @Test
+    @MainActor
+    func closingAWorkspaceWindowClosesTheProjectInsteadOfTheWindow() {
+        let sessions = TestProjectWindowSessions(hasActiveProject: true)
+        let coordinator = LitheWindowCoordinator(
+            projectSessions: sessions,
+            registerWindow: { _ in }
+        )
+        let window = NSWindow()
+
+        #expect(!coordinator.windowShouldClose(window))
+        #expect(sessions.closeActiveProjectCallCount == 1)
+    }
+
+    @Test
+    @MainActor
+    func closingTheWelcomeWindowKeepsItAvailableForDockReopen() {
+        let sessions = TestProjectWindowSessions(hasActiveProject: false)
+        let coordinator = LitheWindowCoordinator(
+            projectSessions: sessions,
+            registerWindow: { _ in }
+        )
+        let window = NSWindow()
+        window.orderFront(nil)
+
+        #expect(!coordinator.windowShouldClose(window))
+        #expect(!window.isVisible)
+        #expect(sessions.closeActiveProjectCallCount == 0)
+    }
+
+    @Test
+    @MainActor
+    func dockReopenShowsTheHiddenWelcomeWindow() {
+        let appDelegate = LitheAppDelegate()
+        let window = NSWindow()
+        appDelegate.registerMainWindow(window)
+        window.orderOut(nil)
+        defer { window.orderOut(nil) }
+
+        let shouldPerformDefaultReopen = appDelegate.applicationShouldHandleReopen(
+            NSApplication.shared,
+            hasVisibleWindows: false
+        )
+
+        #expect(!shouldPerformDefaultReopen)
+        #expect(window.isVisible)
+    }
+
+    @Test
     func databaseSidecarParsesCapabilitiesWithoutStartingUntilRequested() throws {
         let runner = RecordingProcessRunner { request in
             let input = try! #require(request.standardInput)
@@ -2108,6 +2156,20 @@ struct LitheCoreLogicTests {
 
         #expect(firstObserverCalls == 1)
         #expect(secondObserverCalls == 2)
+    }
+}
+
+@MainActor
+private final class TestProjectWindowSessions: ProjectWindowSessionHandling {
+    var hasActiveProject: Bool
+    private(set) var closeActiveProjectCallCount = 0
+
+    init(hasActiveProject: Bool) {
+        self.hasActiveProject = hasActiveProject
+    }
+
+    func closeActiveProject() {
+        closeActiveProjectCallCount += 1
     }
 }
 


### PR DESCRIPTION
## Summary

- close the active project instead of destroying the workspace window
- keep the welcome window alive when hidden and restore it from the Dock
- add regression coverage for project close, welcome-window close, and Dock reopen

## Testing

- `swift test --disable-sandbox` (109 tests passed)
- manually verified the close-project and Dock-reopen flows on macOS

Closes #43