### PR TITLE
feat(search): share workspace search index

### DIFF
--- a/Sources/Lithe/Application/WorkspaceFeatureModel.swift
+++ b/Sources/Lithe/Application/WorkspaceFeatureModel.swift
@@ -29,6 +29,7 @@ final class WorkspaceFeatureModel: ObservableObject {
     private var directoryWatcher: (any DirectoryChangeSource)?
     private var refreshTask: Task<Void, Never>?
     private var visibilityRulesRefreshTask: Task<Void, Never>?
+    private var searchIndexTask: Task<Void, Never>?
     private var pendingExternalPaths: Set<String> = []
     private var externalRefreshGeneration = 0
     private var workspaceSessionPersistenceTask: Task<Void, Never>?
@@ -104,6 +105,9 @@ final class WorkspaceFeatureModel: ObservableObject {
     }
 
     func reset() {
+        if let workspaceURL {
+            scheduleSearchIndexInvalidation(at: workspaceURL, rules: visibilityRules)
+        }
         directoryWatcher?.stop()
         directoryWatcher = nil
         refreshTask?.cancel()
@@ -129,6 +133,7 @@ final class WorkspaceFeatureModel: ObservableObject {
         refreshTask?.cancel()
         visibilityRulesRefreshTask?.cancel()
         workspaceSessionPersistenceTask?.cancel()
+        searchIndexTask?.cancel()
     }
 
     func beginWorkspace(at url: URL, visibilityRules: FileVisibilityRules) {
@@ -205,6 +210,7 @@ final class WorkspaceFeatureModel: ObservableObject {
         loadErrorMessage = nil
         rootNode = snapshot.root
         projectFiles = snapshot.files
+        scheduleSearchIndexWarm(at: workspaceURL, rules: rules)
 
         // The tree is usable as soon as the shared snapshot is ready. Service
         // preparation below may involve Git, Java, and local history work.
@@ -518,6 +524,11 @@ final class WorkspaceFeatureModel: ObservableObject {
             await refreshCurrent()
             return
         }
+        await updateSearchIndex(
+            at: workspaceURL,
+            changedPaths: changedURLs.map(\.path),
+            rules: visibilityRules
+        )
         let requiresProjectServiceReload = changedURLs.contains { url in
             let name = url.lastPathComponent.lowercased()
             return name == "pom.xml" || name == "build.gradle" || name == "build.gradle.kts"
@@ -525,6 +536,49 @@ final class WorkspaceFeatureModel: ObservableObject {
         }
         if requiresProjectServiceReload { await reloadProjectServices?() }
         await refreshGit?()
+    }
+
+    private func scheduleSearchIndexWarm(at workspaceURL: URL, rules: FileVisibilityRules) {
+        let previousTask = searchIndexTask
+        previousTask?.cancel()
+        let operations = self.operations
+        searchIndexTask = Task.detached(priority: .utility) {
+            await previousTask?.value
+            guard !Task.isCancelled else { return }
+            operations.warmSearchIndex(at: workspaceURL, visibilityRules: rules)
+        }
+    }
+
+    private func scheduleSearchIndexInvalidation(at workspaceURL: URL, rules: FileVisibilityRules) {
+        let previousTask = searchIndexTask
+        previousTask?.cancel()
+        let operations = self.operations
+        searchIndexTask = Task.detached(priority: .utility) {
+            await previousTask?.value
+            operations.invalidateSearchIndex(at: workspaceURL, visibilityRules: rules)
+        }
+    }
+
+    private func updateSearchIndex(
+        at workspaceURL: URL,
+        changedPaths: [String],
+        rules: FileVisibilityRules
+    ) async {
+        guard !changedPaths.isEmpty else { return }
+        let previousTask = searchIndexTask
+        previousTask?.cancel()
+        let operations = self.operations
+        let task = Task.detached(priority: .utility) {
+            await previousTask?.value
+            guard !Task.isCancelled else { return }
+            operations.updateSearchIndex(
+                at: workspaceURL,
+                changedPaths: changedPaths,
+                visibilityRules: rules
+            )
+        }
+        searchIndexTask = task
+        await task.value
     }
 
     private func isWorkspaceURL(_ url: URL) -> Bool {

--- a/Sources/Lithe/Core/RustCoreBridge.swift
+++ b/Sources/Lithe/Core/RustCoreBridge.swift
@@ -61,6 +61,15 @@ struct RustCoreBridge: Sendable {
         }
     }
 
+    private struct SearchIndexStatusPayload: Decodable {
+        let fileCount: Int
+        let symbolCount: Int
+        let postingCount: Int
+        let rebuilt: Bool
+    }
+
+    private struct EmptyResponsePayload: Decodable {}
+
     struct SearchMatchPayload: Decodable, Sendable {
         let kind: String
         let path: String
@@ -593,6 +602,13 @@ struct RustCoreBridge: Sendable {
         let hiddenFilePatterns: [String]
     }
 
+    private struct SearchIndexUpdateRequest: Encodable {
+        let root: String
+        let paths: [String]
+        let hiddenDirectoryNames: [String]
+        let hiddenFilePatterns: [String]
+    }
+
     private struct SearchRequest: Encodable {
         let root: String
         let query: String
@@ -825,6 +841,53 @@ struct RustCoreBridge: Sendable {
     ) -> WorkspaceSnapshotPayload? {
         execute(
             command: "workspace.snapshot",
+            payload: SnapshotRequest(
+                root: rootURL.standardizedFileURL.path,
+                hiddenDirectoryNames: hiddenDirectoryNames,
+                hiddenFilePatterns: hiddenFilePatterns
+            )
+        )
+    }
+
+    func warmSearchIndex(
+        at rootURL: URL,
+        hiddenDirectoryNames: [String] = [],
+        hiddenFilePatterns: [String] = []
+    ) {
+        let _: SearchIndexStatusPayload? = execute(
+            command: "workspace.searchIndex.warm",
+            payload: SnapshotRequest(
+                root: rootURL.standardizedFileURL.path,
+                hiddenDirectoryNames: hiddenDirectoryNames,
+                hiddenFilePatterns: hiddenFilePatterns
+            )
+        )
+    }
+
+    func updateSearchIndex(
+        at rootURL: URL,
+        changedPaths: [String],
+        hiddenDirectoryNames: [String] = [],
+        hiddenFilePatterns: [String] = []
+    ) {
+        let _: SearchIndexStatusPayload? = execute(
+            command: "workspace.searchIndex.update",
+            payload: SearchIndexUpdateRequest(
+                root: rootURL.standardizedFileURL.path,
+                paths: changedPaths,
+                hiddenDirectoryNames: hiddenDirectoryNames,
+                hiddenFilePatterns: hiddenFilePatterns
+            )
+        )
+    }
+
+    func invalidateSearchIndex(
+        at rootURL: URL,
+        hiddenDirectoryNames: [String] = [],
+        hiddenFilePatterns: [String] = []
+    ) {
+        let _: EmptyResponsePayload? = execute(
+            command: "workspace.searchIndex.invalidate",
             payload: SnapshotRequest(
                 root: rootURL.standardizedFileURL.path,
                 hiddenDirectoryNames: hiddenDirectoryNames,

--- a/Sources/Lithe/Core/RustWorkspaceOperations.swift
+++ b/Sources/Lithe/Core/RustWorkspaceOperations.swift
@@ -30,8 +30,28 @@ protocol WorkspaceOperations: Sendable {
         visibilityRules: FileVisibilityRules
     ) -> [ProjectReplacementFile]?
 
+    func warmSearchIndex(at rootURL: URL, visibilityRules: FileVisibilityRules)
+    func updateSearchIndex(
+        at rootURL: URL,
+        changedPaths: [String],
+        visibilityRules: FileVisibilityRules
+    )
+    func invalidateSearchIndex(at rootURL: URL, visibilityRules: FileVisibilityRules)
+
     func readFile(at rootURL: URL, relativePath: String) -> String?
     func writeFile(_ text: String, at rootURL: URL, relativePath: String) -> Bool
+}
+
+extension WorkspaceOperations {
+    func warmSearchIndex(at rootURL: URL, visibilityRules: FileVisibilityRules) {}
+
+    func updateSearchIndex(
+        at rootURL: URL,
+        changedPaths: [String],
+        visibilityRules: FileVisibilityRules
+    ) {}
+
+    func invalidateSearchIndex(at rootURL: URL, visibilityRules: FileVisibilityRules) {}
 }
 
 struct RustWorkspaceOperations: WorkspaceOperations, Sendable {
@@ -117,6 +137,35 @@ struct RustWorkspaceOperations: WorkspaceOperations, Sendable {
             hiddenDirectoryNames: visibilityRules.hiddenDirectoryNames,
             hiddenFilePatterns: visibilityRules.hiddenFilePatterns
         )?.makeModels(at: rootURL)
+    }
+
+    func warmSearchIndex(at rootURL: URL, visibilityRules: FileVisibilityRules) {
+        core.warmSearchIndex(
+            at: rootURL,
+            hiddenDirectoryNames: visibilityRules.hiddenDirectoryNames,
+            hiddenFilePatterns: visibilityRules.hiddenFilePatterns
+        )
+    }
+
+    func updateSearchIndex(
+        at rootURL: URL,
+        changedPaths: [String],
+        visibilityRules: FileVisibilityRules
+    ) {
+        core.updateSearchIndex(
+            at: rootURL,
+            changedPaths: changedPaths,
+            hiddenDirectoryNames: visibilityRules.hiddenDirectoryNames,
+            hiddenFilePatterns: visibilityRules.hiddenFilePatterns
+        )
+    }
+
+    func invalidateSearchIndex(at rootURL: URL, visibilityRules: FileVisibilityRules) {
+        core.invalidateSearchIndex(
+            at: rootURL,
+            hiddenDirectoryNames: visibilityRules.hiddenDirectoryNames,
+            hiddenFilePatterns: visibilityRules.hiddenFilePatterns
+        )
     }
 
     func readFile(at rootURL: URL, relativePath: String) -> String? {

--- a/rust/lithe-core/src/command.rs
+++ b/rust/lithe-core/src/command.rs
@@ -19,6 +19,9 @@ pub struct CoreRequest {
 pub enum CoreCommand {
     Ping,
     WorkspaceSnapshot,
+    WorkspaceSearchIndexWarm,
+    WorkspaceSearchIndexUpdate,
+    WorkspaceSearchIndexInvalidate,
     WorkspaceSearch,
     WorkspaceSearchEverywhere,
     WorkspaceReplacePreview,
@@ -60,6 +63,9 @@ impl CoreCommand {
         match value {
             "core.ping" => Some(Self::Ping),
             "workspace.snapshot" => Some(Self::WorkspaceSnapshot),
+            "workspace.searchIndex.warm" => Some(Self::WorkspaceSearchIndexWarm),
+            "workspace.searchIndex.update" => Some(Self::WorkspaceSearchIndexUpdate),
+            "workspace.searchIndex.invalidate" => Some(Self::WorkspaceSearchIndexInvalidate),
             "workspace.search" => Some(Self::WorkspaceSearch),
             "workspace.searchEverywhere" => Some(Self::WorkspaceSearchEverywhere),
             "workspace.replacePreview" => Some(Self::WorkspaceReplacePreview),

--- a/rust/lithe-core/src/lib.rs
+++ b/rust/lithe-core/src/lib.rs
@@ -10,6 +10,7 @@ mod markdown;
 mod maven;
 mod model;
 mod runtime;
+mod search_index;
 mod workspace;
 
 pub use command::{CoreCommand, CoreRequest};
@@ -249,6 +250,143 @@ mod tests {
             override_response["data"]["files"][0]["matches"][0]["before"],
             "    void fetchUser() {}"
         );
+
+        fs::remove_dir_all(root).expect("temporary fixture should be removable");
+    }
+
+    #[test]
+    fn shared_search_index_warms_and_tracks_file_changes() {
+        let root = temporary_root("search-index-updates");
+        fs::create_dir_all(&root).expect("fixture directory should be creatable");
+        let source = root.join("source.txt");
+        fs::write(&source, "oldneedle\n").expect("fixture should be writable");
+
+        let request = |command: &str, payload: Value| -> Value {
+            let request = serde_json::json!({
+                "id": command,
+                "command": command,
+                "payload": payload
+            });
+            serde_json::from_str(&execute_json(
+                &serde_json::to_string(&request).expect("search index request should encode"),
+            ))
+            .expect("search index response should be JSON")
+        };
+        let search = |query: &str| -> Vec<String> {
+            let response = request(
+                "workspace.search",
+                serde_json::json!({"root": root, "query": query}),
+            );
+            assert_eq!(response["ok"], true);
+            response["data"]["matches"]
+                .as_array()
+                .expect("matches should be an array")
+                .iter()
+                .filter(|value| value["kind"] == "content")
+                .filter_map(|value| value["path"].as_str().map(str::to_string))
+                .collect()
+        };
+
+        let warm = request(
+            "workspace.searchIndex.warm",
+            serde_json::json!({"root": root}),
+        );
+        assert_eq!(warm["ok"], true);
+        assert_eq!(warm["data"]["fileCount"], 1);
+        assert_eq!(search("oldneedle"), vec!["source.txt"]);
+
+        fs::write(&source, "newneedle\n").expect("fixture should be updateable");
+        let update = request(
+            "workspace.searchIndex.update",
+            serde_json::json!({"root": root, "paths": [source]}),
+        );
+        assert_eq!(update["ok"], true);
+        assert_eq!(update["data"]["rebuilt"], false);
+        assert!(search("oldneedle").is_empty());
+        assert_eq!(search("newneedle"), vec!["source.txt"]);
+
+        let write = request(
+            "file.write",
+            serde_json::json!({
+                "root": root,
+                "path": "source.txt",
+                "text": "directwritetoken\n"
+            }),
+        );
+        assert_eq!(write["ok"], true);
+        assert!(search("newneedle").is_empty());
+        assert_eq!(search("directwritetoken"), vec!["source.txt"]);
+
+        let added = root.join("added.txt");
+        fs::write(&added, "brandnewtoken\n").expect("new fixture should be writable");
+        let add = request(
+            "workspace.searchIndex.update",
+            serde_json::json!({"root": root, "paths": [added]}),
+        );
+        assert_eq!(add["data"]["rebuilt"], false);
+        assert_eq!(search("brandnewtoken"), vec!["added.txt"]);
+
+        fs::remove_file(&added).expect("new fixture should be removable");
+        let remove = request(
+            "workspace.searchIndex.update",
+            serde_json::json!({"root": root, "paths": [added]}),
+        );
+        assert_eq!(remove["data"]["rebuilt"], false);
+        assert!(search("brandnewtoken").is_empty());
+
+        let nested = root.join("generated");
+        fs::create_dir_all(&nested).expect("nested fixture should be creatable");
+        fs::write(nested.join("result.txt"), "directorytoken\n")
+            .expect("nested fixture should be writable");
+        let rebuild = request(
+            "workspace.searchIndex.update",
+            serde_json::json!({"root": root, "paths": [nested]}),
+        );
+        assert_eq!(rebuild["data"]["rebuilt"], true);
+        assert_eq!(search("directorytoken"), vec!["generated/result.txt"]);
+
+        fs::remove_dir_all(&root).expect("temporary fixture should be removable");
+        let invalidate = request(
+            "workspace.searchIndex.invalidate",
+            serde_json::json!({"root": root}),
+        );
+        assert_eq!(invalidate["ok"], true);
+    }
+
+    #[test]
+    fn shared_search_index_preserves_fallback_query_semantics() {
+        let root = temporary_root("search-index-fallbacks");
+        fs::create_dir_all(&root).expect("fixture directory should be creatable");
+        fs::write(root.join("foo.txt"), "foo xy 你好\n").expect("fixture should be writable");
+        fs::write(root.join("bar.txt"), "bar\n").expect("fixture should be writable");
+
+        let search = |query: &str, regular_expression: bool| -> Vec<String> {
+            let request = serde_json::json!({
+                "id": "fallback-search",
+                "command": "workspace.search",
+                "payload": {
+                    "root": root,
+                    "query": query,
+                    "regularExpression": regular_expression
+                }
+            });
+            let response: Value = serde_json::from_str(&execute_json(
+                &serde_json::to_string(&request).expect("fallback search should encode"),
+            ))
+            .expect("fallback search response should be JSON");
+            assert_eq!(response["ok"], true);
+            response["data"]["matches"]
+                .as_array()
+                .expect("matches should be an array")
+                .iter()
+                .filter(|value| value["kind"] == "content")
+                .filter_map(|value| value["path"].as_str().map(str::to_string))
+                .collect()
+        };
+
+        assert_eq!(search("foo|bar", true), vec!["bar.txt", "foo.txt"]);
+        assert_eq!(search("xy", false), vec!["foo.txt"]);
+        assert_eq!(search("你好", false), vec!["foo.txt"]);
 
         fs::remove_dir_all(root).expect("temporary fixture should be removable");
     }

--- a/rust/lithe-core/src/runtime.rs
+++ b/rust/lithe-core/src/runtime.rs
@@ -17,8 +17,8 @@ use crate::markdown::MarkdownRenderRequest;
 use crate::maven::{MavenDiagnosticsRequest, MavenScanRequest};
 use crate::model::CoreResponse;
 use crate::workspace::{
-    self, FileReadRequest, FileWriteRequest, ReplacementPreviewRequest, SearchRequest,
-    WorkspaceSnapshotRequest,
+    self, FileReadRequest, FileWriteRequest, ReplacementPreviewRequest, SearchIndexRequest,
+    SearchIndexUpdateRequest, SearchRequest, WorkspaceSnapshotRequest,
 };
 use serde_json::json;
 
@@ -83,6 +83,48 @@ fn execute(request: &str) -> CoreResponse {
                     id,
                     serde_json::to_value(data).expect("snapshot should encode"),
                 ),
+                Err(error) => CoreResponse::failure(id, error),
+            }
+        }
+        CoreCommand::WorkspaceSearchIndexWarm => {
+            match serde_json::from_value::<SearchIndexRequest>(parsed.payload)
+                .map_err(|error| {
+                    CoreError::new(ErrorCode::InvalidRequest, "Invalid search index request")
+                        .with_details(error.to_string())
+                })
+                .and_then(workspace::warm_search_index)
+            {
+                Ok(data) => CoreResponse::success(
+                    id,
+                    serde_json::to_value(data).expect("search index status should encode"),
+                ),
+                Err(error) => CoreResponse::failure(id, error),
+            }
+        }
+        CoreCommand::WorkspaceSearchIndexUpdate => {
+            match serde_json::from_value::<SearchIndexUpdateRequest>(parsed.payload)
+                .map_err(|error| {
+                    CoreError::new(ErrorCode::InvalidRequest, "Invalid search index update")
+                        .with_details(error.to_string())
+                })
+                .and_then(workspace::update_search_index)
+            {
+                Ok(data) => CoreResponse::success(
+                    id,
+                    serde_json::to_value(data).expect("search index status should encode"),
+                ),
+                Err(error) => CoreResponse::failure(id, error),
+            }
+        }
+        CoreCommand::WorkspaceSearchIndexInvalidate => {
+            match serde_json::from_value::<SearchIndexRequest>(parsed.payload)
+                .map_err(|error| {
+                    CoreError::new(ErrorCode::InvalidRequest, "Invalid search index request")
+                        .with_details(error.to_string())
+                })
+                .and_then(workspace::invalidate_search_index)
+            {
+                Ok(()) => CoreResponse::success(id, json!({})),
                 Err(error) => CoreResponse::failure(id, error),
             }
         }

--- a/rust/lithe-core/src/search_index.rs
+++ b/rust/lithe-core/src/search_index.rs
@@ -1,0 +1,456 @@
+use crate::error::{CoreError, ErrorCode};
+use crate::model::SearchMatch;
+use crate::workspace::{java_symbols, read_searchable_text, relative_path, VisibilityRules};
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock, RwLock};
+
+/// A workspace-local search index shared by file search, Search Everywhere and
+/// Replace in Files. The postings are file-level on purpose: the final matcher
+/// still reads the current file, so regex, whole-word and unsaved-buffer
+/// semantics remain exact.
+pub(crate) struct WorkspaceSearchIndex {
+    files: Vec<Option<IndexedFile>>,
+    free_ids: Vec<u32>,
+    path_to_id: HashMap<String, u32>,
+    postings: HashMap<u32, Vec<u32>>,
+}
+
+pub(crate) struct IndexedFile {
+    pub(crate) path: String,
+    trigrams: Vec<u32>,
+    pub(crate) symbols: Vec<IndexedSymbol>,
+}
+
+#[derive(Clone)]
+pub(crate) struct IndexedSymbol {
+    pub(crate) name: String,
+    pub(crate) kind: String,
+    pub(crate) line: usize,
+    pub(crate) signature: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UpdateOutcome {
+    NotIndexed,
+    Updated,
+    RequiresRebuild,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SearchIndexStats {
+    pub(crate) file_count: usize,
+    pub(crate) symbol_count: usize,
+    pub(crate) posting_count: usize,
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+struct IndexKey {
+    root: PathBuf,
+    hidden_directories: Vec<String>,
+    hidden_file_patterns: Vec<String>,
+}
+
+type SharedIndex = Arc<RwLock<WorkspaceSearchIndex>>;
+
+static INDEX_CACHE: OnceLock<std::sync::Mutex<HashMap<IndexKey, SharedIndex>>> = OnceLock::new();
+
+fn cache() -> &'static std::sync::Mutex<HashMap<IndexKey, SharedIndex>> {
+    INDEX_CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+fn key(root: &Path, rules: &VisibilityRules) -> IndexKey {
+    IndexKey {
+        root: root.to_path_buf(),
+        hidden_directories: rules.hidden_directories.clone(),
+        hidden_file_patterns: rules.hidden_file_patterns.clone(),
+    }
+}
+
+pub(crate) fn get_or_build(root: &Path, rules: &VisibilityRules) -> Result<SharedIndex, CoreError> {
+    // Hold the cache lock during the first build. This prevents a rapid sequence
+    // of keystrokes from constructing several copies of a large index at once.
+    let mut indexes = cache()
+        .lock()
+        .map_err(|_| CoreError::new(ErrorCode::Unknown, "Search index lock was poisoned"))?;
+    let cache_key = key(root, rules);
+    if let Some(index) = indexes.get(&cache_key) {
+        return Ok(Arc::clone(index));
+    }
+    let index = Arc::new(RwLock::new(WorkspaceSearchIndex::build(root, rules)?));
+    indexes.insert(cache_key, Arc::clone(&index));
+    Ok(index)
+}
+
+pub(crate) fn invalidate_root(root: &Path) {
+    let Ok(mut indexes) = cache().lock() else {
+        return;
+    };
+    indexes.retain(|key, _| key.root != root);
+}
+
+pub(crate) fn update_cached_file(root: &Path, path: &Path) {
+    let entries = {
+        let Ok(indexes) = cache().lock() else {
+            return;
+        };
+        indexes
+            .iter()
+            .filter(|(key, _)| key.root == root)
+            .map(|(key, index)| (key.clone(), Arc::clone(index)))
+            .collect::<Vec<_>>()
+    };
+    if entries.is_empty() {
+        return;
+    }
+    let Some(absolute) = normalized_update_path(root, &path.to_string_lossy()) else {
+        return;
+    };
+    let relative = relative_path(&absolute, root);
+    let metadata = fs::symlink_metadata(&absolute).ok();
+    for (cache_key, index) in entries {
+        let rules = VisibilityRules {
+            hidden_directories: cache_key.hidden_directories,
+            hidden_file_patterns: cache_key.hidden_file_patterns,
+        };
+        if let Ok(mut index) = index.write() {
+            index.update_file(&absolute, &relative, metadata.as_ref(), &rules);
+        }
+    }
+}
+
+/// Updates existing files in-place when a watcher reports file-only changes.
+/// Directory events deliberately request a full rebuild because they can add or
+/// remove an arbitrary number of descendants.
+pub(crate) fn update_paths(
+    root: &Path,
+    rules: &VisibilityRules,
+    paths: &[String],
+) -> UpdateOutcome {
+    let cache_key = key(root, rules);
+    let index = {
+        let Ok(indexes) = cache().lock() else {
+            return UpdateOutcome::NotIndexed;
+        };
+        indexes.get(&cache_key).cloned()
+    };
+    let Some(index) = index else {
+        return UpdateOutcome::NotIndexed;
+    };
+    let Ok(mut index) = index.write() else {
+        return UpdateOutcome::RequiresRebuild;
+    };
+
+    for value in paths {
+        let Some(absolute) = normalized_update_path(root, value) else {
+            continue;
+        };
+        let relative = relative_path(&absolute, root);
+        let metadata = fs::symlink_metadata(&absolute).ok();
+        if metadata.as_ref().is_some_and(|value| value.is_dir()) {
+            return UpdateOutcome::RequiresRebuild;
+        }
+        if metadata.is_none() && index.has_descendant(&relative) {
+            return UpdateOutcome::RequiresRebuild;
+        }
+        index.update_file(&absolute, &relative, metadata.as_ref(), rules);
+    }
+    UpdateOutcome::Updated
+}
+
+impl WorkspaceSearchIndex {
+    fn build(root: &Path, rules: &VisibilityRules) -> Result<Self, CoreError> {
+        let mut paths = Vec::new();
+        collect_files(root, root, rules, &mut paths)?;
+        let mut index = Self {
+            files: Vec::new(),
+            free_ids: Vec::new(),
+            path_to_id: HashMap::with_capacity(paths.len()),
+            postings: HashMap::new(),
+        };
+        for path in paths {
+            crate::cancellation::check()?;
+            let relative = relative_path(&path, root);
+            index.add_file(&path, relative);
+        }
+        Ok(index)
+    }
+
+    fn add_file(&mut self, path: &Path, relative: String) {
+        if let Some(existing) = self.path_to_id.get(&relative).copied() {
+            self.remove_id(existing);
+        }
+        let (trigrams, symbols) = read_search_data(path, &relative);
+        let id = self
+            .free_ids
+            .pop()
+            .unwrap_or_else(|| u32::try_from(self.files.len()).expect("search index is too large"));
+        for trigram in &trigrams {
+            let posting = self.postings.entry(*trigram).or_default();
+            if let Err(position) = posting.binary_search(&id) {
+                posting.insert(position, id);
+            }
+        }
+        let file = Some(IndexedFile {
+            path: relative.clone(),
+            trigrams,
+            symbols,
+        });
+        let id_index = id as usize;
+        if id_index == self.files.len() {
+            self.files.push(file);
+        } else {
+            self.files[id_index] = file;
+        }
+        self.path_to_id.insert(relative, id);
+    }
+
+    fn update_file(
+        &mut self,
+        absolute: &Path,
+        relative: &str,
+        metadata: Option<&fs::Metadata>,
+        rules: &VisibilityRules,
+    ) {
+        self.remove_file(relative);
+        if metadata.is_some_and(|metadata| {
+            metadata.is_file()
+                && !metadata.file_type().is_symlink()
+                && !rules.is_hidden(relative, false)
+        }) {
+            self.add_file(absolute, relative.to_string());
+        }
+    }
+
+    fn remove_file(&mut self, relative: &str) {
+        if let Some(id) = self.path_to_id.remove(relative) {
+            self.remove_id(id);
+        }
+    }
+
+    fn remove_id(&mut self, id: u32) {
+        let Some(file) = self.files.get_mut(id as usize).and_then(Option::take) else {
+            return;
+        };
+        for trigram in file.trigrams {
+            if let Some(posting) = self.postings.get_mut(&trigram) {
+                posting.retain(|value| *value != id);
+                if posting.is_empty() {
+                    self.postings.remove(&trigram);
+                }
+            }
+        }
+        self.free_ids.push(id);
+    }
+
+    fn has_descendant(&self, relative: &str) -> bool {
+        let prefix = if relative.is_empty() {
+            String::new()
+        } else {
+            format!("{relative}/")
+        };
+        self.path_to_id.keys().any(|path| path.starts_with(&prefix))
+    }
+
+    pub(crate) fn all_file_ids(&self) -> Vec<u32> {
+        self.files
+            .iter()
+            .enumerate()
+            .filter_map(|(id, file)| file.as_ref().map(|_| id as u32))
+            .collect()
+    }
+
+    pub(crate) fn file(&self, id: u32) -> Option<&IndexedFile> {
+        self.files.get(id as usize).and_then(Option::as_ref)
+    }
+
+    pub(crate) fn id_for_path(&self, path: &str) -> Option<u32> {
+        self.path_to_id.get(path).copied()
+    }
+
+    pub(crate) fn candidate_ids(&self, query: &str, regular_expression: bool) -> Vec<u32> {
+        let Some(anchor) = search_anchor(query, regular_expression) else {
+            return self.all_file_ids();
+        };
+        let trigrams = unique_trigrams(&anchor);
+        if trigrams.is_empty() {
+            return self.all_file_ids();
+        }
+        let mut postings = Vec::with_capacity(trigrams.len());
+        for trigram in trigrams {
+            let Some(posting) = self.postings.get(&trigram) else {
+                return Vec::new();
+            };
+            postings.push(posting);
+        }
+        postings.sort_by_key(|posting| posting.len());
+        let mut candidates = postings[0]
+            .iter()
+            .copied()
+            .filter(|id| self.file(*id).is_some())
+            .collect::<Vec<_>>();
+        candidates.retain(|id| {
+            postings[1..]
+                .iter()
+                .all(|posting| posting.binary_search(id).is_ok())
+        });
+        candidates.sort_unstable();
+        candidates
+    }
+
+    pub(crate) fn symbols(&self, id: u32) -> &[IndexedSymbol] {
+        self.file(id)
+            .map(|file| file.symbols.as_slice())
+            .unwrap_or(&[])
+    }
+
+    pub(crate) fn stats(&self) -> SearchIndexStats {
+        SearchIndexStats {
+            file_count: self.files.iter().filter(|file| file.is_some()).count(),
+            symbol_count: self
+                .files
+                .iter()
+                .filter_map(Option::as_ref)
+                .map(|file| file.symbols.len())
+                .sum(),
+            posting_count: self.postings.values().map(Vec::len).sum(),
+        }
+    }
+}
+
+fn normalized_update_path(root: &Path, value: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(value);
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        root.join(path)
+    };
+    let normalized = canonicalize_with_missing_components(&absolute)?;
+    normalized.starts_with(root).then_some(normalized)
+}
+
+pub(crate) fn canonicalize_with_missing_components(path: &Path) -> Option<PathBuf> {
+    if let Ok(canonical) = path.canonicalize() {
+        return Some(canonical);
+    }
+    // Deleted paths cannot be canonicalized directly. Canonicalize their
+    // nearest surviving ancestor, then append the missing path components.
+    let mut ancestor = path;
+    let mut suffix = Vec::<OsString>::new();
+    while !ancestor.exists() {
+        suffix.push(ancestor.file_name()?.to_os_string());
+        ancestor = ancestor.parent()?;
+    }
+    let mut normalized = ancestor.canonicalize().ok()?;
+    for component in suffix.iter().rev() {
+        normalized.push(component);
+    }
+    Some(normalized)
+}
+
+fn collect_files(
+    root: &Path,
+    path: &Path,
+    rules: &VisibilityRules,
+    files: &mut Vec<PathBuf>,
+) -> Result<(), CoreError> {
+    crate::cancellation::check()?;
+    let mut children = fs::read_dir(path)
+        .map_err(CoreError::from)?
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let child_path = entry.path();
+            let metadata = fs::symlink_metadata(&child_path).ok()?;
+            if metadata.file_type().is_symlink() {
+                return None;
+            }
+            let relative = relative_path(&child_path, root);
+            if rules.is_hidden(&relative, metadata.is_dir()) {
+                return None;
+            }
+            Some((child_path, metadata.is_dir()))
+        })
+        .collect::<Vec<_>>();
+    children.sort_by(|left, right| {
+        right.1.cmp(&left.1).then_with(|| {
+            left.0
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or_default()
+                .to_lowercase()
+                .cmp(
+                    &right
+                        .0
+                        .file_name()
+                        .and_then(|value| value.to_str())
+                        .unwrap_or_default()
+                        .to_lowercase(),
+                )
+        })
+    });
+    for (child, is_directory) in children {
+        if is_directory {
+            collect_files(root, &child, rules, files)?;
+        } else {
+            files.push(child);
+        }
+    }
+    Ok(())
+}
+
+fn read_search_data(path: &Path, relative: &str) -> (Vec<u32>, Vec<IndexedSymbol>) {
+    let Some(text) = read_searchable_text(path) else {
+        return (Vec::new(), Vec::new());
+    };
+    let trigrams = unique_trigrams(&text);
+    let symbols = java_symbols(relative, &text)
+        .into_iter()
+        .map(|symbol| IndexedSymbol {
+            name: symbol.name,
+            kind: symbol.kind,
+            line: symbol.line,
+            signature: symbol.signature,
+        })
+        .collect();
+    (trigrams, symbols)
+}
+
+fn unique_trigrams(value: &str) -> Vec<u32> {
+    let normalized = value.to_lowercase();
+    let bytes = normalized.as_bytes();
+    let mut unique = HashSet::new();
+    for window in bytes.windows(3) {
+        unique.insert(encode_trigram(window));
+    }
+    let mut result = unique.into_iter().collect::<Vec<_>>();
+    result.sort_unstable();
+    result
+}
+
+fn encode_trigram(window: &[u8]) -> u32 {
+    (u32::from(window[0]) << 16) | (u32::from(window[1]) << 8) | u32::from(window[2])
+}
+
+fn search_anchor(query: &str, regular_expression: bool) -> Option<String> {
+    if regular_expression {
+        return None;
+    }
+    let anchor = query.to_string();
+    if anchor.is_ascii() && anchor.len() >= 3 {
+        Some(anchor)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn make_symbol_match(indexed: &IndexedSymbol, path: String) -> SearchMatch {
+    SearchMatch {
+        kind: indexed.kind.clone(),
+        path,
+        line: Some(indexed.line),
+        preview: indexed.signature.clone(),
+        symbol_name: Some(indexed.name.clone()),
+    }
+}

--- a/rust/lithe-core/src/workspace.rs
+++ b/rust/lithe-core/src/workspace.rs
@@ -3,9 +3,10 @@ use crate::model::{
     FileReadResponse, FileWriteResponse, ReplacementPreviewResponse, SearchMatch, SearchResponse,
     WorkspaceNode, WorkspaceSnapshotResponse,
 };
+use crate::search_index::{self, UpdateOutcome, WorkspaceSearchIndex};
 use regex::{Regex, RegexBuilder};
-use serde::Deserialize;
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -65,6 +66,37 @@ pub struct SearchRequest {
     pub file_mask: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchIndexRequest {
+    pub root: String,
+    #[serde(default)]
+    pub hidden_directory_names: Vec<String>,
+    #[serde(default)]
+    pub hidden_file_patterns: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchIndexUpdateRequest {
+    pub root: String,
+    #[serde(default)]
+    pub paths: Vec<String>,
+    #[serde(default)]
+    pub hidden_directory_names: Vec<String>,
+    #[serde(default)]
+    pub hidden_file_patterns: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchIndexStatusResponse {
+    pub file_count: usize,
+    pub symbol_count: usize,
+    pub posting_count: usize,
+    pub rebuilt: bool,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReplacementPreviewRequest {
@@ -113,6 +145,7 @@ fn default_max_results() -> usize {
 
 pub fn snapshot(request: WorkspaceSnapshotRequest) -> Result<WorkspaceSnapshotResponse, CoreError> {
     let root = existing_root(&request.root)?;
+    search_index::invalidate_root(&root);
     let rules = VisibilityRules::new(request.hidden_directory_names, request.hidden_file_patterns);
     let mut files = Vec::new();
     let node = scan_node(&root, &root, &rules, &mut files)?;
@@ -128,13 +161,25 @@ pub fn search(request: SearchRequest) -> Result<SearchResponse, CoreError> {
         });
     }
 
-    let snapshot = snapshot(WorkspaceSnapshotRequest {
-        root: root.to_string_lossy().into_owned(),
-        hidden_directory_names: request.hidden_directory_names,
-        hidden_file_patterns: request.hidden_file_patterns,
-    })?;
+    let rules = VisibilityRules::new(
+        request.hidden_directory_names.clone(),
+        request.hidden_file_patterns.clone(),
+    );
+    let index = search_index::get_or_build(&root, &rules)?;
+    let index = index
+        .read()
+        .map_err(|_| CoreError::new(ErrorCode::Unknown, "Search index lock was poisoned"))?;
+    search_with_index(&root, &request, &query, &index)
+}
+
+fn search_with_index(
+    root: &Path,
+    request: &SearchRequest,
+    query: &str,
+    index: &WorkspaceSearchIndex,
+) -> Result<SearchResponse, CoreError> {
     let matcher = Matcher::new(
-        &query,
+        query,
         request.case_sensitive,
         request.whole_words,
         request.regular_expression,
@@ -146,11 +191,15 @@ pub fn search(request: SearchRequest) -> Result<SearchResponse, CoreError> {
     let mut matches = Vec::new();
     let mut file_matches = 0;
 
-    for path in &snapshot.files {
+    for id in index.all_file_ids() {
         crate::cancellation::check()?;
         if matches.len() >= limit || file_matches >= file_limit {
             break;
         }
+        let Some(indexed_file) = index.file(id) else {
+            continue;
+        };
+        let path = &indexed_file.path;
         if !file_mask_allows(&masks, path) {
             continue;
         }
@@ -167,11 +216,15 @@ pub fn search(request: SearchRequest) -> Result<SearchResponse, CoreError> {
     }
 
     let mut content_matches = 0;
-    for path in &snapshot.files {
+    for id in index.candidate_ids(query, request.regular_expression) {
         crate::cancellation::check()?;
         if matches.len() >= limit || content_matches >= content_limit {
             break;
         }
+        let Some(indexed_file) = index.file(id) else {
+            continue;
+        };
+        let path = &indexed_file.path;
         if !file_mask_allows(&masks, path) {
             continue;
         }
@@ -202,17 +255,21 @@ pub fn search(request: SearchRequest) -> Result<SearchResponse, CoreError> {
 
 pub fn search_everywhere(request: SearchRequest) -> Result<SearchResponse, CoreError> {
     let root = existing_root(&request.root)?;
-    let response = search(request.clone())?;
     let query = request.query.trim().to_string();
     if query.is_empty() {
-        return Ok(response);
+        return Ok(SearchResponse {
+            matches: Vec::new(),
+        });
     }
-
-    let snapshot = snapshot(WorkspaceSnapshotRequest {
-        root: root.to_string_lossy().into_owned(),
-        hidden_directory_names: request.hidden_directory_names,
-        hidden_file_patterns: request.hidden_file_patterns,
-    })?;
+    let rules = VisibilityRules::new(
+        request.hidden_directory_names.clone(),
+        request.hidden_file_patterns.clone(),
+    );
+    let index = search_index::get_or_build(&root, &rules)?;
+    let index = index
+        .read()
+        .map_err(|_| CoreError::new(ErrorCode::Unknown, "Search index lock was poisoned"))?;
+    let response = search_with_index(&root, &request, &query, &index)?;
     let matcher = Matcher::new(
         &query,
         request.case_sensitive,
@@ -222,30 +279,20 @@ pub fn search_everywhere(request: SearchRequest) -> Result<SearchResponse, CoreE
     let symbol_limit = request.max_symbol_results.unwrap_or(50).min(50);
     let mut types = Vec::new();
     let mut symbols = Vec::new();
-    for path in snapshot.files {
+    for id in index.all_file_ids() {
         crate::cancellation::check()?;
         if types.len() >= symbol_limit && symbols.len() >= symbol_limit {
             break;
         }
-        if !path.to_lowercase().ends_with(".java") {
-            continue;
-        }
-        let file = root.join(&path);
-        let Ok(text) = fs::read_to_string(&file) else {
+        let Some(indexed_file) = index.file(id) else {
             continue;
         };
-        for symbol in java_symbols(&path, &text) {
+        for symbol in index.symbols(id) {
             crate::cancellation::check()?;
             if !matcher.matches(&symbol.name) {
                 continue;
             }
-            let result = SearchMatch {
-                kind: symbol.kind,
-                path: path.clone(),
-                line: Some(symbol.line),
-                preview: symbol.signature,
-                symbol_name: Some(symbol.name),
-            };
+            let result = search_index::make_symbol_match(symbol, indexed_file.path.clone());
             if result.kind == "type" {
                 if types.len() < symbol_limit {
                     types.push(result);
@@ -278,22 +325,43 @@ pub fn replace_preview(
     if query.is_empty() {
         return Ok(ReplacementPreviewResponse { files: Vec::new() });
     }
+    let rules = VisibilityRules::new(
+        request.hidden_directory_names.clone(),
+        request.hidden_file_patterns.clone(),
+    );
+    let shared_index = search_index::get_or_build(&root, &rules)?;
+    let index = shared_index
+        .read()
+        .map_err(|_| CoreError::new(ErrorCode::Unknown, "Search index lock was poisoned"))?;
     let matcher = Matcher::new(
         &query,
         request.case_sensitive,
         request.whole_words,
         request.regular_expression,
     )?;
+    let candidate_ids = index.candidate_ids(&query, request.regular_expression);
+    let candidate_set = candidate_ids.iter().copied().collect::<HashSet<_>>();
     let paths = if request.paths.is_empty() {
-        snapshot(WorkspaceSnapshotRequest {
-            root: root.to_string_lossy().into_owned(),
-            hidden_directory_names: request.hidden_directory_names,
-            hidden_file_patterns: request.hidden_file_patterns,
-        })?
-        .files
+        candidate_ids
+            .into_iter()
+            .filter_map(|id| index.file(id).map(|file| file.path.clone()))
+            .collect::<Vec<_>>()
     } else {
-        request.paths
+        let mut paths = Vec::new();
+        for value in &request.paths {
+            let relative = safe_relative_path_string(value)?;
+            let include = request.text_overrides.contains_key(&relative)
+                || index
+                    .id_for_path(&relative)
+                    .map(|id| candidate_set.contains(&id))
+                    .unwrap_or(true);
+            if include {
+                paths.push(relative);
+            }
+        }
+        paths
     };
+    drop(index);
     let masks = parse_file_mask(&request.file_mask);
     let mut files = Vec::new();
     for path in paths {
@@ -337,6 +405,55 @@ pub fn replace_preview(
     Ok(ReplacementPreviewResponse { files })
 }
 
+pub fn warm_search_index(
+    request: SearchIndexRequest,
+) -> Result<SearchIndexStatusResponse, CoreError> {
+    let root = existing_root(&request.root)?;
+    let rules = VisibilityRules::new(request.hidden_directory_names, request.hidden_file_patterns);
+    let index = search_index::get_or_build(&root, &rules)?;
+    let index = index
+        .read()
+        .map_err(|_| CoreError::new(ErrorCode::Unknown, "Search index lock was poisoned"))?;
+    let stats = index.stats();
+    Ok(SearchIndexStatusResponse {
+        file_count: stats.file_count,
+        symbol_count: stats.symbol_count,
+        posting_count: stats.posting_count,
+        rebuilt: false,
+    })
+}
+
+pub fn update_search_index(
+    request: SearchIndexUpdateRequest,
+) -> Result<SearchIndexStatusResponse, CoreError> {
+    let root = existing_root(&request.root)?;
+    let rules = VisibilityRules::new(request.hidden_directory_names, request.hidden_file_patterns);
+    let outcome = search_index::update_paths(&root, &rules, &request.paths);
+    let rebuilt = matches!(outcome, UpdateOutcome::RequiresRebuild);
+    if rebuilt {
+        search_index::invalidate_root(&root);
+    }
+    let index = search_index::get_or_build(&root, &rules)?;
+    let index = index
+        .read()
+        .map_err(|_| CoreError::new(ErrorCode::Unknown, "Search index lock was poisoned"))?;
+    let stats = index.stats();
+    Ok(SearchIndexStatusResponse {
+        file_count: stats.file_count,
+        symbol_count: stats.symbol_count,
+        posting_count: stats.posting_count,
+        rebuilt: rebuilt || matches!(outcome, UpdateOutcome::NotIndexed),
+    })
+}
+
+pub fn invalidate_search_index(request: SearchIndexRequest) -> Result<(), CoreError> {
+    let requested_root = PathBuf::from(&request.root);
+    let root = search_index::canonicalize_with_missing_components(&requested_root)
+        .unwrap_or(requested_root);
+    search_index::invalidate_root(&root);
+    Ok(())
+}
+
 pub fn read_file(request: FileReadRequest) -> Result<FileReadResponse, CoreError> {
     let root = existing_root(&request.root)?;
     let path = safe_relative_path(&root, &request.path)?;
@@ -373,15 +490,16 @@ pub fn write_file(request: FileWriteRequest) -> Result<FileWriteResponse, CoreEr
         CoreError::new(ErrorCode::PermissionDenied, "Could not write file")
             .with_details(error.to_string())
     })?;
+    search_index::update_cached_file(&root, &path);
     Ok(FileWriteResponse {
         path: relative_path(&path, &root),
         bytes_written: request.text.len(),
     })
 }
 
-struct VisibilityRules {
-    hidden_directories: Vec<String>,
-    hidden_file_patterns: Vec<String>,
+pub(crate) struct VisibilityRules {
+    pub(crate) hidden_directories: Vec<String>,
+    pub(crate) hidden_file_patterns: Vec<String>,
 }
 
 impl VisibilityRules {
@@ -402,7 +520,7 @@ impl VisibilityRules {
         }
     }
 
-    fn is_hidden(&self, path: &str, is_directory: bool) -> bool {
+    pub(crate) fn is_hidden(&self, path: &str, is_directory: bool) -> bool {
         let components = path
             .split('/')
             .filter(|value| !value.is_empty())
@@ -571,7 +689,7 @@ fn writable_relative_path(root: &Path, value: &str) -> Result<PathBuf, CoreError
     Ok(path)
 }
 
-fn relative_path(path: &Path, root: &Path) -> String {
+pub(crate) fn relative_path(path: &Path, root: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
         .to_string_lossy()
@@ -803,14 +921,14 @@ impl Matcher {
     }
 }
 
-struct JavaSymbol {
-    name: String,
-    kind: String,
-    line: usize,
-    signature: String,
+pub(crate) struct JavaSymbol {
+    pub(crate) name: String,
+    pub(crate) kind: String,
+    pub(crate) line: usize,
+    pub(crate) signature: String,
 }
 
-fn java_symbols(path: &str, source: &str) -> Vec<JavaSymbol> {
+pub(crate) fn java_symbols(path: &str, source: &str) -> Vec<JavaSymbol> {
     if !path.to_lowercase().ends_with(".java") {
         return Vec::new();
     }
@@ -894,7 +1012,7 @@ fn safe_relative_path_string(value: &str) -> Result<String, CoreError> {
     Ok(value.replace('\\', "/").trim_matches('/').to_string())
 }
 
-fn read_searchable_text(path: &Path) -> Option<String> {
+pub(crate) fn read_searchable_text(path: &Path) -> Option<String> {
     let metadata = fs::metadata(path).ok()?;
     if !metadata.is_file() || metadata.len() > MAX_FILE_SIZE {
         return None;


### PR DESCRIPTION
## Summary
- add a shared file-level Trigram inverted index for workspace search
- reuse the index for Find in Files, Search Everywhere, and Replace in Files
- add Swift warm/update/invalidate lifecycle integration and watcher updates
- preserve exact matching for regex, short, Unicode, and unsaved-buffer cases

## Verification
- `cargo test --manifest-path rust/lithe-core/Cargo.toml`
- `swift test --disable-sandbox`
- `git diff --check`

Fixes #44