### PR TITLE
fix(windows): send diff pathspecs the shared core accepts

### DIFF
--- a/windows/tauri/src-tauri/src/platform.rs
+++ b/windows/tauri/src-tauri/src/platform.rs
@@ -90,8 +90,13 @@ fn translate(command: &str, args: Value) -> Result<(String, Value), String> {
             "git.write"
         }
         "git_diff_file" | "git_status_diff_stats" => {
-            paths_from_file(&mut payload);
-            payload.entry("pathspecs").or_insert_with(|| json!([]));
+            if let Some(path) = payload.remove("filePath") {
+                payload.insert("pathspecs".into(), Value::Array(vec![path]));
+            } else {
+                // The shared core rejects empty pathspecs; a request without a
+                // file scope means the whole tree, which git spells as `.`.
+                payload.insert("pathspecs".into(), json!(["."]));
+            }
             "git.diff"
         }
         "git_ref_diff" => {
@@ -436,7 +441,41 @@ mod tests {
             translate("git_diff_file", json!({ "repoPath": "C:/work" })).unwrap();
 
         assert_eq!(command, "git.diff");
-        assert_eq!(payload, json!({ "root": "C:/work", "pathspecs": [] }));
+        assert_eq!(payload, json!({ "root": "C:/work", "pathspecs": ["."] }));
+    }
+
+    #[test]
+    fn translates_diff_file_pathspec() {
+        let (command, payload) = translate(
+            "git_diff_file",
+            json!({ "repoPath": "C:/work", "filePath": "src/main.rs", "staged": true }),
+        )
+        .unwrap();
+
+        assert_eq!(command, "git.diff");
+        assert_eq!(
+            payload,
+            json!({
+                "root": "C:/work",
+                "pathspecs": ["src/main.rs"],
+                "staged": true
+            })
+        );
+    }
+
+    #[test]
+    fn translates_status_diff_stats_whole_tree() {
+        let (command, payload) = translate(
+            "git_status_diff_stats",
+            json!({ "repoPath": "C:/work", "staged": true }),
+        )
+        .unwrap();
+
+        assert_eq!(command, "git.diff");
+        assert_eq!(
+            payload,
+            json!({ "root": "C:/work", "pathspecs": ["."], "staged": true })
+        );
     }
 
     #[test]

--- a/windows/tauri/src/features/git/api/git-diff-api.ts
+++ b/windows/tauri/src/features/git/api/git-diff-api.ts
@@ -219,14 +219,20 @@ export const getStatusDiffStats = async (repoPath: string): Promise<GitDiffStat[
     }
 
     const generation = getRepositoryCacheGeneration(resolvedRepoPath);
-    const request = tauriInvoke<GitDiffStat[]>("git_status_diff_stats", {
-      repoPath: resolvedRepoPath,
-    })
-      .then((stats) => {
+    const request = Promise.all([
+      tauriInvoke<GitDiffStat[]>("git_status_diff_stats", {
+        repoPath: resolvedRepoPath,
+      }),
+      tauriInvoke<GitDiffStat[]>("git_status_diff_stats", {
+        repoPath: resolvedRepoPath,
+        staged: true,
+      }),
+    ])
+      .then(([unstagedStats, stagedStats]) => {
         if (generation !== getRepositoryCacheGeneration(resolvedRepoPath)) {
           return getStatusDiffStats(resolvedRepoPath);
         }
-        return stats;
+        return [...unstagedStats, ...stagedStats];
       })
       .catch((error) => {
         if (!isNotGitRepositoryError(error)) {

--- a/windows/tauri/src/platform/core-result-adapter.diff.test.ts
+++ b/windows/tauri/src/platform/core-result-adapter.diff.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { adaptCoreResult } from "./core-result-adapter";
+
+const twoFilePatch = `diff --git a/a.txt b/a.txt
+index 111..222 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1,2 @@
+ hello
++world
+diff --git a/b.txt b/b.txt
+index 333..444 100644
+--- a/b.txt
++++ b/b.txt
+@@ -1 +0,0 @@
+-old line
+`;
+
+describe("git diff stats adaptation", () => {
+  test("maps per-file additions and deletions from the whole tree patch", () => {
+    const stats = adaptCoreResult(
+      "git_status_diff_stats",
+      { repoPath: "C:/work" },
+      { patch: twoFilePatch },
+    );
+
+    expect(stats).toEqual([
+      { file_path: "a.txt", staged: false, additions: 1, deletions: 0 },
+      { file_path: "b.txt", staged: false, additions: 0, deletions: 1 },
+    ]);
+  });
+
+  test("carries the staged flag from the request into every stat entry", () => {
+    const stats = adaptCoreResult(
+      "git_status_diff_stats",
+      { repoPath: "C:/work", staged: true },
+      { patch: twoFilePatch },
+    );
+
+    expect(Array.isArray(stats)).toBe(true);
+    for (const stat of stats as Array<{ staged: boolean }>) {
+      expect(stat.staged).toBe(true);
+    }
+  });
+});
+
+describe("git single-file diff adaptation", () => {
+  test("returns the parsed diff for the requested file", () => {
+    const diff = adaptCoreResult(
+      "git_diff_file",
+      { repoPath: "C:/work", filePath: "a.txt" },
+      { patch: twoFilePatch },
+    );
+
+    expect((diff as { file_path: string }).file_path).toBe("a.txt");
+  });
+});

--- a/windows/tauri/src/platform/core-result-adapter.ts
+++ b/windows/tauri/src/platform/core-result-adapter.ts
@@ -29,10 +29,11 @@ function adaptDiff(command: string, args: JsonRecord | undefined, value: unknown
     return "files" in parsed ? parsed.files[0] ?? null : parsed;
   }
   if (command === "git_status_diff_stats") {
+    const staged = Boolean(argumentsRecord.staged);
     const diffs = "files" in parsed ? parsed.files : [parsed];
     return diffs.map((diff) => ({
       file_path: diff.file_path,
-      staged: false,
+      staged,
       additions: diff.additions ?? diff.lines.filter((line) => line.line_type === "added").length,
       deletions: diff.deletions ?? diff.lines.filter((line) => line.line_type === "removed").length,
     }));


### PR DESCRIPTION
## 问题

Windows 的单文件 diff 与变更统计两条通路把 `filePath` 映射进了 Core 不认识的 `paths` 字段，而 `git.diff` 契约要求 `pathspecs` 且拒绝空数组（`mod.rs` 校验 `pathspecs` 非空）：

1. 点已修改的已跟踪文件 → Core 拒绝 → `getFileDiff` 静默失败返回 null → 上层回退为打开原文件，diff 视图永远不出现，且无任何报错；
2. `git_status_diff_stats` 同样被拒 → Changes 列表完全没有 +/- 行数统计；
3. stats 适配层把 `staged` 写死为 `false`，即使前两项修好，已暂存文件也永远没有统计数字。

## 修复

- `platform.rs`：`git_diff_file` / `git_status_diff_stats` 的 `filePath` 改映射到 `pathspecs`；不带 `filePath` 时兜底 `["."]`（整树，与 `git_ref_diff` 现有写法一致）
- `core-result-adapter.ts`：diff stats 的 `staged` 改从请求参数读取，不再硬编码
- `git-diff-api.ts`：stats 并取未暂存 + 已暂存两组（Core 的 `staged` 参数现成支持），两组文件都能显示统计
- 未跟踪文件点击直接打开原文件的既有行为保持不变

## 验证

- `cargo test`（src-tauri）：11/11 通过（新增 2 个翻译测试：带 filePath 的 pathspec 映射、stats 整树兜底）
- `bun test`：12/12 通过（新增 3 个 adapter 测试：stats 双文件计数、staged 透传、单文件 diff 适配）
- `tsc --noEmit`：通过
- 真机验收通过：点已修改的已跟踪文件打开 diff 视图（修复前打开原文件）；staged diff 正常；Changes 列表出现 +/- 统计（含已暂存文件）；commit / stash 无回归

## 关联

- 与 #101（checkout 接线）同属 Windows 兼容命令翻译层修复，改动区域不重叠
