### PR TITLE
ci: parallelize macOS validation and releases

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -15,14 +15,96 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Test and build macOS application
-    runs-on: macos-14
-    timeout-minutes: 45
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.classify.outputs.full }}
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        shell: bash
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base_sha="$PUSH_BASE_SHA"
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base_sha="$PR_BASE_SHA"
+          fi
+
+          full=false
+          while IFS= read -r path; do
+            case "$path" in
+              README.md|README.zh-CN.md|docs/*|Casks/*)
+                ;;
+              *)
+                full=true
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "$base_sha" "$GITHUB_SHA")
+
+          echo "full=$full" >> "$GITHUB_OUTPUT"
+
+      - name: Validate lightweight changes
+        if: steps.classify.outputs.full == 'false'
+        shell: bash
+        run: |
+          git diff --check "${{ github.event.pull_request.base.sha || github.event.before }}" "$GITHUB_SHA"
+          ruby -c Casks/lithe.rb
+          ruby -c scripts/update-homebrew-cask.rb
+
+  swift-tests:
+    name: Swift tests
+    needs: changes
+    if: needs.changes.outputs.full == 'true'
+    runs-on: macos-14
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
+      - name: Restore SwiftPM dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            ~/.cache/org.swift.swiftpm
+          key: swiftpm-${{ runner.os }}-6.2-${{ hashFiles('Package.resolved') }}
+
+      - name: Run Swift tests
+        run: ./scripts/test-macos.sh
+
+  rust-tests:
+    name: Rust Core and database tests
+    needs: changes
+    if: needs.changes.outputs.full == 'true'
+    runs-on: macos-14
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
 
       - name: Set up Swift
         uses: swift-actions/setup-swift@v2
@@ -33,7 +115,61 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+
+      - name: Restore Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: cargo-dependencies-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
+
+      - name: Run Rust Core tests and verify the Swift bridge
+        run: ./scripts/verify-rust-core.sh
+
+      - name: Test database helpers
+        run: |
+          cargo fmt --manifest-path rust/Cargo.toml --all -- --check
+          cargo test --manifest-path rust/Cargo.toml -p lithe-db-sidecar
+          cargo test --manifest-path rust/Cargo.toml -p lithe-db-mcp
+
+  release-build:
+    name: Release configuration
+    needs: changes
+    if: needs.changes.outputs.full == 'true'
+    runs-on: macos-14
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Restore SwiftPM dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            ~/.cache/org.swift.swiftpm
+          key: swiftpm-${{ runner.os }}-6.2-${{ hashFiles('Package.resolved') }}
+
+      - name: Restore Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: cargo-dependencies-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
 
       - name: Resolve host architecture
         shell: zsh {0}
@@ -56,17 +192,29 @@ jobs:
           ruby -c scripts/update-homebrew-cask.rb
           plutil -lint Resources/Info.plist
 
-      - name: Run Swift tests
-        run: ./scripts/test-macos.sh
-
-      - name: Run Rust Core tests and verify the Swift bridge
-        run: ./scripts/verify-rust-core.sh
-
-      - name: Test database helpers
-        run: |
-          cargo fmt --manifest-path rust/Cargo.toml --all -- --check
-          cargo test --manifest-path rust/Cargo.toml -p lithe-db-sidecar
-          cargo test --manifest-path rust/Cargo.toml -p lithe-db-mcp
-
       - name: Build release configuration
         run: ./scripts/build-macos.sh --configuration release --triple "$LITHE_SWIFT_TRIPLE"
+
+  gate:
+    name: macOS CI gate
+    needs:
+      - changes
+      - swift-tests
+      - rust-tests
+      - release-build
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify required jobs
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          SWIFT_RESULT: ${{ needs.swift-tests.result }}
+          RUST_RESULT: ${{ needs.rust-tests.result }}
+          RELEASE_RESULT: ${{ needs.release-build.result }}
+        shell: bash
+        run: |
+          [[ "$CHANGES_RESULT" == "success" ]]
+          for result in "$SWIFT_RESULT" "$RUST_RESULT" "$RELEASE_RESULT"; do
+            [[ "$result" == "success" || "$result" == "skipped" ]]
+          done

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -14,34 +14,21 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-macos-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
-    name: Build and publish Lithe for macOS
+  prepare:
+    name: Resolve release version
     if: github.actor == github.repository_owner
-    runs-on: macos-14
-    permissions:
-      contents: write
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
+      build_number: ${{ steps.version.outputs.build_number }}
 
     steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Set up Swift
-        # v2 downloads the macOS toolchain package directly. The beta v3
-        # Swiftly installer is currently unstable on the macos-14 runner.
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.2"
-
-      - name: Set up Rust targets
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-          rustup target add aarch64-apple-darwin x86_64-apple-darwin
-
       - name: Resolve release version
         id: version
         env:
@@ -60,50 +47,133 @@ jobs:
             exit 1
           fi
 
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
-          echo "build_number=$GITHUB_RUN_NUMBER" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$version"
+            echo "tag=v$version"
+            echo "build_number=$GITHUB_RUN_NUMBER"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Build the App bundle
+  build:
+    name: Build ${{ matrix.architecture }} release
+    needs: prepare
+    runs-on: macos-14
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - arm64
+          - x86_64
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
+      - name: Set up Rust target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.architecture == 'arm64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }}
+
+      - name: Restore SwiftPM dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            .build/checkouts
+            .build/repositories
+            ~/.cache/org.swift.swiftpm
+          key: swiftpm-${{ runner.os }}-6.2-${{ hashFiles('Package.resolved') }}
+
+      - name: Restore Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: cargo-dependencies-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
+
+      - name: Build and package the App
         env:
-          LITHE_VERSION: ${{ steps.version.outputs.version }}
-          LITHE_BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
+          LITHE_ARCH: ${{ matrix.architecture }}
+          LITHE_VERSION: ${{ needs.prepare.outputs.version }}
+          LITHE_BUILD_NUMBER: ${{ needs.prepare.outputs.build_number }}
         run: |
-          chmod +x scripts/package-app.sh
-          chmod +x scripts/create-dmg.sh
-          for architecture in arm64 x86_64; do
-            LITHE_ARCH="$architecture" ./scripts/package-app.sh
-            LITHE_ARCH="$architecture" ./scripts/create-dmg.sh
-            # 在 dist/ 内部计算，让校验文件只记录裸文件名，
-            # 这样下载后直接 shasum -c 就能通过。
-            dmg_name="Lithe-${LITHE_VERSION}-${architecture}.dmg"
-            (cd dist && shasum -a 256 "$dmg_name" > "$dmg_name.sha256")
-          done
+          ./scripts/package-app.sh
+          ./scripts/create-dmg.sh
+          dmg_name="Lithe-${LITHE_VERSION}-${LITHE_ARCH}.dmg"
+          (cd dist && shasum -a 256 "$dmg_name" > "$dmg_name.sha256")
 
       - name: Verify the bundle and disk image
         env:
-          LITHE_VERSION: ${{ steps.version.outputs.version }}
+          LITHE_ARCH: ${{ matrix.architecture }}
+          LITHE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          app_path="dist/Lithe-${LITHE_ARCH}.app"
+          dmg_path="dist/Lithe-${LITHE_VERSION}-${LITHE_ARCH}.dmg"
+          codesign --verify --deep --strict "$app_path"
+          /usr/libexec/PlistBuddy \
+            -c "Print :CFBundleShortVersionString" \
+            "$app_path/Contents/Info.plist"
+          /usr/libexec/PlistBuddy \
+            -c "Print :CFBundleVersion" \
+            "$app_path/Contents/Info.plist"
+          lipo "$app_path/Contents/MacOS/Lithe" -verify_arch "$LITHE_ARCH"
+          hdiutil imageinfo "$dmg_path" > /dev/null
+          test -s "$dmg_path"
+          (cd dist && shasum -a 256 -c "Lithe-${LITHE_VERSION}-${LITHE_ARCH}.dmg.sha256")
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-release-${{ matrix.architecture }}
+          path: |
+            dist/Lithe-${{ needs.prepare.outputs.version }}-${{ matrix.architecture }}.dmg
+            dist/Lithe-${{ needs.prepare.outputs.version }}-${{ matrix.architecture }}.dmg.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish macOS release
+    needs:
+      - prepare
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ needs.prepare.outputs.version }}
+      tag: ${{ needs.prepare.outputs.tag }}
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+
+      - name: Download release assets
+        uses: actions/download-artifact@v8
+        with:
+          pattern: macos-release-*
+          path: dist
+          merge-multiple: true
+
+      - name: Verify downloaded assets
+        env:
+          LITHE_VERSION: ${{ needs.prepare.outputs.version }}
+        shell: bash
         run: |
           for architecture in arm64 x86_64; do
-            app_path="dist/Lithe-${architecture}.app"
-            dmg_path="dist/Lithe-${LITHE_VERSION}-${architecture}.dmg"
-            codesign --verify --deep --strict "$app_path"
-            /usr/libexec/PlistBuddy \
-              -c "Print :CFBundleShortVersionString" \
-              "$app_path/Contents/Info.plist"
-            /usr/libexec/PlistBuddy \
-              -c "Print :CFBundleVersion" \
-              "$app_path/Contents/Info.plist"
-            lipo "$app_path/Contents/MacOS/Lithe" -verify_arch "$architecture"
-            hdiutil imageinfo "$dmg_path" > /dev/null
-            test -s "$dmg_path"
+            (cd dist && shasum -a 256 -c "Lithe-${LITHE_VERSION}-${architecture}.dmg.sha256")
           done
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-          LITHE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          LITHE_VERSION: ${{ needs.prepare.outputs.version }}
+        shell: bash
         run: |
           notes_file="docs/releases/v${LITHE_VERSION}.md"
           release_args=(
@@ -127,7 +197,7 @@ jobs:
 
   update-cask:
     name: Update Homebrew Cask
-    needs: release
+    needs: publish
     runs-on: macos-14
     permissions:
       contents: write
@@ -135,15 +205,15 @@ jobs:
 
     steps:
       - name: Check out the default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
 
       - name: Download release checksums
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.release.outputs.tag }}
-          LITHE_VERSION: ${{ needs.release.outputs.version }}
+          RELEASE_TAG: ${{ needs.publish.outputs.tag }}
+          LITHE_VERSION: ${{ needs.publish.outputs.version }}
         run: |
           checksum_dir="$RUNNER_TEMP/lithe-release"
           mkdir -p "$checksum_dir"
@@ -155,7 +225,7 @@ jobs:
 
       - name: Update the Cask metadata
         env:
-          LITHE_VERSION: ${{ needs.release.outputs.version }}
+          LITHE_VERSION: ${{ needs.publish.outputs.version }}
         run: |
           arm_sha=$(awk 'NR == 1 { print $1 }' "$CHECKSUM_DIR/Lithe-${LITHE_VERSION}-arm64.dmg.sha256")
           intel_sha=$(awk 'NR == 1 { print $1 }' "$CHECKSUM_DIR/Lithe-${LITHE_VERSION}-x86_64.dmg.sha256")
@@ -176,7 +246,7 @@ jobs:
       - name: Create or update the Cask pull request
         env:
           GH_TOKEN: ${{ github.token }}
-          LITHE_VERSION: ${{ needs.release.outputs.version }}
+          LITHE_VERSION: ${{ needs.publish.outputs.version }}
         run: |
           branch="automation/homebrew-cask-v${LITHE_VERSION}"
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

- classify documentation and Cask-only changes so they use a lightweight validation path
- split macOS validation into parallel Swift tests, Rust/database tests, and release-build jobs
- add a stable aggregate macOS CI gate for branch protection
- cache SwiftPM and Cargo dependency downloads without caching multi-gigabyte build outputs
- build arm64 and x86_64 release assets in parallel, then publish them from one job

## Expected impact

- code PR wall time: approximately 6-8 minutes instead of 12-16 minutes
- documentation/Cask PR wall time: under 1 minute
- macOS release wall time: approximately half of the previous serial dual-architecture build

## Validation

- `actionlint .github/workflows/ci-macos.yml .github/workflows/release-macos.yml`
- Ruby YAML parsing for both workflows
- `git diff --check`
- Zsh syntax validation for packaging/build scripts
- Ruby syntax checks for the Cask and updater
- `plutil -lint Resources/Info.plist`