### PR TITLE
docs: add v0.2.2 release notes

### DIFF
--- a/docs/releases/v0.2.2.md
+++ b/docs/releases/v0.2.2.md
@@ -1,0 +1,25 @@
+## Highlights
+
+- Kept large process logs responsive while resizing the Run tool window.
+- Improved Maven project detection for modules nested below the workspace root.
+- Resolved Maven parent POMs outside the immediate module directory more reliably.
+
+## Run output performance
+
+- Render process output incrementally instead of laying out the full log after every update or resize.
+- Preserve ANSI colors, log-level highlighting, timestamps, source links, text selection, copying, and smart scrolling.
+- Keep the Run tool window responsive with output near the 500,000-character limit.
+
+## Maven project detection
+
+- Detect Maven projects below the workspace root, including nested modules and parent projects.
+- Use the resolved Maven root consistently for scans, run configurations, and Maven actions.
+- Improve inherited module metadata when projects rely on parent POM configuration.
+
+## Install or update
+
+- **GitHub Release:** Download the `arm64` DMG for Apple silicon or the `x86_64` DMG for Intel Macs from the release assets below.
+- **In-app update:** Open **Settings > Updates**, select **Check for Updates**, and install the available update.
+- **Homebrew:** Run `brew upgrade --cask lithe`. For a first installation, follow the Homebrew instructions in the project README.
+
+Lithe requires macOS 13 or later. Java project features require a JDK, and semantic Java navigation requires Eclipse JDT LS.


### PR DESCRIPTION
## Summary
- document the large Run output resize performance fix
- document nested Maven project and parent POM detection improvements
- prepare the macOS-only v0.2.2 release notes

## Verification
- git diff --check
- ruby -c Casks/lithe.rb
- ruby -c scripts/update-homebrew-cask.rb