### PR TITLE
fix(settings): refresh locale when language changes

### DIFF
--- a/Sources/Lithe/Views/RootView.swift
+++ b/Sources/Lithe/Views/RootView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 struct RootView: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var projectSessions: ProjectSessionManager
-    @EnvironmentObject private var settings: AppSettings
     @EnvironmentObject private var updateChecker: UpdateChecker
     @State private var didStartAutomaticUpdateCheck = false
 
@@ -35,11 +34,6 @@ struct RootView: View {
                 initialCategory: model.requestedSettingsCategory
             )
                 .environmentObject(model)
-                // Sheets are presented in a separate SwiftUI hierarchy on
-                // macOS. Pass the selected app locale explicitly so Settings
-                // stays in sync with the workspace while it is open.
-                .environment(\.locale, settings.language.locale)
-                .id(settings.language)
         }
         .sheet(isPresented: $model.isCloneRepositoryPresented) {
             CloneRepositoryView()

--- a/Sources/Lithe/Views/SettingsView.swift
+++ b/Sources/Lithe/Views/SettingsView.swift
@@ -43,6 +43,10 @@ struct SettingsView: View {
         .onChange(of: settings.hiddenDirectoryNames) { _ in syncVisibilityDrafts() }
         .onChange(of: settings.hiddenFilePatterns) { _ in syncVisibilityDrafts() }
         .onChange(of: settings.commitMessageAI.activeProviderID) { _ in syncAIProviderDraft() }
+        // A sheet has its own SwiftUI presentation hierarchy on macOS. Own
+        // the locale here so every Settings presentation updates immediately.
+        .environment(\.locale, settings.language.locale)
+        .id(settings.language)
     }
 
     private var header: some View {

--- a/Tests/LitheTests/AppLocalizationTests.swift
+++ b/Tests/LitheTests/AppLocalizationTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import Lithe
+
+@Suite("App localization")
+@MainActor
+struct AppLocalizationTests {
+    @Test
+    func languageDefaultsToEnglishAndPersistsChanges() {
+        let store = LocalizationTestKeyValueStore()
+        let settings = AppSettings(store: store)
+
+        #expect(settings.language == .english)
+        #expect(settings.language.locale.identifier == "en")
+
+        settings.language = .simplifiedChinese
+        let reloadedSettings = AppSettings(store: store)
+
+        #expect(reloadedSettings.language == .simplifiedChinese)
+        #expect(reloadedSettings.language.locale.identifier == "zh-Hans")
+
+        reloadedSettings.restoreDefaults()
+        #expect(AppSettings(store: store).language == .english)
+    }
+
+    @Test
+    func simplifiedChineseResourcesCoverSettingsLanguageControls() throws {
+        let translations = try simplifiedChineseTranslations()
+
+        #expect(translations["Settings"] == "设置")
+        #expect(translations["General"] == "通用")
+        #expect(translations["Language"] == "语言")
+        #expect(translations["English"] == "英文")
+        #expect(
+            translations["The interface language changes immediately. English is the default."]
+                == "界面语言会立即生效。默认语言为英文。"
+        )
+    }
+
+    private func simplifiedChineseTranslations() throws -> [String: String] {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let resourceURL = repositoryRoot
+            .appendingPathComponent("Resources/zh-Hans.lproj/Localizable.strings")
+        let data = try Data(contentsOf: resourceURL)
+        let propertyList = try PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        )
+        return try #require(propertyList as? [String: String])
+    }
+}
+
+private final class LocalizationTestKeyValueStore: KeyValueStore, @unchecked Sendable {
+    private var values: [String: Any] = [:]
+
+    func object(forKey key: String) -> Any? { values[key] }
+    func string(forKey key: String) -> String? { values[key] as? String }
+    func stringArray(forKey key: String) -> [String]? { values[key] as? [String] }
+    func data(forKey key: String) -> Data? { values[key] as? Data }
+    func set(_ value: Any?, forKey key: String) { values[key] = value }
+}


### PR DESCRIPTION
## Summary
- make `SettingsView` own its selected locale and view identity so language changes refresh an open settings sheet
- remove presentation-specific locale wiring from `RootView`
- add regression coverage for language defaults, persistence, locale mapping, and critical Settings translations

Fixes #15

## Verification
- `./scripts/build-macos.sh --configuration debug --triple arm64-apple-macosx`
- localization files pass `plutil -lint` and critical Simplified Chinese keys resolve correctly
- `./scripts/test-macos.sh --filter AppLocalizationTests` could not run locally because the installed Command Line Tools do not include the Swift `Testing` module used by the existing test suite; GitHub Actions uses the repository's standard Xcode environment
- `./scripts/verify-service-boundaries.sh` currently reports pre-existing violations in `DatabaseRecoveryStore.swift` and `DatabaseSidecarService.swift`; none are in this change