### PR TITLE
feat(macOS): support terminal tab docking

### DIFF
--- a/Sources/Lithe/Application/Features/TerminalPlacementFeatureModel.swift
+++ b/Sources/Lithe/Application/Features/TerminalPlacementFeatureModel.swift
@@ -1,0 +1,121 @@
+import Combine
+import Foundation
+
+/// Owns where live terminal sessions are presented without taking ownership
+/// of their PTY or native surface lifecycle.
+@MainActor
+final class TerminalPlacementFeatureModel: ObservableObject {
+    @Published private(set) var toolSessionIDs: [UUID] = []
+    @Published private(set) var editorSessionIDs: [UUID] = []
+    @Published private(set) var activeEditorSessionID: UUID?
+
+    func registerSession(_ sessionID: UUID) {
+        guard !contains(sessionID) else { return }
+        toolSessionIDs.append(sessionID)
+    }
+
+    func moveToTool(_ sessionID: UUID) {
+        moveToTool(sessionID, relativeTo: nil, insertAfter: false)
+    }
+
+    func moveToTool(_ sessionID: UUID, before targetSessionID: UUID) {
+        guard sessionID != targetSessionID else { return }
+        moveToTool(sessionID, relativeTo: targetSessionID, insertAfter: false)
+    }
+
+    func moveToTool(_ sessionID: UUID, after targetSessionID: UUID) {
+        guard sessionID != targetSessionID else { return }
+        moveToTool(sessionID, relativeTo: targetSessionID, insertAfter: true)
+    }
+
+    func moveToEditor(_ sessionID: UUID) {
+        moveToEditor(sessionID, relativeTo: nil, insertAfter: false)
+    }
+
+    func moveToEditor(_ sessionID: UUID, before targetSessionID: UUID) {
+        guard sessionID != targetSessionID else { return }
+        moveToEditor(sessionID, relativeTo: targetSessionID, insertAfter: false)
+    }
+
+    func moveToEditor(_ sessionID: UUID, after targetSessionID: UUID) {
+        guard sessionID != targetSessionID else { return }
+        moveToEditor(sessionID, relativeTo: targetSessionID, insertAfter: true)
+    }
+
+    func activateEditorSession(_ sessionID: UUID) {
+        guard editorSessionIDs.contains(sessionID) else { return }
+        activeEditorSessionID = sessionID
+    }
+
+    func activateDocument() {
+        activeEditorSessionID = nil
+    }
+
+    func removeSession(_ sessionID: UUID) {
+        toolSessionIDs.removeAll { $0 == sessionID }
+        editorSessionIDs.removeAll { $0 == sessionID }
+        if activeEditorSessionID == sessionID {
+            activeEditorSessionID = editorSessionIDs.last
+        }
+    }
+
+    func reset() {
+        toolSessionIDs = []
+        editorSessionIDs = []
+        activeEditorSessionID = nil
+    }
+
+    private func contains(_ sessionID: UUID) -> Bool {
+        toolSessionIDs.contains(sessionID) || editorSessionIDs.contains(sessionID)
+    }
+
+    private func moveToTool(
+        _ sessionID: UUID,
+        relativeTo targetSessionID: UUID?,
+        insertAfter: Bool
+    ) {
+        guard contains(sessionID) else { return }
+        editorSessionIDs.removeAll { $0 == sessionID }
+        toolSessionIDs.removeAll { $0 == sessionID }
+        insert(
+            sessionID,
+            into: &toolSessionIDs,
+            relativeTo: targetSessionID,
+            insertAfter: insertAfter
+        )
+        if activeEditorSessionID == sessionID {
+            activeEditorSessionID = editorSessionIDs.last
+        }
+    }
+
+    private func moveToEditor(
+        _ sessionID: UUID,
+        relativeTo targetSessionID: UUID?,
+        insertAfter: Bool
+    ) {
+        guard contains(sessionID) else { return }
+        toolSessionIDs.removeAll { $0 == sessionID }
+        editorSessionIDs.removeAll { $0 == sessionID }
+        insert(
+            sessionID,
+            into: &editorSessionIDs,
+            relativeTo: targetSessionID,
+            insertAfter: insertAfter
+        )
+        activeEditorSessionID = sessionID
+    }
+
+    private func insert(
+        _ sessionID: UUID,
+        into sessionIDs: inout [UUID],
+        relativeTo targetSessionID: UUID?,
+        insertAfter: Bool
+    ) {
+        guard let targetSessionID,
+              let targetIndex = sessionIDs.firstIndex(of: targetSessionID) else {
+            sessionIDs.append(sessionID)
+            return
+        }
+        sessionIDs.insert(sessionID, at: targetIndex + (insertAfter ? 1 : 0))
+    }
+}

--- a/Sources/Lithe/Models/AppModel/AppModel+Terminal.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel+Terminal.swift
@@ -23,6 +23,24 @@ extension AppModel {
     var terminalSessions: [TerminalSession] { terminalFeature?.terminalSessions ?? [] }
     var activeTerminalSessionID: UUID? { terminalFeature?.activeTerminalSessionID }
     var activeTerminalSession: TerminalSession? { terminalFeature?.activeTerminalSession }
+    var toolTerminalSessions: [TerminalSession] {
+        sessions(orderedBy: terminalPlacementFeature.toolSessionIDs)
+    }
+    var editorTerminalSessions: [TerminalSession] {
+        sessions(orderedBy: terminalPlacementFeature.editorSessionIDs)
+    }
+    var activeToolTerminalSession: TerminalSession? {
+        let toolSessions = toolTerminalSessions
+        if let activeTerminalSessionID,
+           let activeSession = toolSessions.first(where: { $0.id == activeTerminalSessionID }) {
+            return activeSession
+        }
+        return toolSessions.first
+    }
+    var activeEditorTerminalSession: TerminalSession? {
+        guard let sessionID = terminalPlacementFeature.activeEditorSessionID else { return nil }
+        return terminalSessions.first { $0.id == sessionID }
+    }
     func terminalTitle(for session: TerminalSession) -> String { terminalFeature?.terminalTitle(for: session) ?? "Local" }
 
     @discardableResult
@@ -37,6 +55,7 @@ extension AppModel {
         }
         let session = feature.createSession(in: workspaceURL, shellPath: shellPath ?? settings.terminalShellPath)
         configureTerminalSession(session)
+        terminalPlacementFeature.registerSession(session.id)
         isTerminalVisible = true
         isTestsVisible = false
         isGitLogVisible = false
@@ -81,12 +100,64 @@ extension AppModel {
     }
 
     func selectTerminalSession(_ session: TerminalSession) {
+        guard terminalPlacementFeature.toolSessionIDs.contains(session.id) else { return }
         guard terminalFeature?.selectSession(session) == true else { return }
+        isTerminalVisible = true
+    }
+
+    func selectEditorTerminalSession(_ session: TerminalSession) {
+        guard terminalPlacementFeature.editorSessionIDs.contains(session.id),
+              terminalFeature?.selectSession(session) == true else { return }
+        terminalPlacementFeature.activateEditorSession(session.id)
+    }
+
+    func selectEditorDocument(_ document: EditorDocument) {
+        terminalPlacementFeature.activateDocument()
+        activeDocumentID = document.id
+    }
+
+    func moveTerminalToEditor(_ sessionID: UUID) {
+        guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
+        terminalPlacementFeature.moveToEditor(sessionID)
+        _ = terminalFeature?.selectSession(session)
+    }
+
+    func moveTerminalToEditor(_ sessionID: UUID, before targetSessionID: UUID) {
+        guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
+        terminalPlacementFeature.moveToEditor(sessionID, before: targetSessionID)
+        _ = terminalFeature?.selectSession(session)
+    }
+
+    func moveTerminalToEditor(_ sessionID: UUID, after targetSessionID: UUID) {
+        guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
+        terminalPlacementFeature.moveToEditor(sessionID, after: targetSessionID)
+        _ = terminalFeature?.selectSession(session)
+    }
+
+    func moveTerminalToTool(_ sessionID: UUID) {
+        guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
+        terminalPlacementFeature.moveToTool(sessionID)
+        _ = terminalFeature?.selectSession(session)
+        isTerminalVisible = true
+    }
+
+    func moveTerminalToTool(_ sessionID: UUID, before targetSessionID: UUID) {
+        guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
+        terminalPlacementFeature.moveToTool(sessionID, before: targetSessionID)
+        _ = terminalFeature?.selectSession(session)
+        isTerminalVisible = true
+    }
+
+    func moveTerminalToTool(_ sessionID: UUID, after targetSessionID: UUID) {
+        guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
+        terminalPlacementFeature.moveToTool(sessionID, after: targetSessionID)
+        _ = terminalFeature?.selectSession(session)
         isTerminalVisible = true
     }
 
     func closeTerminalSession(_ session: TerminalSession) {
         guard terminalSessions.contains(where: { $0.id == session.id }) else { return }
+        terminalPlacementFeature.removeSession(session.id)
         terminalFeature?.closeSession(session)
         if terminalSessions.isEmpty {
             isTerminalVisible = false
@@ -96,9 +167,17 @@ extension AppModel {
 
     func restartActiveTerminal() { terminalFeature?.restartActiveSession() }
     func restartActiveTerminal(using shellPath: String) { terminalFeature?.restartActiveSession(using: shellPath) }
-    func stopTerminalSessions() { terminalFeature?.stopAllSessions() }
+    func stopTerminalSessions() {
+        terminalPlacementFeature.reset()
+        terminalFeature?.stopAllSessions()
+    }
 
     var activeTerminalShellPath: String {
         settings.terminalShellPath ?? terminalFeature?.availableShells.first ?? "/bin/zsh"
+    }
+
+    private func sessions(orderedBy sessionIDs: [UUID]) -> [TerminalSession] {
+        let sessionsByID = Dictionary(uniqueKeysWithValues: terminalSessions.map { ($0.id, $0) })
+        return sessionIDs.compactMap { sessionsByID[$0] }
     }
 }

--- a/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -162,6 +162,7 @@ final class AppModel: ObservableObject, Identifiable {
     let workspaceFeature: WorkspaceFeatureModel
     let githubFeature: GitHubFeatureModel
     let discourseCommunityFeature: DiscourseCommunityFeatureModel
+    let terminalPlacementFeature: TerminalPlacementFeatureModel
     private struct CachedModuleCapability {
         let moduleID: ModuleID
         let value: AnyObject
@@ -274,6 +275,8 @@ final class AppModel: ObservableObject, Identifiable {
     private var workspaceFeatureObservation: AnyCancellable?
     private var githubFeatureObservation: AnyCancellable?
     private var runtimeFeatureObservation: AnyCancellable?
+    private var terminalPlacementObservation: AnyCancellable?
+    private var activeDocumentSelectionObservation: AnyCancellable?
     private var moduleRuntimeObservationID: UUID?
 
     var detectedCodexConfiguration: CodexConfigurationSnapshot? {
@@ -357,6 +360,7 @@ final class AppModel: ObservableObject, Identifiable {
         platformUI = services.platformUI
         keyboardShortcutFeature = KeyboardShortcutFeatureModel(settings: settings)
         discourseCommunityFeature = DiscourseCommunityFeatureModel(service: services.discourseCommunityService)
+        terminalPlacementFeature = TerminalPlacementFeatureModel()
         workspaceFeature = WorkspaceFeatureModel(
             operations: services.workspaceOperations,
             fileOperations: services.fileOperations,
@@ -422,6 +426,15 @@ final class AppModel: ObservableObject, Identifiable {
         navigationHistoryFeatureObservation = navigationHistoryFeature.objectWillChange.sink { [weak self] _ in
             self?.scheduleObjectWillChangeRelay()
         }
+        terminalPlacementObservation = terminalPlacementFeature.objectWillChange.sink { [weak self] _ in
+            self?.scheduleObjectWillChangeRelay()
+        }
+        activeDocumentSelectionObservation = documentFeature.$activeDocumentID
+            .dropFirst()
+            .sink { [weak self] documentID in
+                guard documentID != nil else { return }
+                self?.terminalPlacementFeature.activateDocument()
+            }
         Task { [weak self] in
             guard let self else { return }
             await self.githubFeature.restore(workspaceURL: self.workspaceURL)

--- a/Sources/Lithe/Views/App/RootView.swift
+++ b/Sources/Lithe/Views/App/RootView.swift
@@ -178,7 +178,9 @@ private struct ActiveSessionChrome: View {
         if windowLayout == .standalone {
             return projectSessions.activeModel.standaloneFileURL?.lastPathComponent ?? "Lithe"
         }
-        guard windowLayout == .welcome else { return nil }
+        if windowLayout == .workspace {
+            return projectSessions.activeModel.workspaceURL?.lastPathComponent ?? "Lithe"
+        }
         return String(
             localized: "Welcome to Lithe",
             bundle: .main,
@@ -342,7 +344,7 @@ final class LitheWindowCoordinator: NSObject, NSWindowDelegate {
         if let title {
             window.title = title
             window.titlebarAppearsTransparent = true
-            window.titleVisibility = .visible
+            window.titleVisibility = layout == .workspace ? .hidden : .visible
         } else {
             window.title = ""
             window.titleVisibility = .hidden

--- a/Sources/Lithe/Views/Editor/CodeEditorView.swift
+++ b/Sources/Lithe/Views/Editor/CodeEditorView.swift
@@ -244,6 +244,9 @@ struct CodeEditorView: NSViewRepresentable {
         textView.onPasteImage = { [weak coordinator = context.coordinator] in
             coordinator?.pasteMarkdownImage() ?? false
         }
+        textView.onTerminalTabDrop = { [weak coordinator = context.coordinator] sessionID in
+            coordinator?.moveTerminalToEditor(sessionID) ?? false
+        }
 
         scrollView.documentView = textView
         gutter.attach(textView: textView, scrollView: scrollView)
@@ -660,6 +663,15 @@ struct CodeEditorView: NSViewRepresentable {
                     model.showNotification("Could not paste image: \(error.localizedDescription)")
                 }
             }
+            return true
+        }
+
+        func moveTerminalToEditor(_ sessionID: UUID) -> Bool {
+            guard let model,
+                  model.terminalSessions.contains(where: { $0.id == sessionID }) else {
+                return false
+            }
+            model.moveTerminalToEditor(sessionID)
             return true
         }
 
@@ -1211,6 +1223,7 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
     var onFormatRequested: (() -> Void)?
     var onCodeActionsRequested: ((Int, Int) -> Void)?
     var onPasteImage: (() -> Bool)?
+    var onTerminalTabDrop: ((UUID) -> Bool)?
 
     private var findMatchRanges: [NSRange] = []
     private var currentFindMatchIndex = 0
@@ -1266,6 +1279,46 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
     override func paste(_ sender: Any?) {
         if onPasteImage?() == true { return }
         super.paste(sender)
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard isTerminalTabDrag(sender) else { return super.draggingEntered(sender) }
+        return terminalTabDragOperation(sender)
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard isTerminalTabDrag(sender) else { return super.draggingUpdated(sender) }
+        return terminalTabDragOperation(sender)
+    }
+
+    override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard isTerminalTabDrag(sender) else { return super.prepareForDragOperation(sender) }
+        return onTerminalTabDrop != nil
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard isTerminalTabDrag(sender) else { return super.performDragOperation(sender) }
+        return performTerminalTabDrop(from: sender.draggingPasteboard)
+    }
+
+    func performTerminalTabDrop(from pasteboard: NSPasteboard) -> Bool {
+        guard let sessionID = TerminalTabDragPayload.sessionID(from: pasteboard),
+              let onTerminalTabDrop else { return false }
+        return onTerminalTabDrop(sessionID)
+    }
+
+    private func isTerminalTabDrag(_ sender: NSDraggingInfo) -> Bool {
+        sender.draggingPasteboard.availableType(
+            from: [TerminalTabDragPayload.pasteboardType]
+        ) != nil
+    }
+
+    private func terminalTabDragOperation(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard onTerminalTabDrop != nil else { return [] }
+        let sourceMask = sender.draggingSourceOperationMask
+        if sourceMask.contains(.move) { return .move }
+        if sourceMask.contains(.copy) { return .copy }
+        return []
     }
 
     override func setSelectedRange(_ charRange: NSRange) {
@@ -2637,6 +2690,7 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
         let textStorage = NSTextStorage()
         textStorage.addLayoutManager(layoutManager)
         super.init(frame: frameRect, textContainer: textContainer)
+        registerForDraggedTypes([TerminalTabDragPayload.pasteboardType])
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleFindQueryChanged(_:)),

--- a/Sources/Lithe/Views/Editor/EditorAreaView.swift
+++ b/Sources/Lithe/Views/Editor/EditorAreaView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import LitheGitModule
+import LitheTerminalModule
 
 private enum MarkdownViewMode: String, CaseIterable, Identifiable, Equatable {
     case editor
@@ -56,7 +57,7 @@ struct EditorAreaView: View {
                     DiffReviewView(change: selectedChange)
                 } else {
                     VStack(spacing: 0) {
-                        if model.openDocuments.isEmpty {
+                        if model.openDocuments.isEmpty && model.editorTerminalSessions.isEmpty {
                             emptyState
                         } else {
                             editorWorkspace
@@ -95,7 +96,9 @@ struct EditorAreaView: View {
 
     @ViewBuilder
     private var externalConflictBanner: some View {
-        if let document = model.activeDocument, document.hasExternalConflict {
+        if model.activeEditorTerminalSession == nil,
+           let document = model.activeDocument,
+           document.hasExternalConflict {
             HStack(spacing: 10) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(LitheTheme.warning)
@@ -125,6 +128,7 @@ struct EditorAreaView: View {
             editorTabLayout
                 .frame(maxWidth: .infinity, alignment: .leading)
             if let document = model.activeDocument,
+               model.activeEditorTerminalSession == nil,
                isMarkdownFile(document),
                splitDocumentID == nil {
                 markdownModePicker
@@ -153,8 +157,13 @@ struct EditorAreaView: View {
         // next to the last tab. In that case no individual tab receives
         // performDrop, so the tab bar itself must finish the session.
         .onDrop(
-            of: [EditorTabDragPayload.type],
-            delegate: EditorTabBarDropDelegate(finish: { finishTabDrag() })
+            of: [EditorTabDragPayload.type, TerminalTabDragPayload.type],
+            delegate: EditorTabBarDropDelegate(
+                finish: { finishTabDrag() },
+                receiveTerminal: { sessionID in
+                    model.moveTerminalToEditor(sessionID)
+                }
+            )
         )
     }
 
@@ -167,9 +176,13 @@ struct EditorAreaView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    @ViewBuilder
     private var editorTabItems: some View {
         ForEach(Array(model.openDocuments.enumerated()), id: \.element.id) { index, document in
             editorTab(document, at: index)
+        }
+        ForEach(model.editorTerminalSessions) { session in
+            editorTerminalTab(session)
         }
     }
 
@@ -202,7 +215,7 @@ struct EditorAreaView: View {
                 Color.clear
                     .contentShape(Rectangle())
                     .onDrop(
-                        of: [EditorTabDragPayload.type],
+                        of: [EditorTabDragPayload.type, TerminalTabDragPayload.type],
                         delegate: EditorTabDropDelegate(
                             draggedDocumentID: tabDragState.draggedDocumentID,
                             targetDocumentID: document.id,
@@ -236,7 +249,10 @@ struct EditorAreaView: View {
                                     )
                                 }
                             },
-                            finish: { finishTabDrag() }
+                            finish: { finishTabDrag() },
+                            receiveTerminal: { sessionID in
+                                model.moveTerminalToEditor(sessionID)
+                            }
                         )
                     )
             }
@@ -246,11 +262,128 @@ struct EditorAreaView: View {
         .animation(tabAnimation, value: isDragged)
     }
 
+    private func editorTerminalTab(_ session: TerminalSession) -> some View {
+        let isActive = model.activeEditorTerminalSession?.id == session.id
+
+        return HStack(spacing: 0) {
+            HStack(spacing: 7) {
+                Image(systemName: "terminal")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(isActive ? LitheTheme.accent : LitheTheme.secondaryText)
+                EditorTerminalTabTitle(
+                    session: session,
+                    fallbackTitle: model.terminalTitle(for: session)
+                )
+            }
+            .foregroundStyle(isActive ? LitheTheme.primaryText : LitheTheme.secondaryText)
+            .padding(.leading, 11)
+            .frame(height: LitheTheme.Metrics.tabHeight)
+            .contentShape(Rectangle())
+            .contentShape(
+                .dragPreview,
+                RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius)
+            )
+            .onTapGesture {
+                model.selectEditorTerminalSession(session)
+                session.focus()
+            }
+            .onDrag {
+                TerminalTabDragPayload.provider(for: session.id)
+            } preview: {
+                editorTerminalDragPreview(session)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(model.terminalTitle(for: session))
+            .accessibilityAddTraits(.isButton)
+            .accessibilityAction {
+                model.selectEditorTerminalSession(session)
+            }
+            .lithePointer()
+
+            Button {
+                model.closeTerminalSession(session)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .frame(width: 20, height: 20)
+                    .contentShape(Rectangle())
+                    .litheRowHover(cornerRadius: 10)
+            }
+            .buttonStyle(LitheTreeRowButtonStyle())
+            .lithePointer()
+            .foregroundStyle(LitheTheme.secondaryText)
+            .opacity(isActive || hoveredTabID == session.id ? 1 : 0)
+            .allowsHitTesting(isActive || hoveredTabID == session.id)
+            .padding(.trailing, 4)
+        }
+        .background(isActive ? LitheTheme.activeTabBackground : LitheTheme.inactiveTabBackground)
+        .overlay(alignment: .bottom) {
+            if isActive {
+                Rectangle().fill(LitheTheme.accent).frame(height: 2)
+            }
+        }
+        .background {
+            GeometryReader { geometry in
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onDrop(
+                        of: [TerminalTabDragPayload.type],
+                        delegate: EditorTerminalTabDropDelegate(
+                            targetSessionID: session.id,
+                            targetWidth: geometry.size.width,
+                            moveBefore: { sourceID in
+                                model.moveTerminalToEditor(sourceID, before: session.id)
+                            },
+                            moveAfter: { sourceID in
+                                model.moveTerminalToEditor(sourceID, after: session.id)
+                            }
+                        )
+                    )
+            }
+        }
+        .onHover { isHovering in
+            hoveredTabID = isHovering ? session.id : nil
+        }
+        .contextMenu {
+            Button("Move to Terminal") {
+                model.moveTerminalToTool(session.id)
+            }
+            Divider()
+            Button("Interrupt", action: session.interrupt)
+            Button("Restart", action: session.restart)
+            Button("Clear", action: session.clear)
+            Divider()
+            Button("Close") {
+                model.closeTerminalSession(session)
+            }
+        }
+    }
+
+    private func editorTerminalDragPreview(_ session: TerminalSession) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: "terminal")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(LitheTheme.accent)
+            Text(model.terminalTitle(for: session))
+                .font(.system(size: 12.5, weight: .medium))
+                .foregroundStyle(LitheTheme.primaryText)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 11)
+        .frame(height: LitheTheme.Metrics.tabHeight)
+        .background(LitheTheme.activeTabBackground)
+        .clipShape(RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius))
+        .shadow(color: .black.opacity(0.42), radius: 10, y: 6)
+    }
+
     private func editorTabContent(
         _ document: EditorDocument,
         dropSide: EditorTabDropSide? = nil
     ) -> some View {
-        HStack(spacing: 0) {
+        let isActive = model.activeEditorTerminalSession == nil
+            && model.activeDocumentID == document.id
+
+        return HStack(spacing: 0) {
             HStack(spacing: 7) {
                 LitheIcon(
                     kind: LitheIcons.kind(for: document.url, isDirectory: false),
@@ -259,7 +392,7 @@ struct EditorAreaView: View {
                 editorTabTitle(document)
                 EditorTabDirtyIndicator(document: document)
             }
-            .foregroundStyle(model.activeDocumentID == document.id ? LitheTheme.primaryText : LitheTheme.secondaryText)
+            .foregroundStyle(isActive ? LitheTheme.primaryText : LitheTheme.secondaryText)
             .padding(.leading, 11)
             .frame(height: LitheTheme.Metrics.tabHeight)
             .contentShape(Rectangle())
@@ -271,7 +404,7 @@ struct EditorAreaView: View {
             // can win the mouse gesture before a parent onDrag creates a
             // dragging session.
             .onTapGesture {
-                model.activeDocumentID = document.id
+                model.selectEditorDocument(document)
             }
             .onDrag {
                 beginTabDrag(document.id)
@@ -283,7 +416,7 @@ struct EditorAreaView: View {
             .accessibilityLabel(document.displayName)
             .accessibilityAddTraits(.isButton)
             .accessibilityAction {
-                model.activeDocumentID = document.id
+                model.selectEditorDocument(document)
             }
             .lithePointer()
 
@@ -299,19 +432,19 @@ struct EditorAreaView: View {
             .buttonStyle(LitheTreeRowButtonStyle())
             .lithePointer()
             .foregroundStyle(LitheTheme.secondaryText)
-            .opacity(model.activeDocumentID == document.id || hoveredTabID == document.id ? 1 : 0)
-            .allowsHitTesting(model.activeDocumentID == document.id || hoveredTabID == document.id)
+            .opacity(isActive || hoveredTabID == document.id ? 1 : 0)
+            .allowsHitTesting(isActive || hoveredTabID == document.id)
             .padding(.trailing, 4)
         }
         .background(
-            model.activeDocumentID == document.id
+            isActive
                 ? LitheTheme.activeTabBackground
                 : (dropSide == nil
                     ? LitheTheme.inactiveTabBackground
                     : LitheTheme.accent.opacity(0.13))
         )
         .overlay(alignment: .bottom) {
-            if model.activeDocumentID == document.id {
+            if isActive {
                 Rectangle().fill(LitheTheme.accent).frame(height: 2)
             }
         }
@@ -469,7 +602,8 @@ struct EditorAreaView: View {
             editorTabs
             Rectangle().fill(LitheTheme.divider).frame(height: 1)
 
-            if let splitDocumentID,
+            if model.activeEditorTerminalSession == nil,
+               let splitDocumentID,
                let splitDocument = model.openDocuments.first(where: { $0.id == splitDocumentID }) {
                 HStack(spacing: 0) {
                     editorPane(model.activeDocument)
@@ -481,6 +615,13 @@ struct EditorAreaView: View {
                 activeEditor
             }
         }
+        .contentShape(Rectangle())
+        .onDrop(
+            of: [TerminalTabDragPayload.type],
+            delegate: EditorTerminalDropDelegate { sessionID in
+                model.moveTerminalToEditor(sessionID)
+            }
+        )
     }
 
     @ViewBuilder
@@ -610,7 +751,13 @@ struct EditorAreaView: View {
 
     @ViewBuilder
     private var activeEditor: some View {
-        if let document = model.activeDocument {
+        if let session = model.activeEditorTerminalSession {
+            TerminalSurfaceView(session: session)
+                .id(session.id)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(8)
+                .background(LitheTheme.editor)
+        } else if let document = model.activeDocument {
             if isMarkdownFile(document) {
                 switch markdownViewModes[document.id] ?? .editor {
                 case .editor:
@@ -685,24 +832,40 @@ struct EditorAreaView: View {
                 .foregroundStyle(LitheTheme.secondaryText)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .contentShape(Rectangle())
+        .onDrop(
+            of: [TerminalTabDragPayload.type],
+            delegate: EditorTerminalDropDelegate { sessionID in
+                model.moveTerminalToEditor(sessionID)
+            }
+        )
     }
 
 }
 
 private struct EditorTabBarDropDelegate: DropDelegate {
     let finish: () -> Void
+    let receiveTerminal: @MainActor (UUID) -> Void
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
         DropProposal(operation: .move)
     }
 
     func performDrop(info: DropInfo) -> Bool {
+        let terminalProviders = info.itemProviders(for: [TerminalTabDragPayload.type])
+        if !terminalProviders.isEmpty {
+            finish()
+            return TerminalTabDragPayload.loadSessionID(
+                from: terminalProviders,
+                completion: receiveTerminal
+            )
+        }
         finish()
         return true
     }
 
     func validateDrop(info: DropInfo) -> Bool {
-        !info.itemProviders(for: [EditorTabDragPayload.type]).isEmpty
+        !info.itemProviders(for: [EditorTabDragPayload.type, TerminalTabDragPayload.type]).isEmpty
     }
 }
 
@@ -715,6 +878,7 @@ private struct EditorTabDropDelegate: DropDelegate {
     let updateTarget: (EditorTabDropTarget, UUID?, UInt) -> Void
     let clearTarget: (UUID, UUID?, UInt) -> Void
     let finish: () -> Void
+    let receiveTerminal: @MainActor (UUID) -> Void
 
     func dropEntered(info: DropInfo) {
         updateTargetIfNeeded(using: info)
@@ -726,16 +890,25 @@ private struct EditorTabDropDelegate: DropDelegate {
     }
 
     func dropExited(info: DropInfo) {
+        guard !info.itemProviders(for: [EditorTabDragPayload.type]).isEmpty else { return }
         clearTarget(targetDocumentID, dragSessionID, dropTargetRevision)
     }
 
     func performDrop(info: DropInfo) -> Bool {
+        let terminalProviders = info.itemProviders(for: [TerminalTabDragPayload.type])
+        if !terminalProviders.isEmpty {
+            finish()
+            return TerminalTabDragPayload.loadSessionID(
+                from: terminalProviders,
+                completion: receiveTerminal
+            )
+        }
         finish()
         return true
     }
 
     func validateDrop(info: DropInfo) -> Bool {
-        !info.itemProviders(for: [EditorTabDragPayload.type]).isEmpty
+        !info.itemProviders(for: [EditorTabDragPayload.type, TerminalTabDragPayload.type]).isEmpty
     }
 
     private func updateTargetIfNeeded(using info: DropInfo) {
@@ -750,6 +923,67 @@ private struct EditorTabDropDelegate: DropDelegate {
             dragSessionID,
             dropTargetRevision
         )
+    }
+}
+
+private struct EditorTerminalDropDelegate: DropDelegate {
+    let receive: @MainActor (UUID) -> Void
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func validateDrop(info: DropInfo) -> Bool {
+        !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        TerminalTabDragPayload.loadSessionID(
+            from: info.itemProviders(for: [TerminalTabDragPayload.type]),
+            completion: receive
+        )
+    }
+}
+
+private struct EditorTerminalTabDropDelegate: DropDelegate {
+    let targetSessionID: UUID
+    let targetWidth: CGFloat
+    let moveBefore: @MainActor (UUID) -> Void
+    let moveAfter: @MainActor (UUID) -> Void
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func validateDrop(info: DropInfo) -> Bool {
+        !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let insertAfter = info.location.x >= targetWidth / 2
+        return TerminalTabDragPayload.loadSessionID(
+            from: info.itemProviders(for: [TerminalTabDragPayload.type])
+        ) { sourceSessionID in
+            guard sourceSessionID != targetSessionID else { return }
+            if insertAfter {
+                moveAfter(sourceSessionID)
+            } else {
+                moveBefore(sourceSessionID)
+            }
+        }
+    }
+}
+
+private struct EditorTerminalTabTitle: View {
+    @ObservedObject var session: TerminalSession
+    let fallbackTitle: String
+
+    var body: some View {
+        Text(session.processTitle.flatMap { $0.isEmpty ? nil : $0 } ?? fallbackTitle)
+            .font(.system(size: 12.5))
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .frame(maxWidth: 240, alignment: .leading)
     }
 }
 

--- a/Sources/Lithe/Views/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Lithe/Views/Terminal/TerminalSurfaceView.swift
@@ -1,0 +1,84 @@
+import AppKit
+import SwiftUI
+import LitheTerminalModule
+
+struct TerminalSurfaceView: View {
+    @ObservedObject var session: TerminalSession
+    @State private var focusRequestID = 0
+
+    var body: some View {
+        Group {
+            if let nativeView = session.nativeView as? NSView {
+                TerminalNativeSurface(
+                    nativeView: nativeView,
+                    focusRequestID: focusRequestID
+                )
+            } else {
+                LitheTheme.editor
+            }
+        }
+        .background(LitheTheme.editor)
+        .task(id: session.id) {
+            requestInputFocus()
+        }
+    }
+
+    private func requestInputFocus() {
+        guard session.isRunning else { return }
+        focusRequestID &+= 1
+        session.focus()
+    }
+}
+
+private struct TerminalNativeSurface: NSViewRepresentable {
+    let nativeView: NSView
+    let focusRequestID: Int
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> TerminalSurfaceHostView {
+        TerminalSurfaceHostView(frame: .zero)
+    }
+
+    func updateNSView(_ hostView: TerminalSurfaceHostView, context: Context) {
+        hostView.attach(nativeView)
+        guard context.coordinator.lastFocusRequestID != focusRequestID else { return }
+        context.coordinator.lastFocusRequestID = focusRequestID
+        DispatchQueue.main.async {
+            guard nativeView.superview === hostView,
+                  let window = nativeView.window,
+                  window.firstResponder !== nativeView else { return }
+            window.makeFirstResponder(nativeView)
+        }
+    }
+
+    static func dismantleNSView(_ hostView: TerminalSurfaceHostView, coordinator: Coordinator) {
+        hostView.detachCurrentView()
+    }
+
+    final class Coordinator: NSObject {
+        var lastFocusRequestID = -1
+    }
+}
+
+private final class TerminalSurfaceHostView: NSView {
+    private weak var terminalView: NSView?
+
+    func attach(_ view: NSView) {
+        guard terminalView !== view || view.superview !== self else { return }
+        terminalView?.removeFromSuperview()
+        view.removeFromSuperview()
+        terminalView = view
+        view.frame = bounds
+        view.autoresizingMask = [.width, .height]
+        addSubview(view)
+    }
+
+    func detachCurrentView() {
+        guard let terminalView, terminalView.superview === self else { return }
+        terminalView.removeFromSuperview()
+        self.terminalView = nil
+    }
+}

--- a/Sources/Lithe/Views/Terminal/TerminalTabDragPayload.swift
+++ b/Sources/Lithe/Views/Terminal/TerminalTabDragPayload.swift
@@ -1,0 +1,71 @@
+import AppKit
+import UniformTypeIdentifiers
+
+enum TerminalTabDragPayload {
+    static let type = UTType(exportedAs: "com.lithe.terminal-tab")
+    static let pasteboardType = NSPasteboard.PasteboardType(type.identifier)
+    private static let activeDrag = ActiveTerminalTabDrag()
+
+    static func provider(for sessionID: UUID) -> NSItemProvider {
+        activeDrag.store(sessionID)
+        let provider = NSItemProvider()
+        let data = Data(sessionID.uuidString.utf8)
+        provider.registerDataRepresentation(
+            forTypeIdentifier: type.identifier,
+            visibility: .ownProcess
+        ) { completion in
+            completion(data, nil)
+            return nil
+        }
+        return provider
+    }
+
+    static func sessionID(from data: Data) -> UUID? {
+        String(data: data, encoding: .utf8).flatMap(UUID.init(uuidString:))
+    }
+
+    static func sessionID(from pasteboard: NSPasteboard) -> UUID? {
+        if let data = pasteboard.data(forType: pasteboardType),
+           let sessionID = sessionID(from: data) {
+            return sessionID
+        }
+        // SwiftUI advertises NSItemProvider types before their promised data is
+        // necessarily available to synchronous AppKit pasteboard readers.
+        guard pasteboard.availableType(from: [pasteboardType]) != nil else { return nil }
+        return activeDrag.sessionID
+    }
+
+    @discardableResult
+    static func loadSessionID(
+        from providers: [NSItemProvider],
+        completion: @escaping @MainActor (UUID) -> Void
+    ) -> Bool {
+        guard let provider = providers.first(where: {
+            $0.hasItemConformingToTypeIdentifier(type.identifier)
+        }) else { return false }
+        provider.loadDataRepresentation(forTypeIdentifier: type.identifier) { data, _ in
+            guard let data, let sessionID = sessionID(from: data) else { return }
+            Task { @MainActor in
+                completion(sessionID)
+            }
+        }
+        return true
+    }
+}
+
+private final class ActiveTerminalTabDrag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedSessionID: UUID?
+
+    var sessionID: UUID? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedSessionID
+    }
+
+    func store(_ sessionID: UUID) {
+        lock.lock()
+        storedSessionID = sessionID
+        lock.unlock()
+    }
+}

--- a/Sources/Lithe/Views/Terminal/TerminalView.swift
+++ b/Sources/Lithe/Views/Terminal/TerminalView.swift
@@ -1,11 +1,8 @@
-import AppKit
 import SwiftUI
 import LitheTerminalModule
 
 struct TerminalView: View {
     @EnvironmentObject private var model: AppModel
-    @ObservedObject var session: TerminalSession
-    @State private var focusRequestID = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -13,9 +10,6 @@ struct TerminalView: View {
             terminalCanvas
         }
         .background(LitheTheme.editor)
-        .task(id: session.id) {
-            requestInputFocus()
-        }
     }
 
     private var terminalToolbar: some View {
@@ -29,19 +23,27 @@ struct TerminalView: View {
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 3) {
-                    ForEach(model.terminalSessions) { terminalSession in
+                    ForEach(model.toolTerminalSessions) { terminalSession in
                         terminalTab(terminalSession)
                     }
                 }
                 .padding(.horizontal, 2)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .onDrop(
+                of: [TerminalTabDragPayload.type],
+                delegate: TerminalBarDropDelegate { sessionID in
+                    model.moveTerminalToTool(sessionID)
+                }
+            )
 
-            terminalStatus
+            if let session = model.activeToolTerminalSession {
+                TerminalStatusView(session: session)
+            }
 
             Button {
-                model.createTerminalSession()
-                requestInputFocus()
+                _ = model.createTerminalSession()
             } label: {
                 Image(systemName: "plus")
             }
@@ -51,8 +53,7 @@ struct TerminalView: View {
             Menu {
                 ForEach(model.availableTerminalShells, id: \.self) { shell in
                     Button("New \(shellLabel(for: shell))") {
-                        model.createTerminalSession(shellPath: shell)
-                        requestInputFocus()
+                        _ = model.createTerminalSession(shellPath: shell)
                     }
                 }
             } label: {
@@ -67,15 +68,23 @@ struct TerminalView: View {
             .help("New terminal with shell")
 
             Menu {
-                Button("Interrupt", action: session.interrupt)
-                Button("Restart") {
-                    model.restartActiveTerminal()
-                    requestInputFocus()
-                }
-                Button("Clear", action: session.clear)
-                Divider()
-                Button("Close Terminal") {
-                    model.closeTerminalSession(session)
+                if let session = model.activeToolTerminalSession {
+                    Button("Interrupt", action: session.interrupt)
+                    Button("Restart") {
+                        session.restart()
+                        session.focus()
+                    }
+                    Button("Clear", action: session.clear)
+                    Divider()
+                    Button("Move to Editor") {
+                        model.moveTerminalToEditor(session.id)
+                    }
+                    Button("Close Terminal") {
+                        model.closeTerminalSession(session)
+                    }
+                } else {
+                    Button("No Terminal Sessions") {}
+                        .disabled(true)
                 }
             } label: {
                 LitheSystemIcon(systemImage: "ellipsis.vertical")
@@ -105,7 +114,142 @@ struct TerminalView: View {
         }
     }
 
-    private var terminalStatus: some View {
+    private func terminalTab(_ session: TerminalSession) -> some View {
+        let isActive = model.activeToolTerminalSession?.id == session.id
+
+        return HStack(spacing: 1) {
+            HStack(spacing: 6) {
+                Image(systemName: "terminal")
+                    .font(.system(size: 10, weight: .medium))
+                TerminalToolTabTitle(
+                    session: session,
+                    fallbackTitle: model.terminalTitle(for: session),
+                    isActive: isActive
+                )
+            }
+            .foregroundStyle(isActive ? LitheTheme.primaryText : LitheTheme.secondaryText)
+            .padding(.leading, 9)
+            .padding(.trailing, 5)
+            .frame(height: 26)
+            .contentShape(Rectangle())
+            .contentShape(
+                .dragPreview,
+                RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius)
+            )
+            .onTapGesture {
+                model.selectTerminalSession(session)
+                session.focus()
+            }
+            .onDrag {
+                TerminalTabDragPayload.provider(for: session.id)
+            } preview: {
+                terminalTabDragPreview(session)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(model.terminalTitle(for: session))
+            .accessibilityAddTraits(.isButton)
+            .accessibilityAction {
+                model.selectTerminalSession(session)
+            }
+
+            Button {
+                model.closeTerminalSession(session)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(LitheTheme.secondaryText)
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Close \(model.terminalTitle(for: session))")
+        }
+        .background(isActive ? LitheTheme.subtleSelection : .clear)
+        .overlay {
+            RoundedRectangle(cornerRadius: 5)
+                .stroke(isActive ? LitheTheme.inputFocusBorder : .clear, lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+        .background {
+            GeometryReader { geometry in
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onDrop(
+                        of: [TerminalTabDragPayload.type],
+                        delegate: TerminalTabDropDelegate(
+                            targetSessionID: session.id,
+                            targetWidth: geometry.size.width,
+                            moveBefore: { sourceID in
+                                model.moveTerminalToTool(sourceID, before: session.id)
+                            },
+                            moveAfter: { sourceID in
+                                model.moveTerminalToTool(sourceID, after: session.id)
+                            }
+                        )
+                    )
+            }
+        }
+        .contextMenu {
+            Button("Move to Editor") {
+                model.moveTerminalToEditor(session.id)
+            }
+            Divider()
+            Button("Close") {
+                model.closeTerminalSession(session)
+            }
+        }
+        .lithePointer()
+    }
+
+    @ViewBuilder
+    private var terminalCanvas: some View {
+        if let session = model.activeToolTerminalSession {
+            TerminalSurfaceView(session: session)
+                .id(session.id)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(8)
+        } else {
+            Image(systemName: "terminal")
+                .font(.system(size: 34, weight: .ultraLight))
+                .foregroundStyle(LitheTheme.tertiaryText)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .contentShape(Rectangle())
+                .onDrop(
+                    of: [TerminalTabDragPayload.type],
+                    delegate: TerminalBarDropDelegate { sessionID in
+                        model.moveTerminalToTool(sessionID)
+                    }
+                )
+        }
+    }
+
+    private func terminalTabDragPreview(_ session: TerminalSession) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: "terminal")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(LitheTheme.accent)
+            Text(model.terminalTitle(for: session))
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(LitheTheme.primaryText)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: LitheTheme.Metrics.tabHeight)
+        .background(LitheTheme.activeTabBackground)
+        .clipShape(RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius))
+        .shadow(color: .black.opacity(0.42), radius: 10, y: 6)
+    }
+
+    private func shellLabel(for path: String) -> String {
+        let name = URL(fileURLWithPath: path).lastPathComponent
+        return path == "/bin/\(name)" ? name : "\(name) (\(path))"
+    }
+}
+
+private struct TerminalStatusView: View {
+    @ObservedObject var session: TerminalSession
+
+    var body: some View {
         TimelineView(.periodic(from: .now, by: 1)) { context in
             HStack(spacing: 5) {
                 Circle()
@@ -139,97 +283,64 @@ struct TerminalView: View {
             .help("Command-click a file path or URL to open it")
         }
     }
+}
 
-    private func terminalTab(_ terminalSession: TerminalSession) -> some View {
-        let isActive = model.activeTerminalSessionID == terminalSession.id
-            || (model.activeTerminalSessionID == nil && model.terminalSessions.first?.id == terminalSession.id)
+private struct TerminalToolTabTitle: View {
+    @ObservedObject var session: TerminalSession
+    let fallbackTitle: String
+    let isActive: Bool
 
-        return HStack(spacing: 1) {
-            Button {
-                model.selectTerminalSession(terminalSession)
-                requestInputFocus()
-            } label: {
-                Text(model.terminalTitle(for: terminalSession))
-                    .font(.system(size: 11.5, weight: isActive ? .semibold : .medium))
-                    .foregroundStyle(isActive ? LitheTheme.primaryText : LitheTheme.secondaryText)
-                    .padding(.leading, 9)
-                    .padding(.trailing, 5)
-                    .frame(height: 26)
-            }
-            .buttonStyle(.plain)
-
-            Button {
-                model.closeTerminalSession(terminalSession)
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(LitheTheme.secondaryText)
-                    .frame(width: 22, height: 22)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .help("Close \(model.terminalTitle(for: terminalSession))")
-        }
-        .background(isActive ? LitheTheme.subtleSelection : .clear)
-        .overlay {
-            RoundedRectangle(cornerRadius: 5)
-                .stroke(isActive ? LitheTheme.inputFocusBorder : .clear, lineWidth: 1)
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 5))
-        .lithePointer()
-    }
-
-    private var terminalCanvas: some View {
-        Group {
-            if let nativeView = session.nativeView as? NSView {
-                SwiftTermSurface(
-                    nativeView: nativeView,
-                    focusRequestID: focusRequestID
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 8)
-            } else {
-                LitheTheme.editor
-            }
-        }
-        .background(LitheTheme.editor)
-    }
-
-    private func shellLabel(for path: String) -> String {
-        let name = URL(fileURLWithPath: path).lastPathComponent
-        return path == "/bin/\(name)" ? name : "\(name) (\(path))"
-    }
-
-    private func requestInputFocus() {
-        guard session.isRunning else { return }
-        focusRequestID &+= 1
-        session.focus()
+    var body: some View {
+        Text(session.processTitle.flatMap { $0.isEmpty ? nil : $0 } ?? fallbackTitle)
+            .font(.system(size: 11.5, weight: isActive ? .semibold : .medium))
+            .lineLimit(1)
     }
 }
 
-private struct SwiftTermSurface: NSViewRepresentable {
-    let nativeView: NSView
-    let focusRequestID: Int
+private struct TerminalBarDropDelegate: DropDelegate {
+    let receive: @MainActor (UUID) -> Void
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator()
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
     }
 
-    func makeNSView(context: Context) -> NSView {
-        nativeView
+    func validateDrop(info: DropInfo) -> Bool {
+        !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty
     }
 
-    func updateNSView(_ view: NSView, context: Context) {
-        guard context.coordinator.lastFocusRequestID != focusRequestID else { return }
-        context.coordinator.lastFocusRequestID = focusRequestID
-        DispatchQueue.main.async {
-            guard let window = view.window, window.firstResponder !== view else { return }
-            window.makeFirstResponder(view)
+    func performDrop(info: DropInfo) -> Bool {
+        TerminalTabDragPayload.loadSessionID(
+            from: info.itemProviders(for: [TerminalTabDragPayload.type]),
+            completion: receive
+        )
+    }
+}
+
+private struct TerminalTabDropDelegate: DropDelegate {
+    let targetSessionID: UUID
+    let targetWidth: CGFloat
+    let moveBefore: @MainActor (UUID) -> Void
+    let moveAfter: @MainActor (UUID) -> Void
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func validateDrop(info: DropInfo) -> Bool {
+        !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let insertAfter = info.location.x >= targetWidth / 2
+        return TerminalTabDragPayload.loadSessionID(
+            from: info.itemProviders(for: [TerminalTabDragPayload.type])
+        ) { sourceSessionID in
+            guard sourceSessionID != targetSessionID else { return }
+            if insertAfter {
+                moveAfter(sourceSessionID)
+            } else {
+                moveBefore(sourceSessionID)
+            }
         }
-    }
-
-    final class Coordinator: NSObject {
-        var lastFocusRequestID = -1
     }
 }

--- a/Sources/Lithe/Views/Workbench/WorkbenchModuleUIComposition.swift
+++ b/Sources/Lithe/Views/Workbench/WorkbenchModuleUIComposition.swift
@@ -34,12 +34,7 @@ enum WorkbenchModuleUIComposition {
                 ideaAssetPath: nil,
                 isVisible: { _ in true },
                 isSelected: { $0.isTerminalVisible },
-                content: { model in
-                    guard let session = model.activeTerminalSession else {
-                        return AnyView(WorkbenchModuleUIRegistry.moduleLoadingView)
-                    }
-                    return AnyView(TerminalView(session: session).id(session.id))
-                }
+                content: { _ in AnyView(TerminalView()) }
             )
         ]
     )

--- a/Tests/LitheTests/EditorTabLayoutTests.swift
+++ b/Tests/LitheTests/EditorTabLayoutTests.swift
@@ -1,10 +1,11 @@
+import AppKit
 import CoreGraphics
 import Foundation
 import Testing
 import UniformTypeIdentifiers
 @testable import Lithe
 
-@Suite("Editor tab layout")
+@Suite("Editor tab layout", .serialized)
 struct EditorTabLayoutTests {
     @Test
     func flowLayoutWrapsByIntrinsicWidth() {
@@ -60,6 +61,48 @@ struct EditorTabLayoutTests {
 
         #expect(provider.registeredTypeIdentifiers.contains(EditorTabDragPayload.type.identifier))
         #expect(provider.registeredTypeIdentifiers.contains(UTType.utf8PlainText.identifier))
+    }
+
+    @Test
+    func terminalTabDragPayloadOnlyOffersItsPrivateSessionIdentifier() throws {
+        let sessionID = UUID()
+        let provider = TerminalTabDragPayload.provider(for: sessionID)
+        let encoded = Data(sessionID.uuidString.utf8)
+
+        #expect(provider.registeredTypeIdentifiers.contains(TerminalTabDragPayload.type.identifier))
+        #expect(!provider.registeredTypeIdentifiers.contains(UTType.utf8PlainText.identifier))
+        #expect(TerminalTabDragPayload.sessionID(from: encoded) == sessionID)
+    }
+
+    @Test
+    func terminalTabPasteboardRoundTripsItsPrivateSessionIdentifier() throws {
+        let sessionID = UUID()
+        let pasteboard = NSPasteboard(
+            name: .init("lithe-terminal-tab-\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        pasteboard.setData(
+            Data(sessionID.uuidString.utf8),
+            forType: TerminalTabDragPayload.pasteboardType
+        )
+        defer { pasteboard.clearContents() }
+
+        #expect(TerminalTabDragPayload.sessionID(from: pasteboard) == sessionID)
+        #expect(pasteboard.string(forType: .string) == nil)
+    }
+
+    @Test
+    func terminalTabPasteboardUsesTheActiveDragWhenPromisedDataIsNotReady() {
+        let sessionID = UUID()
+        _ = TerminalTabDragPayload.provider(for: sessionID)
+        let pasteboard = NSPasteboard(
+            name: .init("lithe-promised-terminal-tab-\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        pasteboard.setData(Data(), forType: TerminalTabDragPayload.pasteboardType)
+        defer { pasteboard.clearContents() }
+
+        #expect(TerminalTabDragPayload.sessionID(from: pasteboard) == sessionID)
     }
 
     @Test

--- a/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -75,6 +75,19 @@ struct LitheCoreLogicTests {
     }
 
     @Test
+    @MainActor
+    func workspaceWindowKeepsAnAccessibleTitleWithoutShowingTheNativeTitle() {
+        let sessions = TestProjectWindowSessions(hasActiveProject: true)
+        let coordinator = LitheWindowCoordinator(projectSessions: sessions)
+        let window = NSWindow()
+
+        coordinator.attach(to: window, layout: .workspace, title: "Lithe-IDEA")
+
+        #expect(window.title == "Lithe-IDEA")
+        #expect(window.titleVisibility == .hidden)
+    }
+
+    @Test
     func workspaceWindowFitsInsideTheVisibleScreen() {
         let visibleFrame = NSRect(x: 0, y: 24, width: 1280, height: 776)
         let oversizedFrame = NSRect(x: -80, y: -40, width: 1440, height: 900)
@@ -2117,6 +2130,40 @@ struct LitheCoreLogicTests {
         textView.paste(nil)
 
         #expect(handled)
+        #expect(textView.string == "before")
+    }
+
+    @Test
+    @MainActor
+    func codeEditorRegistersThePrivateTerminalTabDropType() {
+        let textView = CodeTextView(frame: .zero)
+
+        #expect(textView.registeredDraggedTypes.contains(TerminalTabDragPayload.pasteboardType))
+    }
+
+    @Test
+    @MainActor
+    func codeEditorRoutesPrivateTerminalTabDropsWithoutChangingText() {
+        let sessionID = UUID()
+        let textView = CodeTextView(frame: .zero)
+        let pasteboard = NSPasteboard(
+            name: .init("lithe-code-editor-terminal-tab-\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        pasteboard.setData(
+            Data(sessionID.uuidString.utf8),
+            forType: TerminalTabDragPayload.pasteboardType
+        )
+        defer { pasteboard.clearContents() }
+        textView.string = "before"
+        var receivedSessionID: UUID?
+        textView.onTerminalTabDrop = { droppedSessionID in
+            receivedSessionID = droppedSessionID
+            return true
+        }
+
+        #expect(textView.performTerminalTabDrop(from: pasteboard))
+        #expect(receivedSessionID == sessionID)
         #expect(textView.string == "before")
     }
 

--- a/Tests/LitheTests/TerminalPlacementFeatureModelTests.swift
+++ b/Tests/LitheTests/TerminalPlacementFeatureModelTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import LitheTerminalModule
+import Testing
+@testable import Lithe
+
+@Suite("Terminal tab placement")
+@MainActor
+struct TerminalPlacementFeatureModelTests {
+    @Test
+    func reordersTerminalToolTabs() {
+        let model = TerminalPlacementFeatureModel()
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+        [first, second, third].forEach(model.registerSession)
+
+        model.moveToTool(first, after: third)
+        #expect(model.toolSessionIDs == [second, third, first])
+
+        model.moveToTool(first, before: second)
+        #expect(model.toolSessionIDs == [first, second, third])
+        #expect(model.editorSessionIDs.isEmpty)
+    }
+
+    @Test
+    func movesAUniqueSessionBetweenToolAndEditor() {
+        let model = TerminalPlacementFeatureModel()
+        let sessionID = UUID()
+        model.registerSession(sessionID)
+
+        model.moveToEditor(sessionID)
+        #expect(model.toolSessionIDs.isEmpty)
+        #expect(model.editorSessionIDs == [sessionID])
+        #expect(model.activeEditorSessionID == sessionID)
+
+        model.moveToTool(sessionID)
+        #expect(model.toolSessionIDs == [sessionID])
+        #expect(model.editorSessionIDs.isEmpty)
+        #expect(model.activeEditorSessionID == nil)
+    }
+
+    @Test
+    func reordersEditorTerminalTabsAndSelectsTheMovedSession() {
+        let model = TerminalPlacementFeatureModel()
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+        [first, second, third].forEach(model.registerSession)
+        [first, second, third].forEach(model.moveToEditor)
+
+        model.moveToEditor(first, after: third)
+
+        #expect(model.editorSessionIDs == [second, third, first])
+        #expect(model.activeEditorSessionID == first)
+        #expect(model.toolSessionIDs.isEmpty)
+    }
+
+    @Test
+    func movingPresentationNeverStopsOrRecreatesTheTerminalTransport() {
+        let transport = PlacementTestTerminalTransport()
+        let terminalFeature = TerminalFeatureModel(terminalFactory: { transport })
+        let placement = TerminalPlacementFeatureModel()
+        let session = terminalFeature.createSession(
+            in: URL(fileURLWithPath: "/tmp/lithe-terminal-placement-tests"),
+            shellPath: "/bin/zsh"
+        )
+        let nativeViewID = ObjectIdentifier(session.nativeView)
+        placement.registerSession(session.id)
+
+        placement.moveToEditor(session.id)
+        placement.moveToTool(session.id)
+
+        #expect(transport.startCount == 1)
+        #expect(transport.stopCount == 0)
+        #expect(session.isRunning)
+        #expect(ObjectIdentifier(session.nativeView) == nativeViewID)
+
+        terminalFeature.stopAllSessions()
+        #expect(transport.stopCount == 1)
+    }
+}
+
+@MainActor
+private final class PlacementTestTerminalTransport: TerminalTransport {
+    let nativeView: AnyObject = NSObject()
+    var isRunning = false
+    var shellName = "Shell"
+    var onTermination: ((Int32?) -> Void)?
+    var onTitle: ((String) -> Void)?
+    var onDirectoryUpdate: ((String?) -> Void)?
+    var onLink: ((String, [String: String]) -> Void)?
+    var startCount = 0
+    var stopCount = 0
+
+    func defaultShellPath() -> String { "/bin/zsh" }
+    func defaultEnvironment() -> [String: String] { [:] }
+
+    func start(
+        workingDirectory: String,
+        shellPath: String,
+        environment: [String: String]
+    ) throws {
+        startCount += 1
+        isRunning = true
+    }
+
+    func send(_ input: Data) throws {}
+    func interrupt() throws {}
+    func focus() {}
+    func clear() {}
+
+    func stop() {
+        guard isRunning else { return }
+        stopCount += 1
+        isRunning = false
+    }
+}


### PR DESCRIPTION
## Summary

- add application-owned placement state for live terminal sessions
- support moving and reordering terminal tabs between the bottom Terminal tool area and editor tabs
- preserve the existing PTY and native terminal surface while moving sessions
- prevent terminal tab drops from being inserted as text in the code editor
- add regression coverage for placement, drag payloads, native drop routing, and window accessibility

## Scope

This adds terminal session tab docking between the bottom Terminal area and the main editor. Left and right tool-window docking are not included.

## Validation

- ./scripts/test-macos.sh (494 tests in 58 suites)
- ./scripts/verify-service-boundaries.sh
- git diff --check