### PR TITLE
fix(windows): suppress console flashes and align project tabs

### DIFF
--- a/rust/lithe-core/src/lsp/interface/process.rs
+++ b/rust/lithe-core/src/lsp/interface/process.rs
@@ -13,6 +13,9 @@ use std::path::PathBuf;
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::{Arc, Mutex};
 
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 /// Everything needed to start a language server, after provider adaptation has
 /// already rewritten the arguments.
 pub struct LspProcessSpec {
@@ -75,6 +78,7 @@ impl LspProcessLauncher for SystemProcessLauncher {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        apply_language_server_creation_flags(&mut command);
         let mut child = command.spawn().map_err(|error| {
             CoreError::new(
                 ErrorCode::ProcessStartFailed,
@@ -100,6 +104,20 @@ impl LspProcessLauncher for SystemProcessLauncher {
             errors: Box::new(stderr),
         })
     }
+}
+
+fn apply_language_server_creation_flags(command: &mut Command) {
+    #[cfg(target_os = "windows")]
+    command.creation_flags(language_server_process_creation_flags());
+
+    #[cfg(not(target_os = "windows"))]
+    let _ = command;
+}
+
+#[cfg(target_os = "windows")]
+fn language_server_process_creation_flags() -> u32 {
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    CREATE_NO_WINDOW
 }
 
 struct SystemProcess {
@@ -165,4 +183,12 @@ fn missing_stream(stream: &str) -> CoreError {
         "A language-server standard stream was unavailable.",
     )
     .with_details(stream)
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    #[test]
+    fn background_language_servers_do_not_create_windows_console() {
+        assert_eq!(super::language_server_process_creation_flags(), 0x0800_0000);
+    }
 }

--- a/windows/tauri/src-tauri/src/host.rs
+++ b/windows/tauri/src-tauri/src/host.rs
@@ -371,6 +371,12 @@ mod tests {
         assert!(widths.contains(&32), "{widths:?}");
         assert!(widths.contains(&256), "{widths:?}");
     }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn background_font_queries_do_not_create_windows_console() {
+        assert_eq!(super::font_query_process_creation_flags(), 0x0800_0000);
+    }
 }
 
 #[tauri::command]
@@ -431,13 +437,17 @@ pub fn validate_font(font_family: String) -> bool {
 
 #[cfg(target_os = "windows")]
 fn platform_fonts() -> Vec<FontInfo> {
+    use std::os::windows::process::CommandExt;
     use std::process::Command;
-    let output = Command::new("reg.exe")
+
+    let mut command = Command::new("reg.exe");
+    command
         .args([
             "query",
             r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts",
         ])
-        .output();
+        .creation_flags(font_query_process_creation_flags());
+    let output = command.output();
     let text = output
         .ok()
         .filter(|value| value.status.success())
@@ -466,6 +476,12 @@ fn platform_fonts() -> Vec<FontInfo> {
             style: "Regular".into(),
         })
         .collect()
+}
+
+#[cfg(target_os = "windows")]
+fn font_query_process_creation_flags() -> u32 {
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    CREATE_NO_WINDOW
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/windows/tauri/src/features/window/components/project-tab-bar.test.ts
+++ b/windows/tauri/src/features/window/components/project-tab-bar.test.ts
@@ -17,4 +17,8 @@ test("project tab bar exposes accessible switchable and closable project tabs", 
   expect(source).toContain('t("titleProject.closeProject", { name: project.name })');
   expect(source).toContain("group-hover:opacity-100");
   expect(source).toContain("group-focus-within:opacity-100");
+  expect(source).toContain(
+    "absolute inset-y-0 right-1 z-10 flex items-center transition-opacity",
+  );
+  expect(source).not.toContain("-translate-y-1/2");
 });

--- a/windows/tauri/src/features/window/components/project-tab-bar.tsx
+++ b/windows/tauri/src/features/window/components/project-tab-bar.tsx
@@ -75,26 +75,29 @@ export function ProjectTabBar() {
                   />
                 ) : null}
               </button>
-              <Button
-                type="button"
-                size="icon-xs"
-                variant="ghost"
-                aria-label={closeLabel}
-                tooltip={closeLabel}
-                disabled={isProjectActionPending}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  void handleCloseProject(project.id);
-                }}
+              <div
                 className={cn(
-                  "absolute top-1/2 right-1 z-10 -translate-y-1/2 transition-opacity",
+                  "absolute inset-y-0 right-1 z-10 flex items-center transition-opacity",
                   project.isActive
                     ? "opacity-100"
                     : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
                 )}
               >
-                <X className="pointer-events-none select-none" aria-hidden="true" />
-              </Button>
+                <Button
+                  type="button"
+                  size="icon-xs"
+                  variant="ghost"
+                  aria-label={closeLabel}
+                  tooltip={closeLabel}
+                  disabled={isProjectActionPending}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void handleCloseProject(project.id);
+                  }}
+                >
+                  <X className="pointer-events-none select-none" aria-hidden="true" />
+                </Button>
+              </div>
             </div>
           );
         })}


### PR DESCRIPTION
## Summary

- prevent Windows language-server launches from opening visible background console windows
- prevent the registry-based font query from flashing a console while keeping explicit ConPTY terminals unchanged
- vertically center project-tab close controls with the folder icon and project name
- add focused regression coverage for both process flags and tab alignment

## Verification

- focused and full Rust tests
- `scripts/verify-windows-boundaries.ps1`
- `bun run typecheck`
- targeted frontend lint and project-tab component test
- `bun run build`
- native Windows debug build and real Tauri-window runtime/visual checks

Related to #132