### PR TITLE
fix: stop redundant Git refresh loops

### DIFF
--- a/Sources/Lithe/Application/GitFeatureModel.swift
+++ b/Sources/Lithe/Application/GitFeatureModel.swift
@@ -53,6 +53,10 @@ final class GitFeatureModel: ObservableObject {
 
     private let service: GitService
     private let shelveService: ShelveService?
+    private let snapshotProvider: @Sendable (URL) async -> GitSnapshot?
+    private let stashesProvider: @Sendable (URL) async -> [GitStash]
+    private let operationStateProvider: @Sendable (URL) async -> GitOperationState?
+    private let diffDocumentProvider: @Sendable (GitChange, GitDiffWhitespaceMode) async -> DiffDocument
     private var workspaceURLProvider: (@MainActor () -> URL?)?
     private var isGitLogVisibleProvider: (@MainActor () -> Bool)?
     private var notify: (@MainActor (String) -> Void)?
@@ -65,9 +69,22 @@ final class GitFeatureModel: ObservableObject {
     private var refreshRequestedWhileRunning = false
 
 
-    init(service: GitService, shelveService: ShelveService? = nil) {
+    init(
+        service: GitService,
+        shelveService: ShelveService? = nil,
+        snapshotProvider: (@Sendable (URL) async -> GitSnapshot?)? = nil,
+        stashesProvider: (@Sendable (URL) async -> [GitStash])? = nil,
+        operationStateProvider: (@Sendable (URL) async -> GitOperationState?)? = nil,
+        diffDocumentProvider: (@Sendable (GitChange, GitDiffWhitespaceMode) async -> DiffDocument)? = nil
+    ) {
         self.service = service
         self.shelveService = shelveService
+        self.snapshotProvider = snapshotProvider ?? { await service.snapshot(for: $0) }
+        self.stashesProvider = stashesProvider ?? { await service.stashes(at: $0) }
+        self.operationStateProvider = operationStateProvider ?? { await service.operationState(at: $0) }
+        self.diffDocumentProvider = diffDocumentProvider ?? {
+            await service.diffDocument(for: $0, whitespace: $1)
+        }
     }
 
     func configure(
@@ -161,16 +178,41 @@ final class GitFeatureModel: ObservableObject {
     }
 
     private func refreshGitState(at workspaceURL: URL) async {
-        if let snapshot = await service.snapshot(for: workspaceURL) {
-            gitRepositoryRoot = snapshot.repositoryRoot
-            currentBranch = snapshot.branch
-            gitChanges = snapshot.changes
-            if !gitConflictFilterPaths.isEmpty {
-                gitConflictFilterPaths.formIntersection(Set(snapshot.changes.map(\.path)))
+        var didChange = false
+        if let snapshot = await snapshotProvider(workspaceURL) {
+            let changesChanged = gitChanges != snapshot.changes
+            if gitRepositoryRoot != snapshot.repositoryRoot {
+                gitRepositoryRoot = snapshot.repositoryRoot
+                didChange = true
             }
-            gitStashes = await service.stashes(at: snapshot.repositoryRoot)
-            gitShelves = await shelveService?.entries(for: snapshot.repositoryRoot) ?? []
-            gitOperationState = await service.operationState(at: snapshot.repositoryRoot)
+            if currentBranch != snapshot.branch {
+                currentBranch = snapshot.branch
+                didChange = true
+            }
+            if changesChanged {
+                gitChanges = snapshot.changes
+                didChange = true
+            }
+            if !gitConflictFilterPaths.isEmpty {
+                let previousFilter = gitConflictFilterPaths
+                gitConflictFilterPaths.formIntersection(Set(snapshot.changes.map(\.path)))
+                didChange = didChange || previousFilter != gitConflictFilterPaths
+            }
+            let stashes = await stashesProvider(snapshot.repositoryRoot)
+            if gitStashes != stashes {
+                gitStashes = stashes
+                didChange = true
+            }
+            let shelves = await shelveService?.entries(for: snapshot.repositoryRoot) ?? []
+            if gitShelves != shelves {
+                gitShelves = shelves
+                didChange = true
+            }
+            let operationState = await operationStateProvider(snapshot.repositoryRoot)
+            if gitOperationState != operationState {
+                gitOperationState = operationState
+                didChange = true
+            }
             if let gitOperationState, deferredSavedChanges == nil,
                let stash = gitStashes.first(where: { $0.message.contains("Lithe auto-stash before") }) {
                 deferredSavedChanges = GitDeferredSavedChanges(
@@ -181,39 +223,45 @@ final class GitFeatureModel: ObservableObject {
 
             if let selectedChange,
                let updated = snapshot.changes.first(where: { $0.path == selectedChange.path }) {
-                self.selectedChange = updated
-                let document = await service.diffDocument(
-                    for: updated,
-                    whitespace: gitDiffWhitespaceMode
-                )
-                selectedDiffPatch = document.patch
-                diffRows = document.rows
-                diffHunks = document.hunks
+                if self.selectedChange != updated {
+                    self.selectedChange = updated
+                    didChange = true
+                }
+                let document = await diffDocumentProvider(updated, gitDiffWhitespaceMode)
+                if selectedDiffPatch != document.patch {
+                    selectedDiffPatch = document.patch
+                    diffRows = document.rows
+                    diffHunks = document.hunks
+                    didChange = true
+                }
             } else if selectedChange != nil {
                 self.selectedChange = nil
                 selectedDiffPatch = ""
                 diffRows = []
                 diffHunks = []
                 isLoadingDiff = false
+                didChange = true
             }
         } else {
-            gitRepositoryRoot = nil
-            currentBranch = "No Git"
-            gitChanges = []
-            gitStashes = []
-            gitShelves = []
-            gitOperationState = nil
-            selectedChange = nil
-            selectedDiffPatch = ""
-            diffRows = []
-            diffHunks = []
-            isLoadingDiff = false
+            if gitRepositoryRoot != nil { gitRepositoryRoot = nil; didChange = true }
+            if currentBranch != "No Git" { currentBranch = "No Git"; didChange = true }
+            if !gitChanges.isEmpty { gitChanges = []; didChange = true }
+            if !gitStashes.isEmpty { gitStashes = []; didChange = true }
+            if !gitShelves.isEmpty { gitShelves = []; didChange = true }
+            if gitOperationState != nil { gitOperationState = nil; didChange = true }
+            if selectedChange != nil { selectedChange = nil; didChange = true }
+            if !selectedDiffPatch.isEmpty { selectedDiffPatch = ""; didChange = true }
+            if !diffRows.isEmpty { diffRows = []; didChange = true }
+            if !diffHunks.isEmpty { diffHunks = []; didChange = true }
+            if isLoadingDiff { isLoadingDiff = false; didChange = true }
         }
 
-        if isGitLogVisibleProvider?() == true {
+        if didChange && isGitLogVisibleProvider?() == true {
             await refreshGitHistory()
         }
-        await onStateRefreshed?()
+        if didChange {
+            await onStateRefreshed?()
+        }
     }
 
     func selectChange(_ change: GitChange) async {

--- a/Sources/Lithe/Models/AppModel.swift
+++ b/Sources/Lithe/Models/AppModel.swift
@@ -217,10 +217,21 @@ final class AppModel: ObservableObject, Identifiable {
     private var gitFeatureObservation: AnyCancellable?
     private var documentFeatureObservation: AnyCancellable?
     private var javaFeatureObservation: AnyCancellable?
+    private var isObjectWillChangeRelayScheduled = false
     private var languageToolingObservation: AnyCancellable?
     private var languageTestObservation: AnyCancellable?
     private var recentProjectsStore: RecentProjectsStore { services.recentProjectsStore }
     private var workbenchLayoutStore: WorkbenchLayoutStore { services.workbenchLayoutStore }
+
+    private func scheduleObjectWillChangeRelay() {
+        guard !isObjectWillChangeRelayScheduled else { return }
+        isObjectWillChangeRelayScheduled = true
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.isObjectWillChangeRelayScheduled = false
+            self.objectWillChange.send()
+        }
+    }
 
     init(settings: AppSettings, services: AppServices) {
         self.settings = settings
@@ -289,25 +300,25 @@ final class AppModel: ObservableObject, Identifiable {
         )
         recentProjects = services.recentProjectsStore.load()
         databaseFeatureObservation = databaseFeature.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         workspaceFeatureObservation = workspaceFeature.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         runtimeFeatureObservation = runtimeFeature.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         searchFeatureObservation = searchFeature.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         terminalFeatureObservation = terminalFeature.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         languageToolingObservation = services.languageToolingSessions.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         languageTestObservation = services.languageTestService.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         projectHistoryFeature.configure(
             workspaceURLProvider: { [weak self] in self?.workspaceURL },
@@ -378,7 +389,7 @@ final class AppModel: ObservableObject, Identifiable {
             },
             onSnapshotLoaded: { [weak self] snapshot, isInitialLoad in
                 guard let self, let workspaceURL = self.workspaceURL else { return }
-                await self.refreshGit()
+                // WorkspaceFeatureModel requests the single Git refresh after this callback.
                 await self.loadProjectServices(at: workspaceURL, files: snapshot.files)
                 if isInitialLoad {
                     self.projectHistoryFeature.seed(files: snapshot.files)
@@ -394,7 +405,7 @@ final class AppModel: ObservableObject, Identifiable {
             notify: { [weak self] message in self?.showNotification(message) }
         )
         projectHistoryFeatureObservation = projectHistoryFeature.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         gitFeature.configure(
             workspaceURLProvider: { [weak self] in self?.workspaceURL },
@@ -413,7 +424,7 @@ final class AppModel: ObservableObject, Identifiable {
             }
         )
         gitFeatureObservation = gitFeature.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         documentFeature.configure(
             workspaceURLProvider: { [weak self] in self?.workspaceURL },
@@ -454,7 +465,7 @@ final class AppModel: ObservableObject, Identifiable {
             }
         )
         documentFeatureObservation = documentFeature.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         javaFeature.configure(
             documentProvider: { [weak self] in self?.activeDocument },
@@ -466,7 +477,7 @@ final class AppModel: ObservableObject, Identifiable {
             }
         )
         javaFeatureObservation = javaFeature.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
+            self?.scheduleObjectWillChangeRelay()
         }
         fileVisibilityRulesObserverID = settings.addFileVisibilityRulesObserver { [weak self] in
             guard let self else { return }

--- a/Sources/Lithe/Models/GitModels.swift
+++ b/Sources/Lithe/Models/GitModels.swift
@@ -533,7 +533,7 @@ enum GitPullStrategy: String, Sendable {
     case rebase
 }
 
-enum GitOperationKind: String, Sendable {
+enum GitOperationKind: String, Equatable, Sendable {
     case merge
     case rebase
     case cherryPick
@@ -574,7 +574,7 @@ enum GitOperationKind: String, Sendable {
 
 /// A merge, rebase, cherry-pick, or revert that Git left half-finished, usually
 /// because it hit conflicts. Absent when the repository is in its normal state.
-struct GitOperationState: Sendable {
+struct GitOperationState: Equatable, Sendable {
     let kind: GitOperationKind
     let reference: String?
     let step: Int?

--- a/Tests/LitheTests/GitStatusObservationTests.swift
+++ b/Tests/LitheTests/GitStatusObservationTests.swift
@@ -6,6 +6,45 @@ import Testing
 struct GitStatusObservationTests {
     @Test
     @MainActor
+    func identicalGitRefreshSkipsExpensiveDownstreamWork() async {
+        let repository = URL(fileURLWithPath: "/tmp/lithe-identical-git-refresh")
+        let snapshot = GitSnapshot(
+            repositoryRoot: repository,
+            branch: "main",
+            changes: [
+                GitChange(
+                    repositoryRoot: repository,
+                    path: "tracked.txt",
+                    originalPath: nil,
+                    indexStatus: " ",
+                    workTreeStatus: "M"
+                )
+            ]
+        )
+        let model = GitFeatureModel(
+            service: GitService(operations: RustGitOperations(core: RustCoreBridge())),
+            snapshotProvider: { _ in snapshot },
+            stashesProvider: { _ in [] },
+            operationStateProvider: { _ in nil },
+            diffDocumentProvider: { _, _ in DiffDocument(rows: [], hunks: []) }
+        )
+        var downstreamRefreshCount = 0
+        model.configure(
+            workspaceURLProvider: { repository },
+            isGitLogVisibleProvider: { false },
+            notify: { _ in },
+            onStateRefreshed: { downstreamRefreshCount += 1 }
+        )
+
+        await model.refreshGit()
+        #expect(downstreamRefreshCount == 1)
+
+        await model.refreshGit()
+        #expect(downstreamRefreshCount == 1)
+    }
+
+    @Test
+    @MainActor
     func visibleWorkspaceEditStillUsesTheWorkspacePipelineAndRefreshesGit() async throws {
         let fixture = try GitObservationFixture(label: "visible-edit")
         let repository = fixture.url.appendingPathComponent("repository", isDirectory: true)

--- a/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -2769,6 +2769,50 @@ struct EditorDocumentTests {
     }
 
     @Test
+    @MainActor
+    func workspaceInitialRebuildRequestsOneGitRefresh() async {
+        let operations = SequencedWorkspaceOperations(snapshotAvailability: [true])
+        let model = WorkspaceFeatureModel(
+            operations: operations,
+            fileOperations: EmptyWorkspaceFileOperations(),
+            fileStorage: InMemoryFileStorage(),
+            gitWatchContextProvider: SequencedGitWatchContextProvider([nil]),
+            directoryWatcherFactory: TestDirectoryWatcherFactory(),
+            workspaceSessionStore: WorkspaceSessionStore(store: EmptyKeyValueStore())
+        )
+        var snapshotLoadCount = 0
+        var gitRefreshCount = 0
+        model.configure(
+            documentsProvider: { [] },
+            activeDocumentProvider: { nil },
+            selectedSidebarProvider: { "project" },
+            setSelectedSidebar: { _ in },
+            restoreSession: { _, _ in },
+            openFile: { _ in },
+            notify: { _ in },
+            recordHistory: { _, _ in },
+            relocateHistory: { _, _ in },
+            relocateOpenDocuments: { _, _ in },
+            closeDocuments: { _ in },
+            processExternalChanges: { _ in false },
+            reloadProjectServices: {},
+            refreshGit: { gitRefreshCount += 1 },
+            updateHistoryVisibilityRules: { _ in },
+            onSnapshotLoaded: { _, _ in snapshotLoadCount += 1 }
+        )
+        let workspace = URL(fileURLWithPath: "/tmp/lithe-initial-refresh")
+        model.beginWorkspace(at: workspace, visibilityRules: .default)
+        let result = await model.rebuild(at: workspace, rules: .default, isCurrent: { true })
+
+        guard case .loaded = result else {
+            Issue.record("The initial workspace snapshot should load")
+            return
+        }
+        #expect(snapshotLoadCount == 1)
+        #expect(gitRefreshCount == 1)
+    }
+
+    @Test
     func workspaceFilesystemFallbackBuildsAVisibleTreeAndHonorsHiddenRules() throws {
         let fileManager = FileManager.default
         let workspace = fileManager.temporaryDirectory

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,0 +1,20 @@
+## Highlights
+
+- Fixed sustained CPU usage and interface stuttering after opening larger Git workspaces.
+- Prevented read-only Git status queries from updating the repository index and retriggering workspace file observation.
+- Reduced redundant Git refreshes and downstream interface updates when repository state has not changed.
+
+## Git and workspace performance
+
+- Run read-only Git queries with optional locks disabled, so status polling does not write to `.git/index`.
+- Consolidated Git operation-state discovery to avoid repeated subprocesses.
+- Refresh Git snapshots, stashes, shelves, operation state, history, and code vision only when their observable state changes.
+- Removed the duplicate Git refresh during initial workspace loading and coalesced feature-model update notifications.
+
+## Install or update
+
+- **GitHub Release:** Download the `arm64` DMG for Apple silicon or the `x86_64` DMG for Intel Macs from the release assets below.
+- **In-app update:** Open **Settings > Updates**, select **Check for Updates**, and install the available update.
+- **Homebrew:** Run `brew upgrade --cask lithe`. For a first installation, follow the Homebrew instructions in the project README.
+
+Lithe requires macOS 13 or later. Java project features require a JDK, and semantic Java navigation requires Eclipse JDT LS.

--- a/rust/lithe-core/src/git/mod.rs
+++ b/rust/lithe-core/src/git/mod.rs
@@ -215,6 +215,11 @@ pub fn command(request: GitCommandRequest) -> Result<GitCommandResponse, CoreErr
     execute_git(&root, &request.arguments, request.input)
 }
 
+fn readonly_command(request: GitCommandRequest) -> Result<GitCommandResponse, CoreError> {
+    let root = validate_root(&request.root)?;
+    execute_git_readonly(&root, &request.arguments, request.input)
+}
+
 pub fn write(request: GitWriteRequest) -> Result<GitCommandResponse, CoreError> {
     let root = validate_root(&request.root)?;
     let mut arguments: Vec<String>;
@@ -449,9 +454,29 @@ fn execute_git(
     arguments: &[String],
     input: Option<String>,
 ) -> Result<GitCommandResponse, CoreError> {
+    execute_git_with_options(root, arguments, input, false)
+}
+
+fn execute_git_readonly(
+    root: &str,
+    arguments: &[String],
+    input: Option<String>,
+) -> Result<GitCommandResponse, CoreError> {
+    execute_git_with_options(root, arguments, input, true)
+}
+
+fn execute_git_with_options(
+    root: &str,
+    arguments: &[String],
+    input: Option<String>,
+    disable_optional_locks: bool,
+) -> Result<GitCommandResponse, CoreError> {
     crate::protocol::cancellation::check()?;
     let mut process = Command::new("git");
     process.args(arguments).current_dir(root);
+    if disable_optional_locks {
+        process.env("GIT_OPTIONAL_LOCKS", "0");
+    }
     process.stdin(if input.is_some() {
         std::process::Stdio::piped()
     } else {
@@ -579,7 +604,7 @@ pub fn diff(request: GitDiffRequest) -> Result<GitDiffResponse, CoreError> {
     }
     arguments.extend(request.pathspecs);
 
-    let command_response = command(GitCommandRequest {
+    let command_response = readonly_command(GitCommandRequest {
         root: request.root,
         arguments,
         input: None,
@@ -651,7 +676,7 @@ pub fn apply(request: GitApplyRequest) -> Result<GitCommandResponse, CoreError> 
 pub fn history(request: GitHistoryRequest) -> Result<GitHistoryResponse, CoreError> {
     let limit = request.limit.clamp(1, 5_000);
     let root = validate_root(&request.root)?;
-    let reference_output = command(GitCommandRequest {
+    let reference_output = readonly_command(GitCommandRequest {
         root: root.clone(),
         arguments: vec![
             "for-each-ref".to_string(),
@@ -696,7 +721,7 @@ pub fn history(request: GitHistoryRequest) -> Result<GitHistoryResponse, CoreErr
         "--date=format:%Y/%m/%d %H:%M".to_string(),
         "--pretty=format:%H%x1f%h%x1f%P%x1f%an%x1f%ae%x1f%ad%x1f%s%x1f%D".to_string(),
     ]);
-    let commit_output = command(GitCommandRequest {
+    let commit_output = readonly_command(GitCommandRequest {
         root,
         arguments,
         input: None,
@@ -724,7 +749,7 @@ pub fn history(request: GitHistoryRequest) -> Result<GitHistoryResponse, CoreErr
 pub fn commit(request: GitCommitRequest) -> Result<GitCommitLookupResponse, CoreError> {
     let root = validate_root(&request.root)?;
     validate_revision(&request.commit)?;
-    let response = command(GitCommandRequest {
+    let response = readonly_command(GitCommandRequest {
         root,
         arguments: vec![
             "show".to_string(),
@@ -752,7 +777,7 @@ pub fn commit(request: GitCommitRequest) -> Result<GitCommitLookupResponse, Core
 pub fn commit_files(request: GitCommitFilesRequest) -> Result<GitFilesResponse, CoreError> {
     let root = validate_root(&request.root)?;
     validate_revision(&request.commit)?;
-    let response = command(GitCommandRequest {
+    let response = readonly_command(GitCommandRequest {
         root,
         arguments: vec![
             "-c".to_string(),
@@ -779,7 +804,7 @@ pub fn commit_files(request: GitCommitFilesRequest) -> Result<GitFilesResponse, 
 pub fn comparison(request: GitComparisonRequest) -> Result<GitComparisonResponse, CoreError> {
     let root = validate_root(&request.root)?;
     validate_revision(&request.reference)?;
-    let response = command(GitCommandRequest {
+    let response = readonly_command(GitCommandRequest {
         root,
         arguments: vec![
             "-c".to_string(),
@@ -814,7 +839,7 @@ pub fn checkout_preflight(
     let root = validate_root(&request.root)?;
     let reference = validated_reference(Some(&request.reference))?;
 
-    let dirty = command(GitCommandRequest {
+    let dirty = readonly_command(GitCommandRequest {
         root: root.clone(),
         arguments: vec![
             "diff".to_string(),
@@ -837,7 +862,7 @@ pub fn checkout_preflight(
 
     // Untracked files block a checkout too, whenever the target branch tracks the same
     // path: git refuses rather than overwrite them. These never appear in `diff HEAD`.
-    let untracked = command(GitCommandRequest {
+    let untracked = readonly_command(GitCommandRequest {
         root: root.clone(),
         arguments: vec![
             "ls-files".to_string(),
@@ -867,7 +892,7 @@ pub fn checkout_preflight(
 
     let mut blocking_paths = Vec::new();
     if !untracked_paths.is_empty() {
-        let tracked_on_target = command(GitCommandRequest {
+        let tracked_on_target = readonly_command(GitCommandRequest {
             root: root.clone(),
             arguments: vec![
                 "ls-tree".to_string(),
@@ -899,7 +924,7 @@ pub fn checkout_preflight(
         return Ok(GitCheckoutPreflightResponse { blocking_paths });
     }
 
-    let divergent = command(GitCommandRequest {
+    let divergent = readonly_command(GitCommandRequest {
         root,
         arguments: vec![
             "diff".to_string(),
@@ -938,7 +963,7 @@ pub fn conflict_marker_paths(
 ) -> Result<GitConflictMarkerResponse, CoreError> {
     let root = validate_root(&request.root)?;
 
-    let found = command(GitCommandRequest {
+    let found = readonly_command(GitCommandRequest {
         root,
         arguments: vec![
             "grep".to_string(),
@@ -1005,7 +1030,7 @@ pub fn integration_preflight(
     };
 
     // Tracked files differing from HEAD, staged or not: `diff HEAD` covers both.
-    let dirty = command(GitCommandRequest {
+    let dirty = readonly_command(GitCommandRequest {
         root: root.clone(),
         arguments: vec![
             "diff".to_string(),
@@ -1051,7 +1076,7 @@ pub fn integration_preflight(
     // are the files that commit changed against its own parent.
     let written = match shape {
         IntegrationShape::MergeBase => {
-            let base = command(GitCommandRequest {
+            let base = readonly_command(GitCommandRequest {
                 root: root.clone(),
                 arguments: vec![
                     "merge-base".to_string(),
@@ -1066,7 +1091,7 @@ pub fn integration_preflight(
                         .with_details(base.output),
                 );
             }
-            command(GitCommandRequest {
+            readonly_command(GitCommandRequest {
                 root,
                 arguments: vec![
                     "diff".to_string(),
@@ -1079,7 +1104,7 @@ pub fn integration_preflight(
         }
         // `diff-tree` against the commit itself; the extra flags make a merge commit
         // and the root commit behave rather than print nothing.
-        IntegrationShape::SingleCommit => command(GitCommandRequest {
+        IntegrationShape::SingleCommit => readonly_command(GitCommandRequest {
             root,
             arguments: vec![
                 "diff-tree".to_string(),
@@ -1128,7 +1153,7 @@ pub fn pull_preflight(
 ) -> Result<GitPullPreflightResponse, CoreError> {
     let root = validate_root(&request.root)?;
 
-    let upstream = command(GitCommandRequest {
+    let upstream = readonly_command(GitCommandRequest {
         root: root.clone(),
         arguments: vec![
             "rev-parse".to_string(),
@@ -1150,7 +1175,7 @@ pub fn pull_preflight(
     }
     let upstream = upstream.output.trim().to_string();
 
-    let counts = command(GitCommandRequest {
+    let counts = readonly_command(GitCommandRequest {
         root: root.clone(),
         arguments: vec![
             "rev-list".to_string(),
@@ -1171,7 +1196,7 @@ pub fn pull_preflight(
     let behind = fields.next().and_then(|v| v.parse().ok()).unwrap_or(0);
     let ahead = fields.next().and_then(|v| v.parse().ok()).unwrap_or(0);
 
-    let dirty = command(GitCommandRequest {
+    let dirty = readonly_command(GitCommandRequest {
         root,
         arguments: vec![
             "status".to_string(),
@@ -1196,18 +1221,14 @@ pub fn pull_preflight(
     })
 }
 
-/// Resolves a path inside the Git directory, honoring worktrees and submodules
-/// where `.git` is a file pointing elsewhere rather than a directory.
-fn git_path(root: &str, name: &str) -> Result<Option<std::path::PathBuf>, CoreError> {
-    let response = command(GitCommandRequest {
-        root: root.to_string(),
-        arguments: vec![
-            "rev-parse".to_string(),
-            "--git-path".to_string(),
-            name.to_string(),
-        ],
-        input: None,
-    })?;
+/// Resolves the Git directory once, honoring worktrees and submodules where
+/// `.git` is a file pointing elsewhere rather than a directory.
+fn git_directory(root: &str) -> Result<Option<PathBuf>, CoreError> {
+    let response = execute_git_readonly(
+        root,
+        &["rev-parse".to_string(), "--absolute-git-dir".to_string()],
+        None,
+    )?;
     if response.exit_code != 0 {
         return Err(
             CoreError::new(ErrorCode::ProcessFailed, "Git rev-parse failed")
@@ -1218,9 +1239,7 @@ fn git_path(root: &str, name: &str) -> Result<Option<std::path::PathBuf>, CoreEr
     if raw.is_empty() {
         return Ok(None);
     }
-    // `--git-path` yields a path relative to the working directory, not the git dir.
-    let path = std::path::Path::new(root).join(raw);
-    Ok(path.exists().then_some(path))
+    Ok(Some(PathBuf::from(raw)))
 }
 
 /// Reads a single-line numeric counter written by an in-progress rebase.
@@ -1249,27 +1268,34 @@ pub fn operation_state(
 
     // Order matters: a conflicted rebase can carry a REVERT_HEAD from the commit
     // it is replaying, so the more specific rebase directories are checked first.
-    if let Some(directory) = git_path(&root, "rebase-merge")?.or(git_path(&root, "rebase-apply")?) {
-        kind = "rebase".to_string();
-        step = rebase_counter(&directory, "msgnum");
-        total = rebase_counter(&directory, "end");
-        reference = std::fs::read_to_string(directory.join("onto"))
-            .ok()
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty());
-    } else if git_path(&root, "MERGE_HEAD")?.is_some() {
-        kind = "merge".to_string();
-    } else if git_path(&root, "CHERRY_PICK_HEAD")?.is_some() {
-        kind = "cherryPick".to_string();
-    } else if git_path(&root, "REVERT_HEAD")?.is_some() {
-        kind = "revert".to_string();
+    if let Some(git_directory) = git_directory(&root)? {
+        let rebase_merge = git_directory.join("rebase-merge");
+        let rebase_apply = git_directory.join("rebase-apply");
+        let operation_directory = [rebase_merge, rebase_apply]
+            .into_iter()
+            .find(|path| path.exists());
+        if let Some(directory) = operation_directory {
+            kind = "rebase".to_string();
+            step = rebase_counter(&directory, "msgnum");
+            total = rebase_counter(&directory, "end");
+            reference = std::fs::read_to_string(directory.join("onto"))
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty());
+        } else if git_directory.join("MERGE_HEAD").exists() {
+            kind = "merge".to_string();
+        } else if git_directory.join("CHERRY_PICK_HEAD").exists() {
+            kind = "cherryPick".to_string();
+        } else if git_directory.join("REVERT_HEAD").exists() {
+            kind = "revert".to_string();
+        }
     }
 
-    let status = command(GitCommandRequest {
-        root,
-        arguments: vec!["status".to_string(), "--porcelain".to_string()],
-        input: None,
-    })?;
+    let status = execute_git_readonly(
+        &root,
+        &["status".to_string(), "--porcelain".to_string()],
+        None,
+    )?;
     if status.exit_code != 0 {
         return Err(
             CoreError::new(ErrorCode::ProcessFailed, "Git status failed")
@@ -1369,7 +1395,7 @@ fn is_conflicted_status(code: &str) -> bool {
 
 pub fn stashes(request: GitStashesRequest) -> Result<GitStashesResponse, CoreError> {
     let root = validate_root(&request.root)?;
-    let response = command(GitCommandRequest {
+    let response = readonly_command(GitCommandRequest {
         root,
         arguments: vec![
             "stash".to_string(),
@@ -1397,7 +1423,7 @@ pub fn blame(request: GitBlameRequest) -> Result<GitBlameResponse, CoreError> {
             "Git blame contains an invalid path",
         ));
     }
-    let response = command(GitCommandRequest {
+    let response = readonly_command(GitCommandRequest {
         root: request.root,
         arguments: vec![
             "blame".to_string(),
@@ -2443,7 +2469,12 @@ pub fn status(request: GitStatusRequest) -> Result<GitStatusResponse, CoreError>
 }
 
 fn run_git(directory: &Path, arguments: &[&str]) -> Result<std::process::Output, CoreError> {
+    // Status and path discovery are read-only from Lithe's point of view. Git
+    // may otherwise refresh its optional index data while answering a query,
+    // which emits `.git/index` events into the native watcher and can trigger
+    // another status refresh.
     Command::new("git")
+        .env("GIT_OPTIONAL_LOCKS", "0")
         .args(arguments)
         .current_dir(directory)
         .output()

--- a/rust/lithe-core/src/tests/git.rs
+++ b/rust/lithe-core/src/tests/git.rs
@@ -1,8 +1,9 @@
 use super::support::temporary_root;
 use crate::execute_json;
 use serde_json::Value;
-use std::fs;
+use std::fs::{self, FileTimes, OpenOptions};
 use std::process::Command;
+use std::time::{Duration, UNIX_EPOCH};
 
 #[test]
 fn git_status_returns_contract_shape() {
@@ -32,6 +33,82 @@ fn git_status_returns_contract_shape() {
     assert_eq!(response["data"]["repositoryRoot"], ".");
     assert_eq!(response["data"]["changes"][0]["path"], "new.txt");
     assert_eq!(response["data"]["changes"][0]["untracked"], true);
+
+    fs::remove_dir_all(root).expect("temporary repository should be removable");
+}
+
+#[test]
+fn git_status_does_not_refresh_the_index() {
+    let root = temporary_root("git-status-index");
+    fs::create_dir_all(&root).expect("temporary repository should be creatable");
+    let run = |arguments: &[&str]| {
+        Command::new("git")
+            .env_remove("GIT_OPTIONAL_LOCKS")
+            .args(arguments)
+            .current_dir(&root)
+            .output()
+            .expect("git should be available")
+    };
+    assert!(run(&["init", "-q"]).status.success());
+    assert!(run(&["config", "core.autocrlf", "false"]).status.success());
+    assert!(run(&["config", "core.trustctime", "true"]).status.success());
+    assert!(run(&["config", "user.email", "test@example.com"])
+        .status
+        .success());
+    assert!(run(&["config", "user.name", "Lithe Test"]).status.success());
+    let tracked = root.join("tracked.txt");
+    fs::write(&tracked, "tracked\n").expect("test file should be writable");
+    assert!(run(&["add", "tracked.txt"]).status.success());
+    assert!(run(&["commit", "-qm", "initial"]).status.success());
+
+    let index = root.join(".git/index");
+    let make_cached_stat_stale = |seconds| {
+        let file = OpenOptions::new()
+            .write(true)
+            .open(&tracked)
+            .expect("tracked file should be writable");
+        file.set_times(FileTimes::new().set_modified(UNIX_EPOCH + Duration::from_secs(seconds)))
+            .expect("tracked file timestamp should be mutable");
+    };
+
+    // Keep a control path so this test fails closed if the fixture does not make
+    // Git consider the cached stat stale on the host running it.
+    make_cached_stat_stale(946_684_800);
+    let control_before = fs::metadata(&index)
+        .and_then(|metadata| metadata.modified())
+        .expect("index timestamp should be readable");
+    assert!(run(&["status", "--porcelain"]).status.success());
+    let control_after = fs::metadata(&index)
+        .and_then(|metadata| metadata.modified())
+        .expect("index timestamp should be readable");
+    assert_ne!(
+        control_before, control_after,
+        "the fixture should require an index refresh"
+    );
+
+    make_cached_stat_stale(978_307_200);
+    let before = fs::metadata(&index)
+        .and_then(|metadata| metadata.modified())
+        .expect("index timestamp should be readable");
+    let request = serde_json::json!({
+        "id": "git-status-readonly",
+        "command": "git.status",
+        "payload": {"root": root}
+    });
+    let response: Value = serde_json::from_str(&execute_json(
+        &serde_json::to_string(&request).expect("Git request should encode"),
+    ))
+    .expect("Git response should be JSON");
+    let after = fs::metadata(&index)
+        .and_then(|metadata| metadata.modified())
+        .expect("index timestamp should be readable");
+
+    assert_eq!(response["ok"], true, "{response:?}");
+    assert_eq!(response["data"]["changes"], serde_json::json!([]));
+    assert_eq!(
+        before, after,
+        "a read-only status query must not rewrite the index"
+    );
 
     fs::remove_dir_all(root).expect("temporary repository should be removable");
 }


### PR DESCRIPTION
## Summary

- prevent read-only Git queries from updating `.git/index` and retriggering workspace observation
- publish Git and aggregate model state only when observable data changes
- remove the duplicate Git refresh during initial workspace loading
- add regression coverage and v0.2.1 release notes

## Validation

- `./scripts/test-macos.sh` (274 tests, 20 suites)
- `./scripts/verify-rust-core.sh` (156 Rust Core tests plus Swift bridge/link verification)
- `cargo test -p lithe-core --test git_watch_context`
- `./scripts/verify-service-boundaries.sh`
- `cargo fmt --manifest-path rust/lithe-core/Cargo.toml --check`
- `git diff --check`
- packaged release arm64 app and manually opened the full Lithe repository
- observed no repeated Git subprocesses, unchanged `.git/index`, and 0% idle CPU for 45 seconds after refresh

## Release

This is the macOS v0.2.1 performance patch.