### PR TITLE
fix(windows): align local branch checkout and deletion refs

### DIFF
--- a/windows/tauri/src-tauri/src/platform.rs
+++ b/windows/tauri/src-tauri/src/platform.rs
@@ -117,14 +117,31 @@ fn translate(command: &str, args: Value) -> Result<(String, Value), String> {
             "git.write"
         }
         "git_delete_branch" => {
-            move_field(&mut payload, "branchName", "reference");
+            let branch = take_text(&mut payload, "branchName")?;
+            payload.insert(
+                "reference".into(),
+                json!(local_branch_reference(&branch)),
+            );
             payload.insert("operation".into(), json!("deleteBranch"));
             "git.write"
         }
         "git_checkout" => {
-            move_field(&mut payload, "branchName", "reference");
+            let branch = take_text(&mut payload, "branchName")?;
+            payload.insert(
+                "reference".into(),
+                json!(local_branch_reference(&branch)),
+            );
             payload.insert("operation".into(), json!("checkout"));
+            payload.insert("referenceKind".into(), json!("local"));
             "git.write"
+        }
+        "git_checkout_preflight" => {
+            let branch = take_text(&mut payload, "branchName")?;
+            payload.insert(
+                "reference".into(),
+                json!(local_branch_reference(&branch)),
+            );
+            "git.checkoutPreflight"
         }
         "git_create_stash" => {
             payload.insert("operation".into(), json!("stashPush"));
@@ -384,6 +401,19 @@ fn move_field(payload: &mut Map<String, Value>, from: &str, to: &str) {
     }
 }
 
+/// Windows callers name local branches by their short form, while the shared
+/// core requires fully qualified references so branch and tag names cannot
+/// collide. Only `refs/heads/` counts as already qualified; any other ref
+/// namespace is treated as a branch name instead of silently targeting a
+/// different namespace.
+fn local_branch_reference(branch: &str) -> String {
+    if branch.starts_with("refs/heads/") {
+        branch.to_string()
+    } else {
+        format!("refs/heads/{branch}")
+    }
+}
+
 fn paths_from_file(payload: &mut Map<String, Value>) {
     if let Some(path) = payload.remove("filePath") {
         payload.insert("paths".into(), Value::Array(vec![path]));
@@ -400,7 +430,7 @@ fn take_text(payload: &mut Map<String, Value>, field: &str) -> Result<String, St
 
 #[cfg(test)]
 mod tests {
-    use super::translate;
+    use super::{local_branch_reference, translate};
     use serde_json::json;
 
     #[test]
@@ -428,6 +458,74 @@ mod tests {
                 "paths": ["src/main.rs"]
             })
         );
+    }
+
+    #[test]
+    fn translates_checkout_branch_with_reference_kind() {
+        let (command, payload) = translate(
+            "git_checkout",
+            json!({ "repoPath": "C:/work", "branchName": "feature/checkout" }),
+        )
+        .unwrap();
+
+        assert_eq!(command, "git.write");
+        assert_eq!(
+            payload,
+            json!({
+                "root": "C:/work",
+                "operation": "checkout",
+                "reference": "refs/heads/feature/checkout",
+                "referenceKind": "local"
+            })
+        );
+    }
+
+    #[test]
+    fn translates_checkout_preflight_reference() {
+        let (command, payload) = translate(
+            "git_checkout_preflight",
+            json!({ "repoPath": "C:/work", "branchName": "main" }),
+        )
+        .unwrap();
+
+        assert_eq!(command, "git.checkoutPreflight");
+        assert_eq!(
+            payload,
+            json!({ "root": "C:/work", "reference": "refs/heads/main" })
+        );
+    }
+
+    #[test]
+    fn translates_delete_branch_to_qualified_reference() {
+        let (command, payload) = translate(
+            "git_delete_branch",
+            json!({ "repoPath": "C:/work", "branchName": "feature/old" }),
+        )
+        .unwrap();
+
+        assert_eq!(command, "git.write");
+        assert_eq!(
+            payload,
+            json!({
+                "root": "C:/work",
+                "operation": "deleteBranch",
+                "reference": "refs/heads/feature/old"
+            })
+        );
+    }
+
+    #[test]
+    fn qualifies_short_branch_names_only() {
+        assert_eq!(local_branch_reference("main"), "refs/heads/main");
+        assert_eq!(
+            local_branch_reference("feature/old"),
+            "refs/heads/feature/old"
+        );
+        assert_eq!(
+            local_branch_reference("refs/heads/main"),
+            "refs/heads/main"
+        );
+        assert_eq!(local_branch_reference("refs/foo"), "refs/heads/refs/foo");
     }
 
     #[test]

--- a/windows/tauri/src/features/git/api/git-branches-api.ts
+++ b/windows/tauri/src/features/git/api/git-branches-api.ts
@@ -13,6 +13,23 @@ interface CheckoutResult {
   message: string;
 }
 
+interface CheckoutPreflightResult {
+  blocked: boolean;
+  blockingPaths: string[];
+}
+
+const checkoutErrorMessage = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.trim() || "Failed to checkout branch";
+};
+
+const blockingChangesMessage = (blockingPaths: string[]): string => {
+  const listed = blockingPaths.slice(0, 3).join(", ");
+  const remaining = blockingPaths.length - Math.min(blockingPaths.length, 3);
+  const suffix = remaining > 0 ? ` (+${remaining} more)` : "";
+  return `Local changes would be overwritten by switching branches: ${listed}${suffix}`;
+};
+
 export const getBranches = async (repoPath: string): Promise<string[]> => {
   try {
     const resolvedRepoPath = await resolveRepositoryPath(repoPath);
@@ -37,6 +54,19 @@ export const checkoutBranch = async (
 ): Promise<CheckoutResult> => {
   try {
     const resolvedRepoPath = await resolveRepositoryPathOrThrow(repoPath);
+
+    const preflight = await tauriInvoke<CheckoutPreflightResult>("git_checkout_preflight", {
+      repoPath: resolvedRepoPath,
+      branchName,
+    });
+    if (preflight.blocked) {
+      return {
+        success: false,
+        hasChanges: true,
+        message: blockingChangesMessage(preflight.blockingPaths),
+      };
+    }
+
     const result = await tauriInvoke<CheckoutResult>("git_checkout", {
       repoPath: resolvedRepoPath,
       branchName,
@@ -54,7 +84,7 @@ export const checkoutBranch = async (
     return {
       success: false,
       hasChanges: false,
-      message: "Failed to checkout branch",
+      message: checkoutErrorMessage(error),
     };
   }
 };

--- a/windows/tauri/src/platform/core-result-adapter.test.ts
+++ b/windows/tauri/src/platform/core-result-adapter.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { adaptCoreResult } from "./core-result-adapter";
+
+describe("git checkout result adaptation", () => {
+  test("maps a successful core checkout to the UI checkout result", () => {
+    const result = adaptCoreResult(
+      "git_checkout",
+      { repoPath: "C:/work", branchName: "main" },
+      { output: "Switched to branch 'main'\n", exitCode: 0 },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      hasChanges: false,
+      message: "Switched to branch 'main'",
+    });
+  });
+
+  test("reports failure when the core checkout exited non-zero", () => {
+    const result = adaptCoreResult(
+      "git_checkout",
+      { repoPath: "C:/work", branchName: "main" },
+      { output: "error: pathspec 'main' did not match", exitCode: 1 },
+    );
+
+    expect(result).toEqual({
+      success: false,
+      hasChanges: false,
+      message: "error: pathspec 'main' did not match",
+    });
+  });
+
+  test("keeps an empty message for a silent successful checkout", () => {
+    const result = adaptCoreResult("git_checkout", undefined, { output: "", exitCode: 0 });
+
+    expect(result).toEqual({ success: true, hasChanges: false, message: "" });
+  });
+});
+
+describe("git checkout preflight adaptation", () => {
+  test("reports blocked paths returned by the shared core", () => {
+    const result = adaptCoreResult(
+      "git_checkout_preflight",
+      { repoPath: "C:/work", branchName: "main" },
+      { blockingPaths: ["src/main.rs", "README.md"] },
+    );
+
+    expect(result).toEqual({
+      blocked: true,
+      blockingPaths: ["src/main.rs", "README.md"],
+    });
+  });
+
+  test("reports no blockage when the core returns no blocking paths", () => {
+    const result = adaptCoreResult(
+      "git_checkout_preflight",
+      { repoPath: "C:/work", branchName: "main" },
+      { blockingPaths: [] },
+    );
+
+    expect(result).toEqual({ blocked: false, blockingPaths: [] });
+  });
+});

--- a/windows/tauri/src/platform/core-result-adapter.ts
+++ b/windows/tauri/src/platform/core-result-adapter.ts
@@ -146,6 +146,17 @@ export function adaptCoreResult<T>(
         };
       }) as T;
     }
+    case "git_checkout": {
+      const exitCode = typeof data.exitCode === "number" ? data.exitCode : 0;
+      const output = typeof data.output === "string" ? data.output.trim() : "";
+      return { success: exitCode === 0, hasChanges: false, message: output } as T;
+    }
+    case "git_checkout_preflight": {
+      const blockingPaths = Array.isArray(data.blockingPaths)
+        ? data.blockingPaths.map((path: unknown) => String(path))
+        : [];
+      return { blocked: blockingPaths.length > 0, blockingPaths } as T;
+    }
     case "git_checkout_tag":
       return { success: true, hasChanges: false, message: "" } as T;
     default:


### PR DESCRIPTION
## 问题

Windows 分支切换和删除调用链存在三处契约错位，导致两个操作都会被共享 Core 拒绝：

1. `git_checkout` / `git_delete_branch` 翻译层只传短分支名，而 Core 的 `local_branch_name()` 要求完整引用 `refs/heads/<branch>`；
2. `git_checkout` 缺少 `referenceKind`，Core 的 `switch_reference()` 对缺省值直接返回 `invalid_request`；
3. `core-result-adapter` 没有 `git_checkout` 适配分支，前端拿到的原始 `{output, exitCode}` 缺少 `success` / `hasChanges`，成功切换也不会触发状态刷新。

## 修复

- `platform.rs`：新增 `local_branch_reference()` 统一补全 `refs/heads/` 前缀（仅对已是 `refs/heads/` 开头的值透传）；`git_checkout` 传 `referenceKind: "local"`；新增 `git_checkout_preflight` → `git.checkoutPreflight` 翻译；`git_delete_branch` 走同样的限定引用
- `core-result-adapter.ts`：补 `git_checkout`（exitCode/output → success/message）与 `git_checkout_preflight`（blockingPaths）适配
- `git-branches-api.ts`：切换前先跑 preflight，阻塞时返回 `hasChanges: true` 复用现有 Stash Changes 重试流程；失败信息透传 git 真实输出

UI 组件、Rust Core、macOS 实现均未改动。

## 验证

- `cargo test`（src-tauri）：13/13 通过（新增 checkout / preflight / deleteBranch 翻译测试及 helper 边界测试）
- `bun test`：14/14 通过（新增 5 个 adapter 适配测试）
- `tsc --noEmit`：通过
- 未验证：真机 UI 手工场景（Stash 重试、错误提示展示），依赖 reviewer 环境确认

## 后续

- `checkoutBranch` catch 路径的 API 层错误传播测试计划随下一个 PR 补充（需要 invoke 模块 mock）
- `scripts/verify-windows-boundaries.sh` 在 Windows 存在基线既有的路径分隔符误报（白名单正则用 `/`，rg 输出 `\`），与本 PR 无关，可单独修复
