### PR TITLE
fix(windows): 修复 Git 记录鼠标滚轮偶发无法滚动

### DIFF
--- a/windows/tauri/src/features/git/components/log/git-commit-table.tsx
+++ b/windows/tauri/src/features/git/components/log/git-commit-table.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -8,6 +8,7 @@ import {
   ContextMenuShortcut,
   ContextMenuTrigger,
 } from "@/ui/context-menu";
+import { bindScrollContainerWheel } from "@/ui/scroll-container-wheel";
 import {
   CopyIcon as Copy,
   EyeIcon as Eye,
@@ -72,6 +73,12 @@ export function GitCommitTable({
     estimateSize: () => ROW_HEIGHT,
     overscan: 14,
   });
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    return bindScrollContainerWheel(element);
+  }, []);
 
   useEffect(() => {
     if (!selectedCommit) return;
@@ -183,7 +190,11 @@ export function GitCommitTable({
         <span className="w-32 shrink-0 text-right">{t("git.log.date")}</span>
       </div>
 
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
+      <div
+        ref={scrollRef}
+        data-scroll-container=""
+        className="min-h-0 flex-1 overflow-auto [overflow-anchor:none]"
+      >
         {visibleRows.length === 0 ? (
           <div className="flex h-full items-center justify-center text-subtle-foreground">
             {query ? t("git.log.noMatch") : t("git.log.noCommits")}
@@ -216,10 +227,10 @@ export function GitCommitTable({
                       title={t("git.log.openDiffHint")}
                     >
                       <GitGraphRow row={row} showDecorations={showDecorations} />
-                      <span className="w-28 shrink-0 truncate px-2 text-subtle-foreground">
+                      <span className="w-28 shrink-0 overflow-clip px-2 text-ellipsis whitespace-nowrap text-subtle-foreground">
                         {row.commit.author}
                       </span>
-                      <span className="w-32 shrink-0 truncate text-right font-mono text-[11px] text-subtle-foreground">
+                      <span className="w-32 shrink-0 overflow-clip text-ellipsis whitespace-nowrap text-right font-mono text-[11px] text-subtle-foreground">
                         {row.commit.date}
                       </span>
                     </ContextMenuTrigger>

--- a/windows/tauri/src/features/git/components/log/git-graph-row.tsx
+++ b/windows/tauri/src/features/git/components/log/git-graph-row.tsx
@@ -34,7 +34,7 @@ export function GitGraphRow({ row, showDecorations }: { row: GraphRow; showDecor
         aria-hidden="true"
         width={width}
         height={ROW_HEIGHT}
-        className="shrink-0 overflow-visible"
+        className="pointer-events-none shrink-0 overflow-visible"
       >
         {row.incomingLaneColors.map((colorIndex, lane) => {
           if (colorIndex === null) return null;
@@ -78,13 +78,13 @@ export function GitGraphRow({ row, showDecorations }: { row: GraphRow; showDecor
         />
       </svg>
 
-      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-clip">
         {showDecorations &&
           row.labels.map((label, index) => (
             <span
               key={`${label.kind}:${label.title}:${index}`}
               className={cn(
-                "max-w-28 shrink-0 truncate rounded border px-1.5 py-0.5 font-medium text-[10px] leading-none",
+                "max-w-28 shrink-0 overflow-clip text-ellipsis whitespace-nowrap rounded border px-1.5 py-0.5 font-medium text-[10px] leading-none",
                 gitGraphLabelClassName(label),
               )}
               title={label.title}
@@ -92,7 +92,10 @@ export function GitGraphRow({ row, showDecorations }: { row: GraphRow; showDecor
               {label.title}
             </span>
           ))}
-        <span className="min-w-0 flex-1 truncate text-foreground" title={row.commit.message}>
+        <span
+          className="min-w-0 flex-1 overflow-clip text-ellipsis whitespace-nowrap text-foreground"
+          title={row.commit.message}
+        >
           {row.commit.message}
         </span>
       </div>


### PR DESCRIPTION
## Summary
- 修复 Windows Git 记录在反复滑动时偶发无法滚动的问题。
- WebView2 会把滚轮锁在 `overflow:hidden` 的提交行文本上；现将滚轮交给真正的滚动容器，并把行内截断改为 `overflow:clip`，避免 hover 后卡住。

## Test plan
- [X] 打开 Windows 开发版，并打开含提交历史的仓库
- [X] 打开 Git 记录
- [X] 在提交列表上反复执行「滑动 → 停止 → 滑动」，停在某一行 hover 时列表仍能滚动
- [X] 鼠标移出或点击其他区域后再滑回，滚动仍然正常

Fixes #152
