### PR TITLE
Check for Windows updates on startup

### DIFF
--- a/windows/winui/MainWindow.xaml.cpp
+++ b/windows/winui/MainWindow.xaml.cpp
@@ -3307,6 +3307,10 @@ fire_and_forget MainWindow::ConfigureAICommitClick(IInspectable const&, RoutedEv
 }
 
 void MainWindow::CheckForUpdatesClick(IInspectable const&, RoutedEventArgs const&) {
+    checkForUpdates();
+}
+
+void MainWindow::checkForUpdates() {
 #if defined(_M_ARM64)
     session_->checkForUpdates("arm64");
 #elif defined(_M_X64)
@@ -4012,6 +4016,10 @@ void MainWindow::RootLoaded(IInspectable const&, RoutedEventArgs const&) {
         showWelcomeSurface();
     } else {
         showWorkbenchSurface();
+    }
+    if (!startupUpdateCheckStarted_) {
+        startupUpdateCheckStarted_ = true;
+        checkForUpdates();
     }
 }
 

--- a/windows/winui/MainWindow.xaml.h
+++ b/windows/winui/MainWindow.xaml.h
@@ -227,6 +227,7 @@ struct MainWindow : MainWindowT<MainWindow> {
 private:
     void showWelcomeSurface();
     void showWorkbenchSurface();
+    void checkForUpdates();
     void renderWelcomeProjects(std::string query = {});
     struct NavigationTarget {
         std::string relativePath;
@@ -412,6 +413,7 @@ private:
     bool externalConflictVisible_ = false;
     bool terminalUiUpdating_ = false;
     bool showWelcomeOnLoad_ = false;
+    bool startupUpdateCheckStarted_ = false;
     std::uint64_t terminalRevision_ = 0;
     double bottomPanelHeight_ = 290.0;
 };


### PR DESCRIPTION
## What changed

- Keep the Windows welcome-page **Check for Updates** action wired to the shared update flow.
- Trigger one automatic update check after the WinUI root has loaded.
- Reuse the existing release dialog so only an available update opens a modal; up-to-date and failure results remain status-only.
- Guard the startup trigger so repeated `Loaded` events do not start duplicate checks.

## Why

Windows users should be able to check from the home page and should learn about new releases on the first app launch without navigating into Settings.

## Validation

- `scripts/verify-windows-boundaries.ps1`
- `scripts/build-windows.ps1 -Configuration Release -BuildWinUI`
- `ctest --test-dir windows/build-windows -C Release --output-on-failure` (18/18 passed)
