### PR TITLE
fix: resolve Swift 6.2 pointer modifier isolation

### DIFF
--- a/Sources/Lithe/Theme/LitheTheme.swift
+++ b/Sources/Lithe/Theme/LitheTheme.swift
@@ -465,6 +465,7 @@ struct LitheSecondaryButtonStyle: ButtonStyle {
     }
 }
 
+@MainActor
 private struct LithePointerModifier: ViewModifier {
     @Environment(\.isEnabled) private var isEnabled
     @State private var cursor = LithePointerCursor()

--- a/Sources/Lithe/Theme/LitheTheme.swift
+++ b/Sources/Lithe/Theme/LitheTheme.swift
@@ -350,6 +350,7 @@ extension View {
 
     /// Shows the macOS pointing-hand cursor while an interactive control is
     /// hovered. The push/pop pair is balanced even when a view disappears.
+    @MainActor
     func lithePointer() -> some View {
         modifier(LithePointerModifier())
     }


### PR DESCRIPTION
Fix the macOS CI Swift 6.2 compilation error by isolating LithePointerModifier on MainActor. Local test-macos.sh passes all 271 tests.