### PR TITLE
优化 macOS UI 布局与交互体验

### DIFF
--- a/Sources/Lithe/Application/DocumentFeatureModel.swift
+++ b/Sources/Lithe/Application/DocumentFeatureModel.swift
@@ -100,6 +100,17 @@ final class DocumentFeatureModel: ObservableObject {
         displayPath: String? = nil
     ) {
         let normalizedURL = url.standardizedFileURL
+
+        // Switching to an already-open document does not require file I/O.
+        // Apply that state change synchronously so repeated tree clicks feel immediate.
+        if let existing = openDocuments.first(where: { $0.url == normalizedURL }) {
+            activeDocumentID = existing.id
+            if !isReadOnly {
+                onDocumentOpened?(existing)
+            }
+            return
+        }
+
         Task { await openFileAsync(
             normalizedURL,
             isReadOnly: isReadOnly,

--- a/Sources/Lithe/Application/DocumentFeatureModel.swift
+++ b/Sources/Lithe/Application/DocumentFeatureModel.swift
@@ -104,6 +104,7 @@ final class DocumentFeatureModel: ObservableObject {
         // Switching to an already-open document does not require file I/O.
         // Apply that state change synchronously so repeated tree clicks feel immediate.
         if let existing = openDocuments.first(where: { $0.url == normalizedURL }) {
+            latestFileOpenRequestID = UUID()
             activeDocumentID = existing.id
             if !isReadOnly {
                 onDocumentOpened?(existing)

--- a/Sources/Lithe/LitheApp.swift
+++ b/Sources/Lithe/LitheApp.swift
@@ -97,13 +97,15 @@ struct LitheApp: App {
                 // changes. Re-identify the root so a language selection takes
                 // effect immediately across every workspace, including sheets.
                 .id(settings.language)
-                .frame(minWidth: 980, minHeight: 640)
                 .preferredColorScheme(.dark)
                 .task {
                     memoryUsageMonitor.start()
                 }
         }
-        .defaultSize(width: 1440, height: 900)
+        .defaultSize(
+            width: LitheWindowLayout.welcomeContentSize.width,
+            height: LitheWindowLayout.welcomeContentSize.height
+        )
         .windowStyle(.hiddenTitleBar)
         .commands {
             CommandGroup(replacing: .newItem) {

--- a/Sources/Lithe/Theme/LitheTheme.swift
+++ b/Sources/Lithe/Theme/LitheTheme.swift
@@ -58,13 +58,16 @@ enum LitheTheme {
     static let guideColor = guide
     static let activeGuideColor = activeGuide
 
-    static let uiFont = Font.system(size: 13, weight: .regular)
-    static let smallFont = Font.system(size: 11, weight: .regular)
+    static let uiFont = Font.system(size: 14, weight: .regular)
+    static let smallFont = Font.system(size: 12, weight: .regular)
     static let codeFont = Font.system(size: 13, design: .monospaced)
 
     /// 统一的尺寸与间距刻度，避免各视图各写一套魔法数字。
     enum Metrics {
         static let rowHeight: CGFloat = 24
+        static let treeRowHeight: CGFloat = 27
+        static let treeIconSize: CGFloat = 16
+        static let treeFontSize: CGFloat = 13.5
         static let tabHeight: CGFloat = 34
         static let toolbarHeight: CGFloat = 40
         static let toolWindowHeaderHeight: CGFloat = 30
@@ -92,13 +95,17 @@ extension View {
     func litheRowHover(
         isActive: Bool = false,
         cornerRadius: CGFloat = LitheTheme.Metrics.cornerRadius,
-        activeBackground: Color = LitheTheme.selection
+        activeBackground: Color = LitheTheme.selection,
+        hoverBackground: Color = LitheTheme.hoverBackground,
+        animation: Animation? = .easeOut(duration: 0.12)
     ) -> some View {
         modifier(
             LitheRowHoverModifier(
                 isActive: isActive,
                 cornerRadius: cornerRadius,
-                activeBackground: activeBackground
+                activeBackground: activeBackground,
+                hoverBackground: hoverBackground,
+                animation: animation
             )
         )
     }
@@ -124,21 +131,30 @@ struct LitheIconButtonStyle: ButtonStyle {
     }
 }
 
+/// Keeps file-tree rows visually stable while they are being activated.
+struct LitheTreeRowButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+    }
+}
+
 private struct LitheRowHoverModifier: ViewModifier {
     let isActive: Bool
     let cornerRadius: CGFloat
     let activeBackground: Color
+    let hoverBackground: Color
+    let animation: Animation?
     @State private var isHovering = false
 
     func body(content: Content) -> some View {
         content
             .background(
                 RoundedRectangle(cornerRadius: cornerRadius)
-                    .fill(isActive ? activeBackground : (isHovering ? LitheTheme.hoverBackground : .clear))
+                    .fill(isActive ? activeBackground : (isHovering ? hoverBackground : .clear))
             )
             .contentShape(Rectangle())
             .onHover { isHovering = $0 }
-            .animation(.easeOut(duration: 0.12), value: isHovering)
+            .animation(animation, value: isHovering)
     }
 }
 

--- a/Sources/Lithe/Views/EditorAreaView.swift
+++ b/Sources/Lithe/Views/EditorAreaView.swift
@@ -367,15 +367,11 @@ struct EditorAreaView: View {
         }
         .padding(.leading, 11)
         .padding(.trailing, 9)
-        .frame(width: 280, height: LitheTheme.Metrics.tabHeight, alignment: .leading)
+        .fixedSize(horizontal: true, vertical: false)
+        .frame(height: LitheTheme.Metrics.tabHeight, alignment: .leading)
         .background(LitheTheme.activeTabBackground)
         .clipShape(RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius))
-        .overlay {
-            RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius)
-                .stroke(LitheTheme.accent.opacity(0.85), lineWidth: 1)
-        }
         .shadow(color: .black.opacity(0.42), radius: 10, y: 6)
-        .scaleEffect(1.04)
         .compositingGroup()
     }
 

--- a/Sources/Lithe/Views/ProjectSidebarView.swift
+++ b/Sources/Lithe/Views/ProjectSidebarView.swift
@@ -26,6 +26,7 @@ struct ProjectSidebarView: View {
                                 node: root,
                                 depth: 0,
                                 availableWidth: geometry.size.width,
+                                activeDocumentURL: model.activeDocument?.url,
                                 expandedDirectoryPaths: $expandedDirectoryPaths
                             )
                         }
@@ -148,15 +149,21 @@ struct ProjectSidebarView: View {
 }
 
 private struct FileNodeRow: View {
+    private static let horizontalInset: CGFloat = 10
+
     @EnvironmentObject private var model: AppModel
     let node: FileNode
     let depth: Int
     let availableWidth: CGFloat
+    let activeDocumentURL: URL?
     @Binding var expandedDirectoryPaths: Set<String>
     @State private var resolvedJavaIconKind: LitheIconKind?
 
     private var rowWidth: CGFloat {
-        max(availableWidth, CGFloat(depth * 14 + 8 + 180))
+        max(
+            availableWidth - (Self.horizontalInset * 2),
+            CGFloat(depth * 14 + 8 + 180)
+        )
     }
 
     private var isExpanded: Bool {
@@ -172,6 +179,7 @@ private struct FileNodeRow: View {
                         node: child,
                         depth: depth + 1,
                         availableWidth: availableWidth,
+                        activeDocumentURL: activeDocumentURL,
                         expandedDirectoryPaths: $expandedDirectoryPaths
                     )
                 }
@@ -197,10 +205,10 @@ private struct FileNodeRow: View {
                     .font(.system(size: 8, weight: .bold))
                     .frame(width: 10)
                     .foregroundStyle(LitheTheme.secondaryText)
-                LitheIcon(kind: node.iconKind, size: 14)
-                    .frame(width: 14, height: 14)
+                LitheIcon(kind: node.iconKind, size: LitheTheme.Metrics.treeIconSize)
+                    .frame(width: LitheTheme.Metrics.treeIconSize, height: LitheTheme.Metrics.treeIconSize)
                 Text(node.name)
-                    .font(.system(size: 12.5, weight: depth == 0 ? .semibold : .regular))
+                    .font(.system(size: LitheTheme.Metrics.treeFontSize, weight: depth == 0 ? .semibold : .regular))
                     .foregroundStyle(LitheTheme.primaryText)
                     .lineLimit(1)
                     .truncationMode(.middle)
@@ -210,12 +218,16 @@ private struct FileNodeRow: View {
             .padding(.leading, CGFloat(depth * 14 + 8))
             .padding(.trailing, 8)
             .frame(width: rowWidth, alignment: .leading)
-            .frame(height: 25)
+            .frame(height: LitheTheme.Metrics.treeRowHeight)
             .contentShape(Rectangle())
-            .litheRowHover(cornerRadius: 4)
+            .litheRowHover(
+                cornerRadius: 4,
+                hoverBackground: .clear,
+                animation: nil
+            )
         }
-        .buttonStyle(.plain)
-        .lithePointer()
+        .buttonStyle(LitheTreeRowButtonStyle())
+        .padding(.horizontal, Self.horizontalInset)
         .contextMenu { directoryContextMenu }
     }
 
@@ -225,10 +237,10 @@ private struct FileNodeRow: View {
         } label: {
             HStack(spacing: 6) {
                 Color.clear.frame(width: 10)
-                LitheIcon(kind: resolvedJavaIconKind ?? node.iconKind, size: 14)
-                    .frame(width: 14)
+                LitheIcon(kind: resolvedJavaIconKind ?? node.iconKind, size: LitheTheme.Metrics.treeIconSize)
+                    .frame(width: LitheTheme.Metrics.treeIconSize)
                 Text(node.name)
-                    .font(.system(size: 12.5))
+                    .font(.system(size: LitheTheme.Metrics.treeFontSize))
                     .foregroundStyle(LitheTheme.primaryText)
                     .lineLimit(1)
                     .truncationMode(.middle)
@@ -238,16 +250,18 @@ private struct FileNodeRow: View {
             .padding(.leading, CGFloat(depth * 14 + 8))
             .padding(.trailing, 8)
             .frame(width: rowWidth, alignment: .leading)
-            .frame(height: 25)
+            .frame(height: LitheTheme.Metrics.treeRowHeight)
             .contentShape(Rectangle())
             .litheRowHover(
-                isActive: model.activeDocument?.url == node.url,
+                isActive: activeDocumentURL == node.url,
                 cornerRadius: 4,
-                activeBackground: LitheTheme.subtleSelection
+                activeBackground: LitheTheme.subtleSelection,
+                hoverBackground: .clear,
+                animation: nil
             )
         }
-        .buttonStyle(.plain)
-        .lithePointer()
+        .buttonStyle(LitheTreeRowButtonStyle())
+        .padding(.horizontal, Self.horizontalInset)
         .contextMenu { fileContextMenu }
         .task(id: node.url.standardizedFileURL.path) {
             guard node.url.pathExtension.lowercased() == "java" else { return }

--- a/Sources/Lithe/Views/ProjectSidebarView.swift
+++ b/Sources/Lithe/Views/ProjectSidebarView.swift
@@ -21,7 +21,7 @@ struct ProjectSidebarView: View {
             } else if let root = model.rootNode {
                 GeometryReader { geometry in
                     ScrollView([.vertical, .horizontal]) {
-                        LazyVStack(alignment: .leading, spacing: 0) {
+                        LazyVStack(alignment: .leading, spacing: 1) {
                             FileNodeRow(
                                 node: root,
                                 depth: 0,
@@ -222,11 +222,12 @@ private struct FileNodeRow: View {
             .contentShape(Rectangle())
             .litheRowHover(
                 cornerRadius: 4,
-                hoverBackground: .clear,
                 animation: nil
             )
         }
         .buttonStyle(LitheTreeRowButtonStyle())
+        .lithePointer()
+        .padding(.vertical, 0.5)
         .padding(.horizontal, Self.horizontalInset)
         .contextMenu { directoryContextMenu }
     }
@@ -256,11 +257,12 @@ private struct FileNodeRow: View {
                 isActive: activeDocumentURL == node.url,
                 cornerRadius: 4,
                 activeBackground: LitheTheme.subtleSelection,
-                hoverBackground: .clear,
                 animation: nil
             )
         }
         .buttonStyle(LitheTreeRowButtonStyle())
+        .lithePointer()
+        .padding(.vertical, 0.5)
         .padding(.horizontal, Self.horizontalInset)
         .contextMenu { fileContextMenu }
         .task(id: node.url.standardizedFileURL.path) {

--- a/Sources/Lithe/Views/RootView.swift
+++ b/Sources/Lithe/Views/RootView.swift
@@ -18,8 +18,17 @@ struct RootView: View {
                     .zIndex(session.id == projectSessions.activeSessionID ? 1 : 0)
             }
         }
+        .frame(
+            minWidth: windowLayout.minimumContentSize.width,
+            minHeight: windowLayout.minimumContentSize.height
+        )
         .background(LitheTheme.window)
-        .background(WindowCloseGuard(projectSessions: projectSessions))
+        .background(
+            WindowCloseGuard(
+                projectSessions: projectSessions,
+                layout: windowLayout
+            )
+        )
         .sheet(isPresented: $model.isSettingsPresented) {
             SettingsView(
                 settings: model.settings,
@@ -134,10 +143,15 @@ struct RootView: View {
             }
         )
     }
+
+    private var windowLayout: LitheWindowLayout {
+        projectSessions.activeModel.workspaceURL == nil ? .welcome : .workspace
+    }
 }
 
 private struct WindowCloseGuard: NSViewRepresentable {
     let projectSessions: ProjectSessionManager
+    let layout: LitheWindowLayout
 
     func makeCoordinator() -> LitheWindowCoordinator {
         LitheWindowCoordinator(projectSessions: projectSessions)
@@ -146,7 +160,7 @@ private struct WindowCloseGuard: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
         DispatchQueue.main.async {
-            context.coordinator.attach(to: view.window)
+            context.coordinator.attach(to: view.window, layout: layout)
         }
         return view
     }
@@ -154,8 +168,47 @@ private struct WindowCloseGuard: NSViewRepresentable {
     func updateNSView(_ view: NSView, context: Context) {
         context.coordinator.projectSessions = projectSessions
         DispatchQueue.main.async {
-            context.coordinator.attach(to: view.window)
+            context.coordinator.attach(to: view.window, layout: layout)
         }
+    }
+}
+
+enum LitheWindowLayout: Equatable {
+    case welcome
+    case workspace
+
+    static let welcomeContentSize = NSSize(width: 900, height: 620)
+    static let workspaceContentSize = NSSize(width: 1440, height: 900)
+    static let screenMargin: CGFloat = 12
+
+    var contentSize: NSSize {
+        switch self {
+        case .welcome: Self.welcomeContentSize
+        case .workspace: Self.workspaceContentSize
+        }
+    }
+
+    var minimumContentSize: NSSize {
+        switch self {
+        case .welcome: NSSize(width: 820, height: 560)
+        case .workspace: NSSize(width: 980, height: 640)
+        }
+    }
+
+    static func frame(_ targetFrame: NSRect, fitting visibleFrame: NSRect) -> NSRect {
+        let availableFrame = visibleFrame.insetBy(dx: screenMargin, dy: screenMargin)
+        var fittedFrame = targetFrame
+        fittedFrame.size.width = min(fittedFrame.width, availableFrame.width)
+        fittedFrame.size.height = min(fittedFrame.height, availableFrame.height)
+        fittedFrame.origin.x = min(
+            max(fittedFrame.origin.x, availableFrame.minX),
+            availableFrame.maxX - fittedFrame.width
+        )
+        fittedFrame.origin.y = min(
+            max(fittedFrame.origin.y, availableFrame.minY),
+            availableFrame.maxY - fittedFrame.height
+        )
+        return fittedFrame
     }
 }
 
@@ -176,6 +229,8 @@ final class LitheWindowCoordinator: NSObject, NSWindowDelegate {
     var projectSessions: any ProjectWindowSessionHandling
     weak var window: NSWindow?
     private let registerWindow: @MainActor (NSWindow) -> Void
+    private var layout: LitheWindowLayout?
+    private var restoredWorkspaceFrame: NSRect?
 
     init(
         projectSessions: any ProjectWindowSessionHandling,
@@ -187,11 +242,37 @@ final class LitheWindowCoordinator: NSObject, NSWindowDelegate {
         self.registerWindow = registerWindow
     }
 
-    func attach(to window: NSWindow?) {
-        guard let window, self.window !== window else { return }
-        self.window = window
-        window.delegate = self
-        registerWindow(window)
+    func attach(to window: NSWindow?, layout: LitheWindowLayout) {
+        guard let window else { return }
+        if self.window !== window {
+            self.window = window
+            window.delegate = self
+            registerWindow(window)
+            self.layout = nil
+            restoredWorkspaceFrame = nil
+        }
+        apply(layout, to: window)
+    }
+
+    func toggleWorkspaceZoom() {
+        guard let visibleFrame = (window?.screen ?? NSScreen.main)?.visibleFrame else { return }
+        toggleWorkspaceZoom(fitting: visibleFrame)
+    }
+
+    func toggleWorkspaceZoom(fitting visibleFrame: NSRect) {
+        guard layout == .workspace, let window else { return }
+
+        let targetFrame: NSRect
+        if Self.framesMatch(window.frame, visibleFrame) {
+            targetFrame = restoredWorkspaceFrame.map {
+                LitheWindowLayout.frame($0, fitting: visibleFrame)
+            } ?? defaultWorkspaceFrame(for: window, fitting: visibleFrame)
+            restoredWorkspaceFrame = nil
+        } else {
+            restoredWorkspaceFrame = window.frame
+            targetFrame = visibleFrame
+        }
+        window.setFrame(targetFrame, display: true, animate: window.isVisible)
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
@@ -203,5 +284,44 @@ final class LitheWindowCoordinator: NSObject, NSWindowDelegate {
             sender.orderOut(nil)
         }
         return false
+    }
+
+    private func apply(_ layout: LitheWindowLayout, to window: NSWindow) {
+        window.contentMinSize = layout.minimumContentSize
+        guard self.layout != layout else { return }
+
+        let shouldAnimate = self.layout != nil && window.isVisible
+        self.layout = layout
+        restoredWorkspaceFrame = nil
+
+        let currentFrame = window.frame
+        let targetContentRect = NSRect(origin: .zero, size: layout.contentSize)
+        var targetFrame = window.frameRect(forContentRect: targetContentRect)
+        targetFrame.origin = NSPoint(
+            x: currentFrame.midX - targetFrame.width / 2,
+            y: currentFrame.midY - targetFrame.height / 2
+        )
+        if let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame {
+            targetFrame = LitheWindowLayout.frame(targetFrame, fitting: visibleFrame)
+        }
+        window.setFrame(targetFrame, display: true, animate: shouldAnimate)
+    }
+
+    private func defaultWorkspaceFrame(for window: NSWindow, fitting visibleFrame: NSRect) -> NSRect {
+        let targetContentRect = NSRect(origin: .zero, size: LitheWindowLayout.workspace.contentSize)
+        var targetFrame = window.frameRect(forContentRect: targetContentRect)
+        targetFrame.origin = NSPoint(
+            x: visibleFrame.midX - targetFrame.width / 2,
+            y: visibleFrame.midY - targetFrame.height / 2
+        )
+        return LitheWindowLayout.frame(targetFrame, fitting: visibleFrame)
+    }
+
+    private static func framesMatch(_ lhs: NSRect, _ rhs: NSRect) -> Bool {
+        let tolerance: CGFloat = 1
+        return abs(lhs.minX - rhs.minX) <= tolerance
+            && abs(lhs.minY - rhs.minY) <= tolerance
+            && abs(lhs.width - rhs.width) <= tolerance
+            && abs(lhs.height - rhs.height) <= tolerance
     }
 }

--- a/Sources/Lithe/Views/WelcomeView.swift
+++ b/Sources/Lithe/Views/WelcomeView.swift
@@ -14,7 +14,7 @@ struct WelcomeView: View {
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(LitheTheme.primaryText)
                 .frame(maxWidth: .infinity)
-                .frame(height: 58)
+                .frame(height: 48)
                 .background(LitheTheme.window)
 
             HStack(spacing: 0) {
@@ -24,6 +24,7 @@ struct WelcomeView: View {
             }
         }
         .background(LitheTheme.window)
+        .background(WelcomeInitialFocusReset())
     }
 
     private var welcomeSidebar: some View {
@@ -40,9 +41,9 @@ struct WelcomeView: View {
                     updatePrompt
                 }
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 38)
-            .padding(.bottom, 38)
+            .padding(.horizontal, 20)
+            .padding(.top, 28)
+            .padding(.bottom, 30)
 
             HStack(spacing: 9) {
                 LitheIcon(kind: .folder, size: 15)
@@ -81,7 +82,7 @@ struct WelcomeView: View {
             .padding(.horizontal, 14)
             .padding(.bottom, 14)
         }
-        .frame(width: 280)
+        .frame(width: 240)
         .background(LitheTheme.sidebar)
     }
 
@@ -177,26 +178,25 @@ struct WelcomeView: View {
                         .focused($searchFocused)
                 }
                 .litheSearchField(isFocused: searchFocused, height: 30)
-                .frame(maxWidth: 360)
+                .frame(maxWidth: 300)
 
                 Spacer()
 
                 Button("Clone") {
                     model.showCloneRepository()
                 }
-                .buttonStyle(.bordered)
-                .lithePointer()
+                .buttonStyle(LitheSecondaryButtonStyle())
 
                 Button("Open") {
                     model.chooseProject()
                 }
                 .buttonStyle(LithePrimaryButtonStyle())
             }
-            .padding(.horizontal, 30)
-            .frame(height: 76)
+            .padding(.horizontal, 20)
+            .frame(height: 66)
 
             Rectangle().fill(LitheTheme.divider).frame(height: 1)
-                .padding(.horizontal, 24)
+                .padding(.horizontal, 18)
 
             if filteredProjects.isEmpty {
                 emptyProjectsState
@@ -207,8 +207,8 @@ struct WelcomeView: View {
                             projectRow(project)
                         }
                     }
-                    .padding(.horizontal, 18)
-                    .padding(.vertical, 14)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
                 }
             }
         }
@@ -239,7 +239,7 @@ struct WelcomeView: View {
                     Text(initials(for: project.name))
                         .font(.system(size: 12, weight: .bold, design: .rounded))
                         .foregroundStyle(.white)
-                        .frame(width: 38, height: 38)
+                        .frame(width: 34, height: 34)
                         .background(project.exists ? color(for: project.name) : LitheTheme.raised)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
 
@@ -286,7 +286,7 @@ struct WelcomeView: View {
             .allowsHitTesting(hoveredProjectID == project.id)
         }
         .padding(.horizontal, 12)
-        .frame(height: 58)
+        .frame(height: 52)
         .background(hoveredProjectID == project.id ? LitheTheme.hoverBackground : .clear)
         .clipShape(RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius))
         .onHover { isHovering in
@@ -333,5 +333,34 @@ struct WelcomeView: View {
             hash &*= 1_099_511_628_211
         }
         return palette[Int(hash % UInt64(palette.count))]
+    }
+}
+
+private struct WelcomeInitialFocusReset: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        WelcomeInitialFocusResetView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+private final class WelcomeInitialFocusResetView: NSView {
+    private var didClearFocus = false
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+
+        guard !didClearFocus, let window else { return }
+
+        DispatchQueue.main.async { [weak self, weak window] in
+            guard let self, !self.didClearFocus, let window else { return }
+            window.makeFirstResponder(nil)
+            self.didClearFocus = true
+        }
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeFirstResponder(nil)
+        super.mouseDown(with: event)
     }
 }

--- a/Sources/Lithe/Views/WelcomeView.swift
+++ b/Sources/Lithe/Views/WelcomeView.swift
@@ -6,6 +6,7 @@ struct WelcomeView: View {
     @EnvironmentObject private var updateChecker: UpdateChecker
     @State private var projectFilter = ""
     @State private var hoveredProjectID: String?
+    @State private var hoveredProjectMenuID: String?
     @FocusState private var searchFocused: Bool
 
     var body: some View {
@@ -207,6 +208,7 @@ struct WelcomeView: View {
                             projectRow(project)
                         }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
                 }
@@ -262,6 +264,8 @@ struct WelcomeView: View {
             .lithePointer()
             .disabled(!project.exists)
 
+            Spacer(minLength: 0)
+
             Menu {
                 if project.exists {
                     Button("Open") { model.openProject(project.url) }
@@ -273,18 +277,27 @@ struct WelcomeView: View {
                     model.removeRecentProject(project)
                 }
             } label: {
-                LitheSystemIcon(systemImage: "ellipsis")
-                    .font(.system(size: 12, weight: .semibold))
-                    .frame(width: 28, height: 28)
-                    .contentShape(Rectangle())
+                ZStack {
+                    RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius)
+                        .fill(hoveredProjectMenuID == project.id ? LitheTheme.hoverBackground : .clear)
+                    LitheSystemIcon(systemImage: "ellipsis")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(LitheTheme.secondaryText)
+                }
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
+                .onHover { isHovering in
+                    hoveredProjectMenuID = isHovering ? project.id : nil
+                }
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .lithePointer()
-            .foregroundStyle(LitheTheme.secondaryText)
+            .frame(width: 28, height: 28)
             .opacity(hoveredProjectID == project.id ? 1 : 0)
             .allowsHitTesting(hoveredProjectID == project.id)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 12)
         .frame(height: 52)
         .background(hoveredProjectID == project.id ? LitheTheme.hoverBackground : .clear)
@@ -346,6 +359,7 @@ private struct WelcomeInitialFocusReset: NSViewRepresentable {
 
 private final class WelcomeInitialFocusResetView: NSView {
     private var didClearFocus = false
+    private var eventMonitor: Any?
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
@@ -357,10 +371,29 @@ private final class WelcomeInitialFocusResetView: NSView {
             window.makeFirstResponder(nil)
             self.didClearFocus = true
         }
+
+        guard eventMonitor == nil else { return }
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
+            guard let self, let window = self.window, event.window === window else { return event }
+            var hitView = window.contentView?.hitTest(event.locationInWindow)
+            var clickedInput = false
+            while let view = hitView {
+                if view is NSTextField {
+                    clickedInput = true
+                    break
+                }
+                hitView = view.superview
+            }
+            if !clickedInput {
+                window.makeFirstResponder(nil)
+            }
+            return event
+        }
     }
 
-    override func mouseDown(with event: NSEvent) {
-        window?.makeFirstResponder(nil)
-        super.mouseDown(with: event)
+    deinit {
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+        }
     }
 }

--- a/Sources/Lithe/Views/WorkbenchView.swift
+++ b/Sources/Lithe/Views/WorkbenchView.swift
@@ -1,4 +1,13 @@
+import AppKit
 import SwiftUI
+
+private enum ActivityBarMetrics {
+    static let width: CGFloat = 38
+    static let buttonWidth: CGFloat = 30
+    static let buttonHeight: CGFloat = 30
+    static let spacing: CGFloat = 4
+    static let edgeInset: CGFloat = 4
+}
 
 struct WorkbenchView: View {
     @EnvironmentObject private var model: AppModel
@@ -477,6 +486,7 @@ struct WorkbenchView: View {
                     .contentShape(Rectangle())
             }
             .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
             .lithePointer()
             .frame(width: 28, height: 28)
             .help("More actions")
@@ -484,30 +494,33 @@ struct WorkbenchView: View {
         .padding(.leading, 76)
         .padding(.trailing, 10)
         .frame(height: LitheTheme.Metrics.toolbarHeight)
-        .background(LitheTheme.titlebar)
+        .background {
+            LitheTheme.titlebar
+                .contentShape(Rectangle())
+                .onTapGesture(count: 2) {
+                    (NSApplication.shared.keyWindow?.delegate as? LitheWindowCoordinator)?
+                        .toggleWorkspaceZoom()
+                }
+        }
     }
 
     private var activityBar: some View {
         GeometryReader { geometry in
             VStack(spacing: 0) {
-                VStack(spacing: 6) {
+                VStack(spacing: ActivityBarMetrics.spacing) {
                     ForEach(SidebarDestination.allCases) { destination in
                         Button {
                             model.selectedSidebar = destination
                         } label: {
                             LitheIDEAIcon(
                                 resourcePath: destination.ideaAssetPath,
-                                size: 16,
+                                size: 18,
                                 fallbackSystemImage: destination.systemImage
                             )
-                                .frame(width: 40, height: 34)
-                                .overlay(alignment: .leading) {
-                                    if model.selectedSidebar == destination {
-                                        Rectangle()
-                                            .fill(LitheTheme.accent)
-                                            .frame(width: 2, height: 21)
-                                    }
-                                }
+                                .frame(
+                                    width: ActivityBarMetrics.buttonWidth,
+                                    height: ActivityBarMetrics.buttonHeight
+                                )
                                 .litheRowHover(
                                     isActive: model.selectedSidebar == destination,
                                     cornerRadius: 4,
@@ -520,10 +533,11 @@ struct WorkbenchView: View {
                         .help(LocalizedStringKey(destination.title))
                     }
                 }
+                .padding(.top, ActivityBarMetrics.edgeInset)
 
                 Spacer(minLength: 0)
 
-                VStack(spacing: 6) {
+                VStack(spacing: ActivityBarMetrics.spacing) {
                     activityToolButton(
                         systemImage: "terminal",
                         help: "Terminal",
@@ -580,12 +594,12 @@ struct WorkbenchView: View {
                         model.showSettings()
                     }
                 }
-                .padding(.bottom, 8)
+                .padding(.bottom, ActivityBarMetrics.edgeInset)
             }
-            .frame(width: 48, height: geometry.size.height, alignment: .top)
+            .frame(width: ActivityBarMetrics.width, height: geometry.size.height, alignment: .top)
             .background(LitheTheme.titlebar)
         }
-        .frame(width: 48)
+        .frame(width: ActivityBarMetrics.width)
     }
 
     private var runControls: some View {
@@ -677,27 +691,23 @@ struct WorkbenchView: View {
                 if let ideaAssetPath {
                     LitheIDEAIcon(
                         resourcePath: ideaAssetPath,
-                        size: 17,
+                        size: 18,
                         fallbackSystemImage: systemImage
                     )
                 } else {
                     Image(systemName: systemImage)
-                        .font(.system(size: 17, weight: .medium))
+                        .font(.system(size: 16, weight: .medium))
                 }
             }
-            .frame(width: 40, height: 34)
-                .overlay(alignment: .leading) {
-                    if isSelected {
-                        RoundedRectangle(cornerRadius: 1)
-                            .fill(LitheTheme.accent)
-                            .frame(width: 3, height: 22)
-                    }
-                }
-                .litheRowHover(
-                    isActive: isSelected,
-                    cornerRadius: 4,
-                    activeBackground: LitheTheme.subtleSelection
-                )
+            .frame(
+                width: ActivityBarMetrics.buttonWidth,
+                height: ActivityBarMetrics.buttonHeight
+            )
+            .litheRowHover(
+                isActive: isSelected,
+                cornerRadius: 4,
+                activeBackground: LitheTheme.subtleSelection
+            )
         }
         .buttonStyle(.plain)
         .lithePointer()

--- a/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -2741,6 +2741,56 @@ struct EditorDocumentTests {
         model.reorderDocuments(orderedPaths: urls.reversed().map(\.path))
         #expect(model.openDocuments.map(\.url.lastPathComponent) == ["C.swift", "B.swift", "A.swift"])
     }
+
+    @Test
+    @MainActor
+    func switchingToAnOpenDocumentWinsOverAPendingFileOpen() async {
+        let workspace = URL(fileURLWithPath: "/tmp/lithe-pending-open-tests")
+        let fileA = workspace.appendingPathComponent("A.swift")
+        let fileB = workspace.appendingPathComponent("B.swift")
+        let operations = BlockingWorkspaceOperations()
+        let model = DocumentFeatureModel(
+            operations: operations,
+            fileOperations: EmptyWorkspaceFileOperations(),
+            fileStorage: InMemoryFileStorage(),
+            binaryFileViewerRegistry: BinaryFileViewerRegistry()
+        )
+        model.configure(
+            workspaceURLProvider: { workspace },
+            autoSaveEnabledProvider: { false },
+            autoSaveDelayProvider: { 0 },
+            notify: { _ in },
+            onDocumentOpened: { _ in },
+            onDocumentChanged: { _ in },
+            onDocumentClosed: { _ in },
+            onRecordSave: { _, _ in },
+            onRecordDiscard: { _ in },
+            onRecordExternalChanges: { _ in },
+            onDocumentCollectionChanged: {},
+            onProjectCloseReady: {}
+        )
+
+        await model.openFileAsync(fileB, isReadOnly: false, displayPath: nil, activateWhenReady: true)
+        guard let documentB = model.openDocuments.first else {
+            Issue.record("B.swift did not open")
+            return
+        }
+        let pendingA = Task { @MainActor in
+            await model.openFileAsync(fileA, isReadOnly: false, displayPath: nil, activateWhenReady: true)
+        }
+
+        for _ in 0..<100 where !operations.didStartReadingA {
+            await Task.yield()
+        }
+        #expect(operations.didStartReadingA)
+
+        model.openFile(fileB)
+        #expect(model.activeDocumentID == documentB.id)
+
+        operations.releaseA()
+        await pendingA.value
+        #expect(model.activeDocumentID == documentB.id)
+    }
 }
 
 @MainActor
@@ -2973,6 +3023,61 @@ private struct EmptyWorkspaceOperations: WorkspaceOperations {
     ) -> [ProjectReplacementFile]? { nil }
 
     func readFile(at rootURL: URL, relativePath: String) -> String? { readFileValue }
+    func writeFile(_ text: String, at rootURL: URL, relativePath: String) -> Bool { false }
+}
+
+private final class BlockingWorkspaceOperations: WorkspaceOperations, @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseASemaphore = DispatchSemaphore(value: 0)
+    private var startedA = false
+
+    var didStartReadingA: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return startedA
+    }
+
+    func releaseA() {
+        releaseASemaphore.signal()
+    }
+
+    func snapshot(at rootURL: URL, visibilityRules: FileVisibilityRules) -> WorkspaceSnapshot? { nil }
+
+    func search(
+        at rootURL: URL,
+        query: String,
+        options: ProjectSearchOptions,
+        visibilityRules: FileVisibilityRules
+    ) -> [FileSearchResult]? { nil }
+
+    func searchEverywhere(
+        at rootURL: URL,
+        query: String,
+        options: ProjectSearchOptions,
+        visibilityRules: FileVisibilityRules
+    ) -> SearchEverywhereResults? { nil }
+
+    func previewReplacement(
+        at rootURL: URL,
+        query: String,
+        replacement: String,
+        options: ProjectSearchOptions,
+        paths: [String],
+        textOverrides: [String: String],
+        visibilityRules: FileVisibilityRules
+    ) -> [ProjectReplacementFile]? { nil }
+
+    func readFile(at rootURL: URL, relativePath: String) -> String? {
+        if relativePath == "A.swift" {
+            lock.lock()
+            startedA = true
+            lock.unlock()
+            releaseASemaphore.wait()
+            return "A"
+        }
+        return "B"
+    }
+
     func writeFile(_ text: String, at rootURL: URL, relativePath: String) -> Bool { false }
 }
 

--- a/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -37,6 +37,62 @@ struct LitheCoreLogicTests {
 
     @Test
     @MainActor
+    func welcomeAndWorkspaceUseDistinctWindowSizes() {
+        let sessions = TestProjectWindowSessions(hasActiveProject: false)
+        let coordinator = LitheWindowCoordinator(
+            projectSessions: sessions,
+            registerWindow: { _ in }
+        )
+        let window = NSWindow()
+
+        coordinator.attach(to: window, layout: .welcome)
+        #expect(window.contentMinSize == LitheWindowLayout.welcome.minimumContentSize)
+        #expect(window.contentLayoutRect.size == LitheWindowLayout.welcome.contentSize)
+
+        coordinator.attach(to: window, layout: .workspace)
+        #expect(window.contentMinSize == LitheWindowLayout.workspace.minimumContentSize)
+        #expect(window.contentLayoutRect.width <= LitheWindowLayout.workspace.contentSize.width)
+        #expect(window.contentLayoutRect.height <= LitheWindowLayout.workspace.contentSize.height)
+        #expect(window.contentLayoutRect.width >= LitheWindowLayout.workspace.minimumContentSize.width)
+        #expect(window.contentLayoutRect.height >= LitheWindowLayout.workspace.minimumContentSize.height)
+    }
+
+    @Test
+    func workspaceWindowFitsInsideTheVisibleScreen() {
+        let visibleFrame = NSRect(x: 0, y: 24, width: 1280, height: 776)
+        let oversizedFrame = NSRect(x: -80, y: -40, width: 1440, height: 900)
+
+        let fittedFrame = LitheWindowLayout.frame(oversizedFrame, fitting: visibleFrame)
+
+        #expect(fittedFrame.minX >= visibleFrame.minX)
+        #expect(fittedFrame.maxX <= visibleFrame.maxX)
+        #expect(fittedFrame.minY >= visibleFrame.minY)
+        #expect(fittedFrame.maxY <= visibleFrame.maxY)
+    }
+
+    @Test
+    @MainActor
+    func workspaceTitleBarZoomsToTheVisibleScreenAndRestores() {
+        let sessions = TestProjectWindowSessions(hasActiveProject: true)
+        let coordinator = LitheWindowCoordinator(
+            projectSessions: sessions,
+            registerWindow: { _ in }
+        )
+        let window = NSWindow()
+        coordinator.attach(to: window, layout: .workspace)
+        let restoredFrame = NSRect(x: 120, y: 70, width: 1000, height: 680)
+        let visibleFrame = NSRect(x: 0, y: 24, width: 1280, height: 776)
+        window.setFrame(restoredFrame, display: false)
+
+        coordinator.toggleWorkspaceZoom(fitting: visibleFrame)
+        #expect(window.frame == visibleFrame)
+
+        coordinator.toggleWorkspaceZoom(fitting: visibleFrame)
+        #expect(window.frame == restoredFrame)
+    }
+
+    @Test
+    @MainActor
     func dockReopenShowsTheHiddenWelcomeWindow() {
         let appDelegate = LitheAppDelegate()
         let window = NSWindow()


### PR DESCRIPTION

本 PR 优化了 macOS 版本的界面布局和交互体验：

- 优化欢迎页搜索框焦点行为
- 调整目录树字体、图标和行高
- 移除目录树文件点击时的按压反馈和动画
- 优化 Activity Bar 图标尺寸和内边距
- 修复编辑器标签页拖拽预览宽度异常
- 移除拖拽预览边框
- 隐藏顶部更多菜单的下拉箭头
- 优化已打开文件的切换响应速度
- 减少目录树重复计算
<img width="2198" height="1638" alt="11" src="https://github.com/user-attachments/assets/c743f34c-27a8-4fbb-b9f6-48f76c844fd3" />
<img width="1256" height="693" alt="22" src="https://github.com/user-attachments/assets/5239d553-fba8-4914-930b-cb7547b9c530" />
<img width="1280" height="717" alt="33" src="https://github.com/user-attachments/assets/9bd30a83-80ad-4fd8-8b81-b3866abad6ff" />
<img width="1756" height="778" alt="44" src="https://github.com/user-attachments/assets/364937a8-7484-463b-afcb-f3b70ef5cae0" />
<img width="1306" height="568" alt="55" src="https://github.com/user-attachments/assets/ec448bb1-2bf5-4b93-b5e9-1997927ca33b" />

验证结果：
122 tests in 6 suites passed
git diff --check 通过


