### PR TITLE
fix(windows): 修复Windows端编辑器无法点到行尾并拖选整行的问题

### DIFF
--- a/windows/tauri/src/features/editor/components/code-editor.tsx
+++ b/windows/tauri/src/features/editor/components/code-editor.tsx
@@ -18,7 +18,7 @@ import { useEditorSettingsStore } from "@/features/editor/stores/settings.store"
 import { useEditorStateStore } from "@/features/editor/stores/state.store";
 import { useEditorViewStore } from "@/features/editor/stores/view.store";
 import { getBufferById } from "@/features/editor/utils/buffer-index";
-import { calculateLineHeight } from "@/features/editor/utils/lines";
+import { calculateLineHeight, splitLines } from "@/features/editor/utils/lines";
 import { resolveGoToLineTarget } from "@/features/editor/utils/go-to-line";
 import type { EditorModelPositionResolver } from "@/features/editor/view-model/view-layout";
 import { hasTextContent } from "@/features/panes/types/pane-content.types";
@@ -250,7 +250,7 @@ const CodeEditor = ({
     [],
   );
   const getCodeLensLineText = useCallback((line: number) => {
-    return valueRef.current.split("\n")[line];
+    return splitLines(valueRef.current)[line] ?? "";
   }, []);
   const measureCodeLensContentLeft = useCallback(() => {
     const container = editorRef.current;

--- a/windows/tauri/src/features/editor/components/monaco-editor.tsx
+++ b/windows/tauri/src/features/editor/components/monaco-editor.tsx
@@ -63,8 +63,14 @@ import {
 } from "../engines/monaco/hover-widgets";
 import { toMonacoLanguageId } from "../engines/monaco/language";
 import { ensureMonacoLanguageTokenizer } from "../engines/monaco/language-contributions";
+import {
+  createInlineGitBlameWidget,
+  type InlineGitBlameWidget,
+} from "../engines/monaco/inline-git-blame-widget";
 import { acquireMonacoModel } from "../engines/monaco/model-lifecycle";
 import { getEditorBottomScrollPadding } from "../engines/monaco/scroll-padding";
+import { monacoModelMatchesContent } from "../engines/monaco/line-endings";
+import { applyMonacoModelContent } from "../engines/monaco/model-content";
 import {
   clampMonacoPosition,
   createModelUri,
@@ -145,10 +151,11 @@ export function MonacoEditor({
   const previousContentRef = useRef("");
   const pendingLocalContentSnapshotsRef = useRef<string[]>([]);
   const decorationsRef = useRef<string[]>([]);
-  const gitBlameDecorationRef = useRef<string[]>([]);
+  const gitBlameWidgetRef = useRef<InlineGitBlameWidget | null>(null);
   const gitBlameRenderFrameRef = useRef<number | null>(null);
   const renderedGitBlameKeyRef = useRef<string | null>(null);
   const renderInlineGitBlameRef = useRef<() => void>(() => {});
+  const mouseSelectingRef = useRef(false);
   const latestContentChangeRef = useRef(onContentChange);
   const isActiveSurfaceRef = useRef(isActiveSurface);
   const activeBufferId = useBufferStore((state) => propBufferId ?? state.activeBufferId);
@@ -216,56 +223,47 @@ export function MonacoEditor({
     const editor = editorRef.current;
     const model = modelRef.current;
     if (!editor || !model || model.isDisposed()) return;
+    if (mouseSelectingRef.current) return;
 
-    const clearDecoration = () => {
+    const widget = gitBlameWidgetRef.current ?? createInlineGitBlameWidget(editor);
+    gitBlameWidgetRef.current = widget;
+
+    const hideBlame = () => {
       renderedGitBlameKeyRef.current = null;
-      if (gitBlameDecorationRef.current.length === 0) return;
-      gitBlameDecorationRef.current = editor.deltaDecorations(gitBlameDecorationRef.current, []);
+      widget.hide();
     };
 
     if (!inlineGitBlameEnabled || !isActiveSurface || !filePath) {
-      clearDecoration();
+      hideBlame();
       return;
     }
 
     const position = editor.getPosition();
     const lineNumber = position?.lineNumber ?? 0;
     if (lineNumber < 1 || lineNumber > model.getLineCount()) {
-      clearDecoration();
+      hideBlame();
       return;
     }
 
     const blameLine = getBlameForLine(lineNumber - 1);
     if (!blameLine) {
-      clearDecoration();
+      hideBlame();
       return;
     }
 
-    const content = blameLine.is_uncommitted
+    const blameContent = blameLine.is_uncommitted
       ? "  Uncommitted changes"
       : `  ${blameLine.author}, ${formatRelativeTime(blameLine.time)}`;
-    const decorationKey = `${filePath}:${lineNumber}:${blameLine.commit_hash}:${content}`;
+    const decorationKey = `${filePath}:${lineNumber}:${blameLine.commit_hash}:${blameContent}`;
     if (renderedGitBlameKeyRef.current === decorationKey) return;
 
-    const column = model.getLineMaxColumn(lineNumber);
-    gitBlameDecorationRef.current = editor.deltaDecorations(gitBlameDecorationRef.current, [
-      {
-        range: new MonacoRange(lineNumber, column, lineNumber, column),
-        options: {
-          after: {
-            content,
-            inlineClassName: "monaco-inline-git-blame",
-            cursorStops: monacoEditor.InjectedTextCursorStops.None,
-          },
-          showIfCollapsed: false,
-        },
-      },
-    ]);
+    widget.show(lineNumber, model.getLineMaxColumn(lineNumber), blameContent);
     renderedGitBlameKeyRef.current = decorationKey;
   }, [filePath, getBlameForLine, inlineGitBlameEnabled, isActiveSurface]);
   renderInlineGitBlameRef.current = renderInlineGitBlame;
 
   const scheduleInlineGitBlameRender = useCallback(() => {
+    if (mouseSelectingRef.current) return;
     if (gitBlameRenderFrameRef.current !== null) return;
     gitBlameRenderFrameRef.current = requestAnimationFrame(() => {
       gitBlameRenderFrameRef.current = null;
@@ -565,6 +563,10 @@ export function MonacoEditor({
       domReadOnly: readOnly || isPreviewMode,
       minimap: { enabled: minimapEnabled },
       fontLigatures: editorFontLigatures,
+      // Geist Mono is a variable font; Windows DPI plus Monaco's default
+      // monospace width cache places the caret one column left of the click.
+      disableMonospaceOptimizations: true,
+      selectOnLineNumbers: true,
       stickyScroll: { enabled: editorStickyScroll },
       bracketPairColorization: { enabled: editorBracketPairColorization },
       smoothScrolling: editorSmoothScrolling,
@@ -795,6 +797,14 @@ export function MonacoEditor({
         );
         syncCursorAndSelection();
       }),
+      editor.onMouseDown((event) => {
+        if (event.event.leftButton) mouseSelectingRef.current = true;
+      }),
+      editor.onMouseUp(() => {
+        if (!mouseSelectingRef.current) return;
+        mouseSelectingRef.current = false;
+        scheduleInlineGitBlameRender();
+      }),
       editor.onDidChangeCursorSelection(() => {
         syncCursorAndSelection();
         scheduleInlineGitBlameRender();
@@ -811,14 +821,36 @@ export function MonacoEditor({
       }),
     ];
 
+    const handleWindowMouseUp = () => {
+      if (!mouseSelectingRef.current) return;
+      mouseSelectingRef.current = false;
+      scheduleInlineGitBlameRender();
+    };
+    window.addEventListener("mouseup", handleWindowMouseUp);
+
     const unsubscribeCursor = editorAPI.on("cursorChange", (position) => {
       if (!modelRef.current || editorRef.current !== editor) return;
+      if (mouseSelectingRef.current) return;
       const monacoPosition = toClampedMonacoPosition(model, position);
+      const currentPosition = editor.getPosition();
+      if (
+        currentPosition &&
+        currentPosition.lineNumber === monacoPosition.lineNumber &&
+        currentPosition.column === monacoPosition.column
+      ) {
+        return;
+      }
+      const currentSelection = editor.getSelection();
+      if (currentSelection && !currentSelection.isEmpty()) {
+        editor.revealPositionInCenterIfOutsideViewport(monacoPosition);
+        return;
+      }
       editor.setPosition(monacoPosition);
       editor.revealPositionInCenterIfOutsideViewport(monacoPosition);
     });
     const unsubscribeSelection = editorAPI.on("selectionChange", (selection) => {
       if (!modelRef.current || editorRef.current !== editor) return;
+      if (mouseSelectingRef.current) return;
       if (selection) {
         editor.setSelection(toMonacoRange(model, selection));
       } else {
@@ -847,6 +879,7 @@ export function MonacoEditor({
       unsubscribeCursor();
       unsubscribeSelection();
       window.removeEventListener("keydown", handleWindowSelectAllShortcut, true);
+      window.removeEventListener("mouseup", handleWindowMouseUp);
       for (const disposable of disposables) {
         disposable.dispose();
       }
@@ -859,8 +892,10 @@ export function MonacoEditor({
         cancelAnimationFrame(gitBlameRenderFrameRef.current);
         gitBlameRenderFrameRef.current = null;
       }
-      gitBlameDecorationRef.current = [];
+      gitBlameWidgetRef.current?.dispose();
+      gitBlameWidgetRef.current = null;
       renderedGitBlameKeyRef.current = null;
+      mouseSelectingRef.current = false;
       createdEditorDisposable.dispose();
       if (editorRef.current === editor) editorRef.current = null;
       if (modelRef.current === model) modelRef.current = null;
@@ -1117,8 +1152,11 @@ export function MonacoEditor({
     if (!editor || !model) return;
 
     const modelValue = model.getValue();
-    if (modelValue === content) {
+    if (monacoModelMatchesContent(modelValue, content)) {
       consumeLocalContentSnapshot(pendingLocalContentSnapshotsRef.current, content);
+      applyingExternalChangeRef.current = true;
+      applyMonacoModelContent(model, content);
+      applyingExternalChangeRef.current = false;
       previousContentRef.current = content;
       return;
     }
@@ -1130,7 +1168,7 @@ export function MonacoEditor({
 
     applyingExternalChangeRef.current = true;
     const selection = editor.getSelection();
-    model.setValue(content);
+    applyMonacoModelContent(model, content);
     if (selection) editor.setSelection(selection);
     previousContentRef.current = content;
     applyingExternalChangeRef.current = false;
@@ -1207,6 +1245,8 @@ export function MonacoEditor({
       lineNumbers: lineNumbers ? lineNumberFormatter : "off",
       minimap: { enabled: minimapEnabled },
       fontLigatures: editorFontLigatures,
+      disableMonospaceOptimizations: true,
+      selectOnLineNumbers: true,
       stickyScroll: { enabled: editorStickyScroll },
       bracketPairColorization: { enabled: editorBracketPairColorization },
       smoothScrolling: editorSmoothScrolling,

--- a/windows/tauri/src/features/editor/engines/monaco/inline-git-blame-widget.ts
+++ b/windows/tauri/src/features/editor/engines/monaco/inline-git-blame-widget.ts
@@ -1,0 +1,57 @@
+import { editor as monacoEditor } from "monaco-editor";
+import type * as Monaco from "monaco-editor";
+
+const WIDGET_ID = "lithe.inlineGitBlame";
+
+export interface InlineGitBlameWidget {
+  show(lineNumber: number, column: number, content: string): void;
+  hide(): void;
+  dispose(): void;
+}
+
+/**
+ * Render git blame after the line as a content widget so it does not join
+ * Monaco's text hit-testing. Injected `after` text steals clicks at EOL and
+ * can collapse a drag-select when decorations are replaced.
+ */
+export function createInlineGitBlameWidget(
+  editor: Monaco.editor.IStandaloneCodeEditor,
+): InlineGitBlameWidget {
+  const node = document.createElement("div");
+  node.className = "monaco-inline-git-blame";
+  node.setAttribute("aria-hidden", "true");
+  let position: Monaco.IPosition | null = null;
+
+  const widget: Monaco.editor.IContentWidget = {
+    getId: () => WIDGET_ID,
+    getDomNode: () => node,
+    suppressMouseDown: true,
+    allowEditorOverflow: true,
+    getPosition: () =>
+      position
+        ? {
+            position,
+            preference: [monacoEditor.ContentWidgetPositionPreference.EXACT],
+          }
+        : null,
+  };
+
+  editor.addContentWidget(widget);
+
+  return {
+    show(lineNumber, column, content) {
+      node.textContent = content;
+      position = { lineNumber, column };
+      editor.layoutContentWidget(widget);
+    },
+    hide() {
+      if (!position && node.textContent === "") return;
+      node.textContent = "";
+      position = null;
+      editor.layoutContentWidget(widget);
+    },
+    dispose() {
+      editor.removeContentWidget(widget);
+    },
+  };
+}

--- a/windows/tauri/src/features/editor/engines/monaco/line-endings.test.ts
+++ b/windows/tauri/src/features/editor/engines/monaco/line-endings.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { documentUsesCrlf, monacoModelMatchesContent, toMonacoModelValue } from "./line-endings";
+
+describe("monaco line endings", () => {
+  test("strips CRLF so line text does not keep a trailing carriage return", () => {
+    const content = "    private int code;\r\n    private String message;\r\n";
+
+    expect(documentUsesCrlf(content)).toBe(true);
+    expect(toMonacoModelValue(content)).toBe("    private int code;\n    private String message;\n");
+    expect(toMonacoModelValue(content).split("\n")[0]).toBe("    private int code;");
+  });
+
+  test("treats LF and CRLF documents as the same model text", () => {
+    const crlf = "class Demo {\r\n}\r\n";
+    const lf = "class Demo {\n}\n";
+
+    expect(monacoModelMatchesContent(lf, crlf)).toBe(true);
+    expect(monacoModelMatchesContent(crlf, lf)).toBe(true);
+  });
+
+  test("leaves LF documents unchanged", () => {
+    const content = "private int code;\n";
+
+    expect(documentUsesCrlf(content)).toBe(false);
+    expect(toMonacoModelValue(content)).toBe(content);
+  });
+});

--- a/windows/tauri/src/features/editor/engines/monaco/line-endings.ts
+++ b/windows/tauri/src/features/editor/engines/monaco/line-endings.ts
@@ -1,0 +1,17 @@
+/**
+ * Monaco keeps a separate EOL setting. If a model is created or later updated
+ * with LF while the buffer still contains CRLF, `\r` stays on the line and
+ * mouse hit-testing cannot land after the last visible character.
+ */
+export function documentUsesCrlf(content: string): boolean {
+  return content.includes("\r\n");
+}
+
+export function toMonacoModelValue(content: string): string {
+  if (!content.includes("\r")) return content;
+  return content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+export function monacoModelMatchesContent(modelValue: string, content: string): boolean {
+  return toMonacoModelValue(modelValue) === toMonacoModelValue(content);
+}

--- a/windows/tauri/src/features/editor/engines/monaco/model-content.ts
+++ b/windows/tauri/src/features/editor/engines/monaco/model-content.ts
@@ -1,0 +1,16 @@
+import { editor as monacoEditor } from "monaco-editor";
+import type * as Monaco from "monaco-editor";
+import { documentUsesCrlf, toMonacoModelValue } from "./line-endings";
+
+export function applyMonacoModelContent(model: Monaco.editor.ITextModel, content: string): void {
+  const value = toMonacoModelValue(content);
+  const wantsCrlf = documentUsesCrlf(content);
+  if (toMonacoModelValue(model.getValue()) !== value) {
+    model.setValue(value);
+  }
+  if ((model.getEOL() === "\r\n") !== wantsCrlf) {
+    model.setEOL(
+      wantsCrlf ? monacoEditor.EndOfLineSequence.CRLF : monacoEditor.EndOfLineSequence.LF,
+    );
+  }
+}

--- a/windows/tauri/src/features/editor/engines/monaco/model-lifecycle.ts
+++ b/windows/tauri/src/features/editor/engines/monaco/model-lifecycle.ts
@@ -1,5 +1,7 @@
 import { editor as monacoEditor } from "monaco-editor";
 import type * as Monaco from "monaco-editor";
+import { applyMonacoModelContent } from "./model-content";
+import { toMonacoModelValue } from "./line-endings";
 
 interface SharedMonacoModel {
   model: Monaco.editor.ITextModel;
@@ -21,7 +23,12 @@ export function acquireMonacoModel(
   const key = uri.toString();
   let entry = sharedModels.get(key);
   if (!entry || entry.model.isDisposed()) {
-    const model = monacoEditor.getModel(uri) ?? monacoEditor.createModel(content, languageId, uri);
+    const existing = monacoEditor.getModel(uri);
+    const model =
+      existing ?? monacoEditor.createModel(toMonacoModelValue(content), languageId, uri);
+    if (!existing) {
+      applyMonacoModelContent(model, content);
+    }
     entry = { model, referenceCount: 0 };
     sharedModels.set(key, entry);
   }

--- a/windows/tauri/src/features/editor/lsp/code-lens-overlay.tsx
+++ b/windows/tauri/src/features/editor/lsp/code-lens-overlay.tsx
@@ -115,7 +115,7 @@ const CodeLensOverlay = forwardRef(
           return (
             <div
               key={line}
-              className="absolute"
+              className="pointer-events-none absolute"
               style={{
                 top: `${top}px`,
                 left: `${left}px`,

--- a/windows/tauri/src/features/editor/stores/state.store.ts
+++ b/windows/tauri/src/features/editor/stores/state.store.ts
@@ -164,7 +164,9 @@ const ensureCursorVisible = (position: Position) => {
       : null;
   const textarea = scopedTextarea ?? focusedTextarea;
 
-  if (!textarea) return;
+  // Monaco's hidden inputarea is not a full-document textarea. Scrolling it
+  // desyncs the visual caret from Backspace/Delete and mouse selection.
+  if (!textarea || textarea.classList.contains("inputarea")) return;
 
   const computedStyle = window.getComputedStyle(textarea);
   const lineHeight =

--- a/windows/tauri/src/features/editor/styles/monaco-editor.css
+++ b/windows/tauri/src/features/editor/styles/monaco-editor.css
@@ -68,6 +68,8 @@
   color: var(--subtle-foreground, rgba(128, 128, 128, 0.78));
   opacity: 0.8;
   white-space: nowrap;
+  pointer-events: none;
+  user-select: none;
 }
 
 .monaco-editor-shell .monaco-resizable-hover,

--- a/windows/tauri/src/features/editor/view-model/view-layout.test.ts
+++ b/windows/tauri/src/features/editor/view-model/view-layout.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { EDITOR_CONSTANTS } from "../config/constants";
+import { buildEditorViewLayout } from "./view-layout";
+
+const CHAR_WIDTH = 8;
+
+function measureText(text: string): number {
+  let width = 0;
+  for (const char of text) {
+    if (char !== "\r") width += CHAR_WIDTH;
+  }
+  return width;
+}
+
+describe("editorPointToModelPosition", () => {
+  test("places the caret after the last visible character when clicking the line end", () => {
+    const line = "    private int code;";
+    const layout = buildEditorViewLayout({
+      lines: [line],
+      lineHeight: 20,
+      wordWrap: false,
+      contentWidth: 800,
+      measureText,
+    });
+
+    const endX = EDITOR_CONSTANTS.EDITOR_PADDING_LEFT + measureText(line);
+    const atEnd = layout.editorPointToModelPosition(endX, EDITOR_CONSTANTS.EDITOR_PADDING_TOP + 2);
+    const pastEnd = layout.editorPointToModelPosition(
+      endX + CHAR_WIDTH * 4,
+      EDITOR_CONSTANTS.EDITOR_PADDING_TOP + 2,
+    );
+    const rightHalfOfSemicolon = layout.editorPointToModelPosition(
+      endX - CHAR_WIDTH / 4,
+      EDITOR_CONSTANTS.EDITOR_PADDING_TOP + 2,
+    );
+
+    expect(atEnd.column).toBe(line.length);
+    expect(pastEnd.column).toBe(line.length);
+    expect(rightHalfOfSemicolon.column).toBe(line.length);
+  });
+
+  test("does not treat a trailing carriage return as a visible column", () => {
+    const visualLine = "    private int code;";
+    const layout = buildEditorViewLayout({
+      lines: [`${visualLine}\r`],
+      lineHeight: 20,
+      wordWrap: false,
+      contentWidth: 800,
+      measureText,
+    });
+
+    const endX = EDITOR_CONSTANTS.EDITOR_PADDING_LEFT + measureText(visualLine);
+    const pastEnd = layout.editorPointToModelPosition(
+      endX + CHAR_WIDTH,
+      EDITOR_CONSTANTS.EDITOR_PADDING_TOP + 2,
+    );
+
+    expect(pastEnd.column).toBe(visualLine.length);
+  });
+});

--- a/windows/tauri/src/features/editor/view-model/view-layout.ts
+++ b/windows/tauri/src/features/editor/view-model/view-layout.ts
@@ -225,6 +225,16 @@ function findSegmentForModelPosition(
   return segments[lastViewLine] ?? firstSegment;
 }
 
+function visibleEndColumn(lineText: string, startColumn: number, endColumn: number): number {
+  // A trailing CR is not a visible caret stop. Leaving it in the hit-test range
+  // makes the last rendered character unclickable on CRLF files.
+  let column = endColumn;
+  while (column > startColumn && lineText.charCodeAt(column - 1) === 13) {
+    column--;
+  }
+  return column;
+}
+
 function findColumnForSegmentX(
   lineText: string,
   segment: ViewLineSegment,
@@ -232,12 +242,13 @@ function findColumnForSegmentX(
   measureText: (text: string) => number,
 ): number {
   const localX = Math.max(0, x - EDITOR_CONSTANTS.EDITOR_PADDING_LEFT);
-  if (segment.endColumn <= segment.startColumn || localX <= 0) {
+  const endColumn = visibleEndColumn(lineText, segment.startColumn, segment.endColumn);
+  if (endColumn <= segment.startColumn || localX <= 0) {
     return segment.startColumn;
   }
 
   let low = segment.startColumn;
-  let high = segment.endColumn;
+  let high = endColumn;
   while (low < high) {
     const mid = Math.ceil((low + high) / 2);
     const width = measureText(lineText.slice(segment.startColumn, mid));
@@ -250,11 +261,9 @@ function findColumnForSegmentX(
 
   const currentWidth = measureText(lineText.slice(segment.startColumn, low));
   const nextWidth =
-    low < segment.endColumn
-      ? measureText(lineText.slice(segment.startColumn, low + 1))
-      : currentWidth;
+    low < endColumn ? measureText(lineText.slice(segment.startColumn, low + 1)) : currentWidth;
 
-  return nextWidth - localX < localX - currentWidth ? Math.min(segment.endColumn, low + 1) : low;
+  return nextWidth - localX < localX - currentWidth ? Math.min(endColumn, low + 1) : low;
 }
 
 export function buildEditorViewLayout({


### PR DESCRIPTION
## Summary
- 修复 Windows Monaco 编辑器无法把光标点到行尾、也无法拖选整行删除的问题。
- 行尾 Git Blame 不再注入到文本里，避免挡住最后一个字符并在拖选时打断选区。
- 规范化 CRLF 换行，并关闭错误的等宽宽度缓存，让点击位置和光标对齐。

## Test plan
- [x] 打开 Java 文件（如 ``BaseResponse.java``），点击 ``private int code;`` 行尾，光标应停在分号后面
- [x] 按 Backspace 应删除分号，而不是分号前的字符
- [x] 从行首拖到行尾，或点击左侧行号，应能选中整行并删除
- [x] 关闭并重新打开该文件后，上述行为仍然正常