### PR TITLE
fix(ci): bind Windows packaging arguments by name

### DIFF
--- a/.github/workflows/release-preview-windows.yml
+++ b/.github/workflows/release-preview-windows.yml
@@ -90,12 +90,12 @@ jobs:
           LITHE_WINDOWS_TIMESTAMP_SERVER: ${{ secrets.WINDOWS_TIMESTAMP_SERVER }}
           WINDOWS_RELEASE_SIGNED: ${{ steps.signing.outputs.signed }}
         run: |
-          $packageArgs = @(
-            "-Configuration", "Release",
-            "-Version", $env:LITHE_VERSION
-          )
+          $packageArgs = @{
+            Configuration = "Release"
+            Version = $env:LITHE_VERSION
+          }
           if ($env:WINDOWS_RELEASE_SIGNED -eq "true") {
-            $packageArgs += "-RequireAuthenticodeSignature"
+            $packageArgs.RequireAuthenticodeSignature = $true
           } else {
             Write-Output "Packaging an unsigned Windows preview installer."
           }

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -88,12 +88,12 @@ jobs:
           LITHE_WINDOWS_TIMESTAMP_SERVER: ${{ secrets.WINDOWS_TIMESTAMP_SERVER }}
           WINDOWS_RELEASE_SIGNED: ${{ steps.signing.outputs.signed }}
         run: |
-          $packageArgs = @(
-            "-Configuration", "Release",
-            "-Version", $env:LITHE_VERSION
-          )
+          $packageArgs = @{
+            Configuration = "Release"
+            Version = $env:LITHE_VERSION
+          }
           if ($env:WINDOWS_RELEASE_SIGNED -eq "true") {
-            $packageArgs += "-RequireAuthenticodeSignature"
+            $packageArgs.RequireAuthenticodeSignature = $true
           } else {
             Write-Output "Packaging an unsigned Windows installer."
           }


### PR DESCRIPTION
Fix the Windows preview and release workflows to use PowerShell hashtable splatting when invoking package-windows.ps1. Array splatting passed -Configuration as the positional Configuration value and caused packaging to fail before the script ran.\n\nValidation:\n- actionlint on both workflows\n- PowerShell binding check for signed and unsigned modes\n- ./scripts/verify-windows-boundaries.sh