### PR TITLE
fix: restore Maven project detection

### DIFF
--- a/Sources/Lithe/Core/RustCoreBridge.swift
+++ b/Sources/Lithe/Core/RustCoreBridge.swift
@@ -179,6 +179,15 @@ struct RustCoreBridge: Sendable {
             let packaging: String
             let modules: [Module]
 
+            enum CodingKeys: String, CodingKey {
+                case relativePath
+                case groupID = "groupId"
+                case artifactID = "artifactId"
+                case version
+                case packaging
+                case modules
+            }
+
             func makeModel(rootURL: URL) -> MavenModule {
                 MavenModule(
                     relativePath: relativePath,
@@ -199,6 +208,16 @@ struct RustCoreBridge: Sendable {
         let modules: [Module]
         let profiles: [Profile]
         let hasWrapper: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case groupID = "groupId"
+            case artifactID = "artifactId"
+            case version
+            case packaging
+            case modules
+            case profiles
+            case hasWrapper
+        }
 
         func makeProject(rootURL: URL) -> MavenProject {
             MavenProject(

--- a/Sources/Lithe/Services/ProjectRuntimeService.swift
+++ b/Sources/Lithe/Services/ProjectRuntimeService.swift
@@ -17,6 +17,7 @@ final class ProjectRuntimeService: ObservableObject {
 
     private let runtimeLocator: any RuntimeLocator
     private var discoveryTask: Task<Void, Never>?
+    private var activeDiscoveryID: UUID?
 
     private let settingsStore: ProjectRuntimeSettingsStore
 
@@ -31,6 +32,7 @@ final class ProjectRuntimeService: ObservableObject {
 
     func openProject(at url: URL) {
         discoveryTask?.cancel()
+        activeDiscoveryID = nil
         let normalizedURL = url.standardizedFileURL
         projectURL = normalizedURL
         settings = settingsStore.load(for: normalizedURL)
@@ -44,6 +46,7 @@ final class ProjectRuntimeService: ObservableObject {
     func closeProject() {
         discoveryTask?.cancel()
         discoveryTask = nil
+        activeDiscoveryID = nil
         projectURL = nil
         settings = ProjectRuntimeSettings()
         javaRuntimes = []
@@ -85,15 +88,24 @@ final class ProjectRuntimeService: ObservableObject {
 
     func refreshAvailableRuntimes() async {
         let targetProjectURL = projectURL
+        let discoveryID = UUID()
+        activeDiscoveryID = discoveryID
         isDiscovering = true
+        defer {
+            if activeDiscoveryID == discoveryID {
+                activeDiscoveryID = nil
+                isDiscovering = false
+            }
+        }
         let runtimeLocator = runtimeLocator
         let result = await Task.detached(priority: .utility) {
             runtimeLocator.discover()
         }.value
-        guard !Task.isCancelled, projectURL == targetProjectURL else { return }
+        guard !Task.isCancelled,
+              projectURL == targetProjectURL,
+              activeDiscoveryID == discoveryID else { return }
         javaRuntimes = result.javaRuntimes
         mavenRuntimes = result.mavenRuntimes
-        isDiscovering = false
     }
 
     func javaHomeURL(overridePath: String? = nil) -> URL? {

--- a/Tests/LitheTests/MavenRuntimeTests.swift
+++ b/Tests/LitheTests/MavenRuntimeTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import Lithe
+
+@Suite("Maven and runtime integration")
+struct MavenRuntimeTests {
+    @Test
+    func mavenScanPayloadDecodesRustCamelCaseIdentifiers() throws {
+        let json = #"""
+        {
+            "groupId": "com.example",
+            "artifactId": "root",
+            "version": "1.0",
+            "packaging": "pom",
+            "modules": [{
+                "relativePath": "module-a",
+                "groupId": "com.example",
+                "artifactId": "child",
+                "version": "1.0",
+                "packaging": "jar",
+                "modules": []
+            }],
+            "profiles": [{"id": "dev", "isActiveByDefault": true}],
+            "hasWrapper": true
+        }
+        """#
+        let payload = try JSONDecoder().decode(
+            RustCoreBridge.MavenScanPayload.self,
+            from: Data(json.utf8)
+        )
+
+        let project = payload.makeProject(rootURL: URL(fileURLWithPath: "/tmp/maven"))
+        #expect(project.groupID == "com.example")
+        #expect(project.artifactID == "root")
+        #expect(project.modules.count == 1)
+        #expect(project.modules[0].groupID == "com.example")
+        #expect(project.modules[0].artifactID == "child")
+        #expect(project.profiles == [MavenProfile(id: "dev", isActiveByDefault: true)])
+        #expect(project.hasWrapper)
+    }
+
+    @Test
+    @MainActor
+    func canceledRuntimeDiscoveryClearsDiscoveringState() async throws {
+        let locator = BlockingRuntimeLocator()
+        let service = ProjectRuntimeService(runtimeLocator: locator, store: EmptyKeyValueStore())
+        let task = Task { @MainActor in
+            await service.refreshAvailableRuntimes()
+        }
+
+        for _ in 0..<100 where !locator.hasStarted {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(locator.hasStarted)
+        #expect(service.isDiscovering)
+
+        task.cancel()
+        locator.release()
+        await task.value
+
+        #expect(!service.isDiscovering)
+    }
+}
+
+private final class BlockingRuntimeLocator: RuntimeLocator, @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var startedValue = false
+
+    var hasStarted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return startedValue
+    }
+
+    func release() {
+        releaseSemaphore.signal()
+    }
+
+    func environment() -> [String: String] { [:] }
+
+    func discover() -> RuntimeDiscoveryResult {
+        lock.lock()
+        startedValue = true
+        lock.unlock()
+        releaseSemaphore.wait()
+        return RuntimeDiscoveryResult(javaRuntimes: [], mavenRuntimes: [])
+    }
+
+    func validJavaHome(path: String) -> URL? { nil }
+    func isExecutable(at url: URL) -> Bool { false }
+    func systemMavenExecutable() -> URL? { nil }
+    func mavenExecutable(forHomePath path: String) -> URL? { nil }
+    func systemJDBExecutable() -> URL? { nil }
+    func javaLanguageServerExecutable() -> URL? { nil }
+}
+
+private struct EmptyKeyValueStore: KeyValueStore {
+    func data(forKey key: String) -> Data? { nil }
+    func object(forKey key: String) -> Any? { nil }
+    func string(forKey key: String) -> String? { nil }
+    func stringArray(forKey key: String) -> [String]? { nil }
+    func set(_ value: Any?, forKey key: String) {}
+    func removeObject(forKey key: String) {}
+}


### PR DESCRIPTION
## Summary
- Map Rust Maven `groupId`/`artifactId` fields into the Swift DTOs, including nested modules.
- Reset runtime discovery state safely when canceled or superseded.
- Add regression coverage for Maven decoding and canceled runtime discovery.

## Verification
- `swift test` (108 tests passed)
- `cargo test -p lithe-core maven_scan_returns_recursive_shared_project_model`
- macOS preview validation: Maven panel detected `lithe-spring-boot-git-graph`; Project Settings detected Maven 3.9.14.

Fixes #37