### PR TITLE
fix(git): add checkbox staging with optimistic updates

### DIFF
--- a/Sources/Lithe/Models/AppModel/AppModel+FeatureState.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel+FeatureState.swift
@@ -46,6 +46,9 @@ extension AppModel {
     var isPendingProjectClose: Bool { documentFeature.isPendingProjectClose }
 
     var gitChanges: [GitChange] { gitFeatureIfActive?.gitChanges ?? [] }
+    func effectiveStagingState(for change: GitChange) -> Bool {
+        gitFeatureIfActive?.effectiveStagingState(for: change) ?? change.isStaged
+    }
     var gitStashes: [GitStash] { gitFeatureIfActive?.gitStashes ?? [] }
     var gitShelves: [GitShelfEntry] { gitFeatureIfActive?.gitShelves ?? [] }
     var gitSaveChangesPolicy: GitSaveChangesPolicy { settings.gitSaveChangesPolicy }

--- a/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -1488,9 +1488,16 @@ final class AppModel: ObservableObject, Identifiable {
         pendingGeneratedCommitMessage = nil
     }
 
-    func toggleStaging(_ change: GitChange) async {
-        guard let gitFeature = await activateGitModule() else { return }
-        await gitFeature.toggleStaging(change)
+    func toggleStaging(_ change: GitChange) {
+        guard let gitFeature = gitFeatureIfActive else { return }
+        guard let staged = gitFeature.beginToggleStaging(change) else { return }
+        Task { await gitFeature.finishToggleStaging(change, staged: staged) }
+    }
+
+    func setStaging(_ changes: [GitChange], staged: Bool) {
+        guard let gitFeature = gitFeatureIfActive else { return }
+        let pendingChanges = gitFeature.beginSetStaging(changes, staged: staged)
+        Task { await gitFeature.finishSetStaging(pendingChanges, staged: staged) }
     }
 
     func stageAllChanges() async {

--- a/Sources/Lithe/Views/Git/ChangesSidebarView.swift
+++ b/Sources/Lithe/Views/Git/ChangesSidebarView.swift
@@ -499,7 +499,7 @@ struct ChangesSidebarView: View {
                             )
                             changeSection(
                                 "Unversioned Files",
-                                changes: untrackedChanges,
+                                changes: addedChanges,
                                 expanded: $untrackedExpanded,
                                 showsParentPaths: geometry.size.width >= 300
                             )
@@ -522,33 +522,55 @@ struct ChangesSidebarView: View {
         showsParentPaths: Bool
     ) -> some View {
         if !changes.isEmpty {
-            Button {
-                expanded.wrappedValue.toggle()
-            } label: {
-                HStack(spacing: 7) {
+            HStack(spacing: 7) {
+                Button {
+                    expanded.wrappedValue.toggle()
+                } label: {
                     Image(systemName: expanded.wrappedValue ? "chevron.down" : "chevron.right")
                         .font(.system(size: 8, weight: .bold))
-                        .frame(width: 10)
-                    Image(systemName: "square")
-                        .font(.system(size: 16))
-                        .foregroundStyle(LitheTheme.secondaryText)
-                    Text(LocalizedStringKey(title))
-                        .font(.system(size: 12.5, weight: .semibold))
-                        .foregroundStyle(LitheTheme.primaryText)
-                    Text(changes.count == 1 ? "1 file" : "\(changes.count) files")
-                        .font(.system(size: 11))
-                        .foregroundStyle(LitheTheme.secondaryText)
-                    Spacer()
+                        .frame(width: 10, height: 24)
+                        .contentShape(Rectangle())
                 }
-                .padding(.horizontal, 7)
-                .frame(maxWidth: .infinity)
-                .frame(height: 30)
-                .background(LitheTheme.subtleSelection.opacity(0.72))
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-                .contentShape(Rectangle())
+                .buttonStyle(.plain)
+                .lithePointer()
+                .help(LocalizedStringKey(expanded.wrappedValue ? "Collapse section" : "Expand section"))
+
+                Button {
+                    model.setStaging(changes, staged: !allChangesStaged(changes))
+                } label: {
+                    Image(systemName: stagingSymbol(for: changes))
+                        .font(.system(size: 16))
+                        .foregroundStyle(changes.contains(where: isEffectivelyStaged) ? LitheTheme.accent : LitheTheme.secondaryText)
+                        .frame(width: 18, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .lithePointer()
+                .help(LocalizedStringKey(allChangesStaged(changes) ? "Unstage all files" : "Stage all files"))
+
+                Button {
+                    expanded.wrappedValue.toggle()
+                } label: {
+                    HStack(spacing: 7) {
+                        Text(LocalizedStringKey(title))
+                            .font(.system(size: 12.5, weight: .semibold))
+                            .foregroundStyle(LitheTheme.primaryText)
+                        Text(changes.count == 1 ? "1 file" : "\(changes.count) files")
+                            .font(.system(size: 11))
+                            .foregroundStyle(LitheTheme.secondaryText)
+                        Spacer()
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 24)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .lithePointer()
             }
-            .buttonStyle(.plain)
-            .lithePointer()
+            .padding(.horizontal, 7)
+            .frame(maxWidth: .infinity)
+            .frame(height: 30)
+            .background(LitheTheme.subtleSelection.opacity(0.72))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
 
             if expanded.wrappedValue {
                 ForEach(changes) { change in
@@ -561,14 +583,14 @@ struct ChangesSidebarView: View {
     private func changeRow(_ change: GitChange, showsParentPath: Bool) -> some View {
         HStack(spacing: 6) {
             Button {
-                Task { await model.toggleStaging(change) }
+                model.toggleStaging(change)
             } label: {
-                Image(systemName: change.isStaged ? "checkmark.square.fill" : "square")
+                Image(systemName: isEffectivelyStaged(change) ? "checkmark.square.fill" : "square")
                     .font(.system(size: 16))
-                    .foregroundStyle(change.isStaged ? LitheTheme.accent : LitheTheme.secondaryText)
+                    .foregroundStyle(isEffectivelyStaged(change) ? LitheTheme.accent : LitheTheme.secondaryText)
             }
             .litheIconButton()
-            .help(LocalizedStringKey(change.isStaged ? "Unstage file" : "Stage file"))
+            .help(LocalizedStringKey(isEffectivelyStaged(change) ? "Unstage file" : "Stage file"))
 
             Button {
                 model.selectChange(change)
@@ -630,11 +652,11 @@ struct ChangesSidebarView: View {
 
         if change.isStaged {
             Button("Unstage") {
-                Task { await model.toggleStaging(change) }
+                model.toggleStaging(change)
             }
         } else {
             Button("Stage File") {
-                Task { await model.toggleStaging(change) }
+                model.toggleStaging(change)
             }
         }
 
@@ -795,16 +817,29 @@ struct ChangesSidebarView: View {
     }
 
     private var trackedChanges: [GitChange] {
-        displayedChanges.filter { !$0.isUntracked }
+        displayedChanges.filter { $0.kind != .added }
     }
 
-    private var untrackedChanges: [GitChange] {
-        displayedChanges.filter(\.isUntracked)
+    private var addedChanges: [GitChange] {
+        displayedChanges.filter { $0.kind == .added }
     }
 
     private var displayedChanges: [GitChange] {
         guard !model.gitConflictFilterPaths.isEmpty else { return model.gitChanges }
         return model.gitChanges.filter { model.gitConflictFilterPaths.contains($0.path) }
+    }
+
+    private func isEffectivelyStaged(_ change: GitChange) -> Bool {
+        model.effectiveStagingState(for: change)
+    }
+
+    private func allChangesStaged(_ changes: [GitChange]) -> Bool {
+        changes.allSatisfy(isEffectivelyStaged)
+    }
+
+    private func stagingSymbol(for changes: [GitChange]) -> String {
+        if allChangesStaged(changes) { return "checkmark.square.fill" }
+        return changes.contains(where: isEffectivelyStaged) ? "minus.square.fill" : "square"
     }
 
     private var stagedChanges: [GitChange] {

--- a/Sources/LitheGitModule/Application/GitFeatureModel.swift
+++ b/Sources/LitheGitModule/Application/GitFeatureModel.swift
@@ -8,6 +8,7 @@ import LitheModuleAPI
 @MainActor
 package final class GitFeatureModel: ObservableObject {
     @Published package private(set) var gitChanges: [GitChange] = []
+    @Published private var pendingStagingStates: [GitChange.ID: Bool] = [:]
     @Published package private(set) var gitStashes: [GitStash] = []
     @Published package private(set) var gitShelves: [GitShelfEntry] = []
     @Published package private(set) var isPerformingStashOperation = false
@@ -134,6 +135,7 @@ package final class GitFeatureModel: ObservableObject {
 
     package func reset() {
         gitChanges = []
+        pendingStagingStates = [:]
         gitStashes = []
         gitShelves = []
         gitOperationState = nil
@@ -216,6 +218,7 @@ package final class GitFeatureModel: ObservableObject {
                 gitChanges = snapshot.changes
                 didChange = true
             }
+            reconcilePendingStagingStates(with: snapshot.changes)
             if !gitConflictFilterPaths.isEmpty {
                 let previousFilter = gitConflictFilterPaths
                 gitConflictFilterPaths.formIntersection(Set(snapshot.changes.map(\.path)))
@@ -616,15 +619,77 @@ package final class GitFeatureModel: ObservableObject {
         return true
     }
 
-    package func toggleStaging(_ change: GitChange) async {
-        selectedChange = change
-        let result = await withGitOperation {
-            change.isStaged
-                ? await service.unstage(change)
-                : await service.stage(change)
+    func reconcilePendingStagingStates(with changes: [GitChange]) {
+        let changesByID = Dictionary(uniqueKeysWithValues: changes.map { ($0.id, $0) })
+        pendingStagingStates = pendingStagingStates.filter { id, staged in
+            changesByID[id]?.isStaged != staged
         }
-        let verb = change.isStaged ? "Unstaged" : "Staged"
+    }
+
+    package func effectiveStagingState(for change: GitChange) -> Bool {
+        pendingStagingStates[change.id] ?? change.isStaged
+    }
+
+    package func beginToggleStaging(_ change: GitChange) -> Bool? {
+        guard pendingStagingStates[change.id] == nil else { return nil }
+        let staged = !change.isStaged
+        pendingStagingStates[change.id] = staged
+        return staged
+    }
+
+    package func beginSetStaging(_ changes: [GitChange], staged: Bool) -> [GitChange] {
+        let pendingChanges = changes.filter {
+            pendingStagingStates[$0.id] == nil && $0.isStaged != staged
+        }
+        for change in pendingChanges {
+            pendingStagingStates[change.id] = staged
+        }
+        return pendingChanges
+    }
+
+    package func finishToggleStaging(_ change: GitChange, staged: Bool) async {
+        let result = await withGitOperation {
+            staged
+                ? await service.stage(change)
+                : await service.unstage(change)
+        }
+        let verb = staged ? "Staged" : "Unstaged"
         showResult(result, success: "\(verb) \(change.path)")
+        if !result.succeeded {
+            pendingStagingStates.removeValue(forKey: change.id)
+        }
+        await refreshGit()
+    }
+
+    package func finishSetStaging(_ pendingChanges: [GitChange], staged: Bool) async {
+        guard !pendingChanges.isEmpty else { return }
+
+        var completedChangeIDs = Set<GitChange.ID>()
+        var failedChange: GitChange?
+        var failedResult: GitService.CommandResult?
+        await withGitOperation {
+            for change in pendingChanges {
+                let result = staged
+                    ? await service.stage(change)
+                    : await service.unstage(change)
+                guard result.succeeded else {
+                    failedChange = change
+                    failedResult = result
+                    break
+                }
+                completedChangeIDs.insert(change.id)
+            }
+        }
+
+        if let failedChange, let failedResult {
+            notify?("Could not \(staged ? "stage" : "unstage") \(failedChange.path): \(trimmedMessage(failedResult))")
+        } else {
+            let verb = staged ? "Staged" : "Unstaged"
+            notify?("\(verb) \(pendingChanges.count) file(s)")
+        }
+        for change in pendingChanges where !completedChangeIDs.contains(change.id) {
+            pendingStagingStates.removeValue(forKey: change.id)
+        }
         await refreshGit()
     }
 

--- a/Tests/LitheTests/GitStatusObservationTests.swift
+++ b/Tests/LitheTests/GitStatusObservationTests.swift
@@ -274,6 +274,40 @@ struct GitStatusObservationTests {
         #expect(refreshed, "Creating .git must re-resolve the watch context and refresh Git")
         #expect(recorder.externalChangeBatches.isEmpty)
     }
+    @Test
+    @MainActor
+    func staleSnapshotDoesNotClearOptimisticStagingState() {
+        let repository = URL(fileURLWithPath: "/tmp/lithe-staging-state-test", isDirectory: true)
+        let unstaged = GitChange(
+            repositoryRoot: repository,
+            path: "new-file.txt",
+            originalPath: nil,
+            indexStatus: "?",
+            workTreeStatus: "?"
+        )
+        let staged = GitChange(
+            repositoryRoot: repository,
+            path: "new-file.txt",
+            originalPath: nil,
+            indexStatus: "A",
+            workTreeStatus: " "
+        )
+        let model = GitFeatureModel(
+            service: GitService(operations: RustGitOperations(core: RustCoreBridge()))
+        )
+
+        #expect(model.selectedChange == nil)
+        #expect(model.beginToggleStaging(unstaged) == true)
+        #expect(model.selectedChange == nil)
+        model.reconcilePendingStagingStates(with: [unstaged])
+        #expect(model.effectiveStagingState(for: unstaged))
+
+        model.reconcilePendingStagingStates(with: [staged])
+        #expect(model.effectiveStagingState(for: staged))
+        model.selectedChange = unstaged
+        #expect(model.beginToggleStaging(staged) == false)
+        #expect(model.selectedChange == unstaged)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary                                                                                                                                   
                                                                                                                                                
   Fixes #19                                                                                                                                    
                                                                                                                                                
   ### 问题与根本原因                                                                                                                           
                                                                                                                                                
   报告的现象：点击左侧 Changes 面板的"全选"没有全选下列文件。                                              
                                                                                                                                                
   对照改动前后实现，根因是"全选/勾选"从未接入真实的暂存操作：                                                                                  
                                                                                                                                                
   **1. 节头勾选框是装饰性图标，节头整行只有一个折叠按钮。** 旧实现中整个节头是一个大按钮，`square`                                             
 图标只是装饰，点击只切换展开/收起——"全选下列文件"在语义上不存在。→                                                                             
 节头拆分为折叠箭头、全选勾选框、标题行三个独立按钮；勾选框对节内全部文件执行 stage/unstage（`setStaging`），并以三态符号反映"全选/部分/未选"。 
                                                                                                                                                
   **2. 文件行勾选是"命令 → 刷新"的慢路径，没有即时反馈。** 旧实现勾选后 `Task { await toggleStaging(change) }`，状态要等 git                   
 命令返回并刷新后才变化，且暂存会连带切换 `selectedChange`，勾选时右侧 diff 跳动。→ `GitFeatureModel` 新增 `pendingStagingStates`               
 乐观状态：点击立即翻转勾选，后台执行真实 `stage`/`unstage`，完成后与 `git status`                                                              
 快照对账（`reconcilePendingStagingStates`），失败回滚对应勾选；刷新期间到达的陈旧快照不会清掉尚未落盘的乐观状态（新增测试                      
 `staleSnapshotDoesNotClearOptimisticStagingState` 覆盖）。暂存不再改变当前选中的 diff。                                                        
                                                                                                                                                
   **3. 未跟踪文件暂存后会从列表消失。** 旧实现 Unversioned 节按 `isUntracked` 收集文件，暂存后状态变为 added 便离开该节。→ 改为按 added        
 状态收集（`addedChanges`），未跟踪文件暂存后仍保留在原节显示。                                                                                 
                                                                                                                                                
   ### 边界（明确不包含）                                                                                                                       
                                                                                                                                                
   - **暂存粒度**：勾选按整文件 stage/unstage；hunk 级暂存维持原有入口，不受影响。                                                              
   - **Windows**：本 PR 只涉及 macOS 参考产品的 UI 与 GitFeatureModel；Windows 为独立实现，按分层架构另行跟进。                                 
   - **不做跨节批量选择**：全选以节为单位，不引入多选拖拽。                                                                                     
   - **不做 index 增量对比**：对账以 `git status` 快照为准，不做 `.git/index` 增量 diff。                                                       
                                                                                                                                                
   ## 验证                                                                                                                                      
                                                                                                                                                
   - `./scripts/test-macos.sh`（`swift test` 全量 381 个测试通过；`GitStatusObservationTests` 11 个含新增                                       
 `staleSnapshotDoesNotClearOptimisticStagingState` 真实仓库观察测试）                                                                           
   - `./scripts/build-macos.sh`（`swift build` debug 全 target 编译通过）                                                                       
   - `./scripts/verify-rust-core.sh`（内部含 `cargo test` 全量、`cargo fmt --check`、Swift bridge 构建、Rust Core 符号检查；本 PR 无 Rust       
 改动）                                                                                                                                         
   - `cargo fmt --manifest-path rust/lithe-core/Cargo.toml --check`                                                                             
   - `./scripts/verify-core.sh`                                                                                                                 
   - `./scripts/verify-git-graph.sh`                                                                                                            
   - `./scripts/verify-service-boundaries.sh`                                                                                                   
   - `./scripts/verify-shared-contracts.sh`                                                                                                     
   - `./scripts/verify-windows-boundaries.sh`                                                                                                   
   - `git diff --check`                                                                                                   
                                                                                                                                                
   ## Result
<img width="2560" height="1664" alt="aaf9edce-9720-4c75-956b-0e481c4d4e8e" src="https://github.com/user-attachments/assets/630d71c7-bb67-4807-9890-86541f37ae5b" />
<img width="2560" height="1664" alt="b2843dec-320e-4ab2-9fa5-f401db7e7fdc" src="https://github.com/user-attachments/assets/8e8ac599-47c1-4b48-a8fd-7aa773646eaa" />
<img width="2560" height="1664" alt="4d962c03-0dc9-4c1a-8e1f-d092d574eee8" src="https://github.com/user-attachments/assets/85c43156-f8f4-4e41-a049-a9ec49dedd83" />
