### PR TITLE
fix(mac): polish workspace UI interactions

### DIFF
--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -197,6 +197,7 @@
 "Wrap into rows" = "多行展开";
 "Layout" = "布局";
 "Font size" = "字体大小";
+"File tree row height" = "文件树行高";
 "Show usages and Git author" = "显示引用数量和 Git 作者";
 "Indentation" = "缩进";
 "Tab width" = "Tab 宽度";

--- a/Sources/Lithe/Application/Features/DocumentFeatureModel.swift
+++ b/Sources/Lithe/Application/Features/DocumentFeatureModel.swift
@@ -340,8 +340,11 @@ final class DocumentFeatureModel: ObservableObject {
         onDocumentOpened?(document)
     }
 
-    func requestProjectTreeReveal(for fileURL: URL) {
-        projectTreeRevealRequest = ProjectTreeRevealRequest(fileURL: fileURL)
+    func requestProjectTreeReveal(for fileURL: URL, isDirectory: Bool = false) {
+        projectTreeRevealRequest = ProjectTreeRevealRequest(
+            fileURL: fileURL,
+            isDirectory: isDirectory
+        )
     }
 
     func consumeProjectTreeRevealRequest(id: UUID) {

--- a/Sources/Lithe/Models/AppModel/AppModel+FeatureState.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel+FeatureState.swift
@@ -41,16 +41,20 @@ extension AppModel {
 
     func projectTreeURL(for url: URL) -> URL? {
         guard url.isFileURL else { return nil }
-        return ProjectTreeLocator.matchingURL(for: url, among: projectFiles)
+        if let matchingFile = ProjectTreeLocator.matchingURL(for: url, among: projectFiles) {
+            return matchingFile
+        }
+        guard let rootNode else { return nil }
+        return ProjectTreeLocator.matchingURL(for: url, in: rootNode)
     }
 
-    func revealInProjectTree(_ url: URL) {
+    func revealInProjectTree(_ url: URL, isDirectory: Bool = false) {
         guard let treeURL = projectTreeURL(for: url) else {
             showNotification("This file is not in the current workspace")
             return
         }
         selectedSidebar = .project
-        documentFeature.requestProjectTreeReveal(for: treeURL)
+        documentFeature.requestProjectTreeReveal(for: treeURL, isDirectory: isDirectory)
     }
 
     func consumeProjectTreeRevealRequest(id: UUID) {

--- a/Sources/Lithe/Models/AppModel/AppModelSupportTypes.swift
+++ b/Sources/Lithe/Models/AppModel/AppModelSupportTypes.swift
@@ -56,6 +56,7 @@ extension Notification.Name {
 struct ProjectTreeRevealRequest: Equatable {
     let id = UUID()
     let fileURL: URL
+    let isDirectory: Bool
 }
 
 enum ProjectTreeLocator {
@@ -66,9 +67,32 @@ enum ProjectTreeLocator {
         })
     }
 
-    static func expandedDirectoryPaths(for fileURL: URL, rootURL: URL) -> Set<String> {
+    static func matchingURL(for url: URL, in node: FileNode) -> URL? {
+        let standardizedPath = url.standardizedFileURL.path
+        if node.url.standardizedFileURL.path == standardizedPath {
+            return node.url
+        }
+        if node.collapsedAncestorPaths.contains(where: {
+            URL(fileURLWithPath: $0).standardizedFileURL.path == standardizedPath
+        }) {
+            return node.url
+        }
+        for child in node.children ?? [] {
+            if let match = matchingURL(for: url, in: child) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    static func expandedDirectoryPaths(
+        for itemURL: URL,
+        rootURL: URL,
+        includeItem: Bool = false
+    ) -> Set<String> {
         let root = rootURL.standardizedFileURL
-        var directory = fileURL.standardizedFileURL.deletingLastPathComponent()
+        let item = itemURL.standardizedFileURL
+        var directory = includeItem ? item : item.deletingLastPathComponent()
         var paths = Set([root.path])
         while directory.path != root.path, directory.path.hasPrefix(root.path + "/") {
             paths.insert(directory.path)

--- a/Sources/Lithe/Models/Settings/AppSettings.swift
+++ b/Sources/Lithe/Models/Settings/AppSettings.swift
@@ -9,6 +9,7 @@ final class AppSettings: ObservableObject {
         static let themePreference = "settings.themePreference"
         static let language = "settings.language"
         static let editorFontSize = "settings.editorFontSize"
+        static let projectTreeRowHeight = "settings.projectTreeRowHeight"
         static let tabWidth = "settings.tabWidth"
         static let editorTabLayoutMode = "settings.editorTabLayoutMode"
         static let showCodeVision = "settings.showCodeVision"
@@ -46,6 +47,9 @@ final class AppSettings: ObservableObject {
     }
     @Published var language: AppLanguage { didSet { defaults.set(language.rawValue, forKey: Key.language) } }
     @Published var editorFontSize: Double { didSet { defaults.set(editorFontSize, forKey: Key.editorFontSize) } }
+    @Published var projectTreeRowHeight: Double {
+        didSet { defaults.set(projectTreeRowHeight, forKey: Key.projectTreeRowHeight) }
+    }
     @Published var tabWidth: Int { didSet { defaults.set(tabWidth, forKey: Key.tabWidth) } }
     @Published var editorTabLayoutMode: EditorTabLayoutMode {
         didSet { defaults.set(editorTabLayoutMode.rawValue, forKey: Key.editorTabLayoutMode) }
@@ -98,6 +102,7 @@ final class AppSettings: ObservableObject {
         ) ?? .dark
         language = AppLanguage(rawValue: defaults.string(forKey: Key.language) ?? "") ?? .english
         editorFontSize = defaults.object(forKey: Key.editorFontSize) as? Double ?? 13
+        projectTreeRowHeight = defaults.object(forKey: Key.projectTreeRowHeight) as? Double ?? 24
         tabWidth = defaults.object(forKey: Key.tabWidth) as? Int ?? 4
         editorTabLayoutMode = EditorTabLayoutMode(
             rawValue: defaults.string(forKey: Key.editorTabLayoutMode) ?? ""
@@ -183,6 +188,7 @@ final class AppSettings: ObservableObject {
         themePreference = .dark
         language = .english
         editorFontSize = 13
+        projectTreeRowHeight = 24
         tabWidth = 4
         editorTabLayoutMode = .singleLine
         showCodeVision = true

--- a/Sources/Lithe/Views/App/SettingsView.swift
+++ b/Sources/Lithe/Views/App/SettingsView.swift
@@ -169,7 +169,7 @@ struct SettingsView: View {
         case .general:
             ["General", "Appearance", "Color theme", "Appearance mode", "Language", "Projects", "Files", "Version control", "Logs", "Log directory"]
         case .editor:
-            ["Editor", "Display", "Editor tabs", "Font size", "Indentation", "Tab width"]
+            ["Editor", "Display", "Editor tabs", "Font size", "File tree row height", "Indentation", "Tab width"]
         case .keymap:
             ["Keymap", "Keyboard shortcuts", "Shortcuts", "Actions"]
         case .terminal:
@@ -454,6 +454,16 @@ struct SettingsView: View {
                         step: 1,
                         width: 126,
                         accessibilityLabel: "Font size",
+                        title: { "\(Int($0)) pt" }
+                    )
+                }
+                row("File tree row height") {
+                    LitheSettingsStepper(
+                        value: $settings.projectTreeRowHeight,
+                        in: 20...32,
+                        step: 1,
+                        width: 126,
+                        accessibilityLabel: "File tree row height",
                         title: { "\(Int($0)) pt" }
                     )
                 }

--- a/Sources/Lithe/Views/Git/GitLogView.swift
+++ b/Sources/Lithe/Views/Git/GitLogView.swift
@@ -315,17 +315,9 @@ struct GitLogView: View {
             .help("Git tool window actions")
 
             Spacer(minLength: 12)
-
-            Button {
-                model.closeGitLog()
-            } label: {
-                Image(systemName: "minus")
-            }
-            .litheIconButton()
-            .help("Hide Git tool window")
         }
         .padding(.leading, 12)
-        .padding(.trailing, 7)
+        .padding(.trailing, 42)
         .frame(height: 32)
         .background(LitheTheme.toolHeader)
         .overlay(alignment: .bottom) {

--- a/Sources/Lithe/Views/Workbench/SplitHandleView.swift
+++ b/Sources/Lithe/Views/Workbench/SplitHandleView.swift
@@ -21,6 +21,7 @@ struct SplitHandleView: View {
     @State private var isHovering = false
     @State private var isDragging = false
     @State private var lastTranslation: CGFloat = 0
+    @State private var cursor = SplitHandleCursor()
 
     init(
         axis: LitheSplitAxis,
@@ -57,6 +58,7 @@ struct SplitHandleView: View {
                     if !isDragging {
                         isDragging = true
                         lastTranslation = 0
+                        cursor.update(isResizing: true, cursor: resizeCursor)
                         onDragStarted()
                     }
                     let currentTranslation = axis == .horizontal ? value.translation.width : value.translation.height
@@ -69,17 +71,17 @@ struct SplitHandleView: View {
                 .onEnded { _ in
                     isDragging = false
                     lastTranslation = 0
+                    cursor.update(isResizing: isHovering, cursor: resizeCursor)
                     onDragEnded()
                 }
         )
         .onHover { isInside in
             guard isInside != isHovering else { return }
             isHovering = isInside
-            if isInside {
-                resizeCursor.set()
-            } else {
-                NSCursor.arrow.set()
-            }
+            cursor.update(isResizing: isInside || isDragging, cursor: resizeCursor)
+        }
+        .onDisappear {
+            cursor.update(isResizing: false, cursor: resizeCursor)
         }
         .help(axis == .horizontal ? "Drag left or right to resize" : "Drag up or down to resize")
         .accessibilityLabel(axis == .horizontal ? "Horizontal pane resize handle" : "Vertical pane resize handle")
@@ -125,5 +127,20 @@ struct SplitHandleView: View {
 
     private var resizeCursor: NSCursor {
         axis == .horizontal ? .resizeLeftRight : .resizeUpDown
+    }
+}
+
+private final class SplitHandleCursor {
+    private var isResizing = false
+
+    @MainActor
+    func update(isResizing newValue: Bool, cursor: NSCursor) {
+        guard newValue != isResizing else { return }
+        isResizing = newValue
+        if newValue {
+            cursor.push()
+        } else {
+            NSCursor.pop()
+        }
     }
 }

--- a/Sources/Lithe/Views/Workbench/WorkbenchView.swift
+++ b/Sources/Lithe/Views/Workbench/WorkbenchView.swift
@@ -761,8 +761,12 @@ struct WorkbenchView: View {
                 topPaneHeight = height
                 saveLayout(sidebarWidth: sidebarWidth, topPaneHeight: height)
             },
+            showsBottomToolMinimize: model.isGitLogVisible,
+            onBottomToolMinimize: {
+                model.closeGitLog()
+            },
             sidebar: {
-                activeSidebar
+                activeSidebar(projectTreeRowHeight: settings.projectTreeRowHeight)
             },
             editor: {
                 Group {
@@ -794,11 +798,11 @@ struct WorkbenchView: View {
     }
 
     @ViewBuilder
-    private var activeSidebar: some View {
+    private func activeSidebar(projectTreeRowHeight: CGFloat) -> some View {
         Group {
             switch model.selectedSidebar {
             case .project:
-                ProjectSidebarView()
+                ProjectSidebarView(rowHeight: projectTreeRowHeight)
             case .changes:
                 ChangesSidebarView()
             case .pullRequests:
@@ -849,14 +853,20 @@ struct WorkbenchView: View {
                     let path = document.displayPath ?? model.relativePath(for: document.url)
                     let components = path.split(separator: "/")
                     ForEach(Array(components.enumerated()), id: \.offset) { index, component in
+                        let isFile = index == components.count - 1
                         breadcrumbItem(
                             title: String(component),
-                            iconKind: index == components.count - 1
+                            iconKind: isFile
                                 ? LitheIcons.kind(for: document.url, isDirectory: false)
                                 : nil,
-                            isEmphasized: index == components.count - 1
+                            isEmphasized: isFile
                         ) {
-                            model.selectedSidebar = .project
+                            guard let itemURL = breadcrumbURL(
+                                for: document,
+                                componentIndex: index,
+                                componentCount: components.count
+                            ) else { return }
+                            model.revealInProjectTree(itemURL, isDirectory: !isFile)
                         }
                         if index < components.count - 1 {
                             breadcrumbSeparator
@@ -869,6 +879,23 @@ struct WorkbenchView: View {
                     }
                 }
             }
+        }
+    }
+
+    private func breadcrumbURL(
+        for document: EditorDocument,
+        componentIndex: Int,
+        componentCount: Int
+    ) -> URL? {
+        guard componentIndex >= 0, componentIndex < componentCount else { return nil }
+        if componentIndex == componentCount - 1 {
+            return document.url
+        }
+        guard let workspaceURL = model.workspaceURL else { return nil }
+        return (0...componentIndex).reduce(workspaceURL) { url, index in
+            let path = document.displayPath ?? model.relativePath(for: document.url)
+            let components = path.split(separator: "/")
+            return url.appendingPathComponent(String(components[index]), isDirectory: true)
         }
     }
 
@@ -973,6 +1000,8 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
     let isBottomToolVisible: Bool
     let onSidebarWidthCommitted: (CGFloat) -> Void
     let onTopPaneHeightCommitted: (CGFloat) -> Void
+    let showsBottomToolMinimize: Bool
+    let onBottomToolMinimize: () -> Void
     let sidebar: Sidebar
     let editor: Editor
     let bottomTool: BottomTool
@@ -988,6 +1017,8 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
         isBottomToolVisible: Bool,
         onSidebarWidthCommitted: @escaping (CGFloat) -> Void,
         onTopPaneHeightCommitted: @escaping (CGFloat) -> Void,
+        showsBottomToolMinimize: Bool,
+        onBottomToolMinimize: @escaping () -> Void,
         @ViewBuilder sidebar: () -> Sidebar,
         @ViewBuilder editor: () -> Editor,
         @ViewBuilder bottomTool: () -> BottomTool
@@ -997,6 +1028,8 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
         self.isBottomToolVisible = isBottomToolVisible
         self.onSidebarWidthCommitted = onSidebarWidthCommitted
         self.onTopPaneHeightCommitted = onTopPaneHeightCommitted
+        self.showsBottomToolMinimize = showsBottomToolMinimize
+        self.onBottomToolMinimize = onBottomToolMinimize
         self.sidebar = sidebar()
         self.editor = editor()
         self.bottomTool = bottomTool()
@@ -1033,63 +1066,81 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
                 maximum: maximumTopPaneHeight
             )
 
-            VStack(spacing: 0) {
-                HStack(spacing: 0) {
-                    sidebar
-                        .frame(width: resolvedSidebarWidth)
-                    editor
-                }
-                .overlay(alignment: .topLeading) {
-                    SplitHandleView(
-                        axis: .horizontal,
-                        onDragStarted: {
-                            sidebarDragStart = resolvedSidebarWidth
-                        },
-                        onDragChanged: { translation in
-                            liveSidebarWidth = constrained(
-                                sidebarDragStart + translation,
-                                minimum: minimumSidebarWidth,
-                                maximum: maximumSidebarWidth
-                            )
-                        },
-                        onDragEnded: {
-                            liveSidebarWidth = resolvedSidebarWidth
-                            onSidebarWidthCommitted(resolvedSidebarWidth)
-                        }
-                    )
-                    .offset(x: resolvedSidebarWidth - SplitHandleView.thickness / 2)
-                }
-                .padding(.top, 0)
-                .padding(.horizontal, 0)
-                .padding(.bottom, 0)
-                .frame(height: isBottomToolVisible ? resolvedTopPaneHeight : geometry.size.height)
+            ZStack(alignment: .topLeading) {
+                VStack(spacing: 0) {
+                    HStack(spacing: 0) {
+                        sidebar
+                            .frame(width: resolvedSidebarWidth)
+                        editor
+                    }
+                    .overlay(alignment: .topLeading) {
+                        SplitHandleView(
+                            axis: .horizontal,
+                            onDragStarted: {
+                                sidebarDragStart = resolvedSidebarWidth
+                            },
+                            onDragChanged: { translation in
+                                liveSidebarWidth = constrained(
+                                    sidebarDragStart + translation,
+                                    minimum: minimumSidebarWidth,
+                                    maximum: maximumSidebarWidth
+                                )
+                            },
+                            onDragEnded: {
+                                liveSidebarWidth = resolvedSidebarWidth
+                                onSidebarWidthCommitted(resolvedSidebarWidth)
+                            }
+                        )
+                        .offset(x: resolvedSidebarWidth - SplitHandleView.thickness / 2)
+                    }
+                    .frame(height: isBottomToolVisible ? resolvedTopPaneHeight : geometry.size.height)
 
-                if isBottomToolVisible {
-                    SplitHandleView(
-                        axis: .vertical,
-                        onDragStarted: {
-                            topPaneDragStart = resolvedTopPaneHeight
-                        },
-                        onDragChanged: { translation in
-                            liveTopPaneHeight = constrained(
-                                topPaneDragStart + translation,
-                                minimum: minimumTopPaneHeight,
-                                maximum: maximumTopPaneHeight
-                            )
-                        },
-                        onDragEnded: {
-                            liveTopPaneHeight = resolvedTopPaneHeight
-                            onTopPaneHeightCommitted(resolvedTopPaneHeight)
-                        }
-                    )
-                    .padding(.horizontal, 6)
-
-                    bottomTool
+                    if isBottomToolVisible {
+                        SplitHandleView(
+                            axis: .vertical,
+                            onDragStarted: {
+                                topPaneDragStart = resolvedTopPaneHeight
+                            },
+                            onDragChanged: { translation in
+                                liveTopPaneHeight = constrained(
+                                    topPaneDragStart + translation,
+                                    minimum: minimumTopPaneHeight,
+                                    maximum: maximumTopPaneHeight
+                                )
+                            },
+                            onDragEnded: {
+                                liveTopPaneHeight = resolvedTopPaneHeight
+                                onTopPaneHeightCommitted(resolvedTopPaneHeight)
+                            }
+                        )
                         .padding(.horizontal, 6)
-                        .padding(.bottom, 6)
-                        .frame(maxHeight: .infinity)
+
+                        bottomTool
+                            .padding(.horizontal, 6)
+                            .padding(.bottom, 6)
+                            .frame(maxHeight: .infinity)
+                    }
+                }
+
+                if isBottomToolVisible, showsBottomToolMinimize {
+                    Button(action: onBottomToolMinimize) {
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                    .litheIconButton()
+                    .help("Collapse tool window")
+                    .accessibilityLabel("Collapse tool window")
+                    .position(
+                        x: geometry.size.width - ActivityBarMetrics.rightWidth - 20,
+                        y: resolvedTopPaneHeight + SplitHandleView.thickness + 16
+                    )
                 }
             }
+            .frame(
+                width: geometry.size.width,
+                height: geometry.size.height,
+                alignment: .topLeading
+            )
             .background(LitheTheme.titlebar)
             // Keep the workspace as a live view hierarchy. `drawingGroup()`
             // cannot composite AppKit-backed editors, fields, checkboxes, or

--- a/Sources/Lithe/Views/Workspace/ProjectSidebarView.swift
+++ b/Sources/Lithe/Views/Workspace/ProjectSidebarView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ProjectSidebarView: View {
     @EnvironmentObject private var model: AppModel
+    let rowHeight: CGFloat
     @State private var expandedDirectoryPaths: Set<String> = []
     @State private var expandedTreeRootPath: String?
 
@@ -27,6 +28,7 @@ struct ProjectSidebarView: View {
                                 ProjectFileTreeContent(
                                     root: root,
                                     availableWidth: geometry.size.width,
+                                    rowHeight: rowHeight,
                                     activeDocumentURL: model.activeDocument?.url,
                                     gitStatus: ProjectGitStatusSnapshot(
                                         repositoryRoot: model.gitRepositoryRoot,
@@ -62,7 +64,8 @@ struct ProjectSidebarView: View {
                                 expandedDirectoryPaths.formUnion(
                                     ProjectTreeLocator.expandedDirectoryPaths(
                                         for: request.fileURL,
-                                        rootURL: root.url
+                                        rootURL: root.url,
+                                        includeItem: request.isDirectory
                                     )
                                 )
                                 await Task.yield()
@@ -270,6 +273,7 @@ private final class ProjectTreeActions: @unchecked Sendable {
 private struct ProjectFileTreeContent: View, Equatable {
     let root: FileNode
     let availableWidth: CGFloat
+    let rowHeight: CGFloat
     let activeDocumentURL: URL?
     let gitStatus: ProjectGitStatusSnapshot
     let actions: ProjectTreeActions
@@ -279,6 +283,7 @@ private struct ProjectFileTreeContent: View, Equatable {
     static func == (lhs: ProjectFileTreeContent, rhs: ProjectFileTreeContent) -> Bool {
         lhs.root == rhs.root
             && lhs.availableWidth == rhs.availableWidth
+            && lhs.rowHeight == rhs.rowHeight
             && lhs.activeDocumentURL == rhs.activeDocumentURL
             && lhs.gitStatus == rhs.gitStatus
             && lhs.expandedDirectoryPathsSnapshot == rhs.expandedDirectoryPathsSnapshot
@@ -289,6 +294,7 @@ private struct ProjectFileTreeContent: View, Equatable {
             node: root,
             depth: 0,
             availableWidth: availableWidth,
+            rowHeight: rowHeight,
             activeDocumentURL: activeDocumentURL,
             gitStatus: gitStatus,
             actions: actions,
@@ -304,6 +310,7 @@ private struct FileNodeRow: View {
     let node: FileNode
     let depth: Int
     let availableWidth: CGFloat
+    let rowHeight: CGFloat
     let activeDocumentURL: URL?
     let gitStatus: ProjectGitStatusSnapshot
     let actions: ProjectTreeActions
@@ -330,6 +337,7 @@ private struct FileNodeRow: View {
                         node: child,
                         depth: depth + 1,
                         availableWidth: availableWidth,
+                        rowHeight: rowHeight,
                         activeDocumentURL: activeDocumentURL,
                         gitStatus: gitStatus,
                         actions: actions,
@@ -372,7 +380,7 @@ private struct FileNodeRow: View {
             .padding(.leading, CGFloat(depth * 14 + 8))
             .padding(.trailing, 8)
             .frame(width: rowWidth, alignment: .leading)
-            .frame(height: LitheTheme.Metrics.treeRowHeight)
+            .frame(height: rowHeight)
             .contentShape(Rectangle())
             .litheRowHover(
                 cornerRadius: 4,
@@ -381,7 +389,6 @@ private struct FileNodeRow: View {
         }
         .buttonStyle(LitheTreeRowButtonStyle())
         .lithePointer()
-        .padding(.vertical, 0.5)
         .padding(.horizontal, Self.horizontalInset)
         .contextMenu { directoryContextMenu }
     }
@@ -411,7 +418,7 @@ private struct FileNodeRow: View {
             .padding(.leading, CGFloat(depth * 14 + 8))
             .padding(.trailing, 8)
             .frame(width: rowWidth, alignment: .leading)
-            .frame(height: LitheTheme.Metrics.treeRowHeight)
+            .frame(height: rowHeight)
             .contentShape(Rectangle())
             .litheRowHover(
                 isActive: activeDocumentURL?.standardizedFileURL.path
@@ -423,7 +430,6 @@ private struct FileNodeRow: View {
         }
         .buttonStyle(LitheTreeRowButtonStyle())
         .lithePointer()
-        .padding(.vertical, 0.5)
         .padding(.horizontal, Self.horizontalInset)
         .contextMenu { fileContextMenu }
         .task(id: node.url.standardizedFileURL.path) {

--- a/Tests/LitheTests/AppSettingsTests.swift
+++ b/Tests/LitheTests/AppSettingsTests.swift
@@ -30,6 +30,21 @@ struct AppSettingsTests {
     }
 
     @Test
+    func projectTreeRowHeightDefaultsPersistsAndRestores() {
+        let store = AppSettingsTestStore()
+        let settings = AppSettings(store: store)
+
+        #expect(settings.projectTreeRowHeight == 24)
+
+        settings.projectTreeRowHeight = 29
+        #expect(AppSettings(store: store).projectTreeRowHeight == 29)
+
+        settings.restoreDefaults()
+        #expect(settings.projectTreeRowHeight == 24)
+        #expect(AppSettings(store: store).projectTreeRowHeight == 24)
+    }
+
+    @Test
     func customLogDirectoryPersistsAndCanBeRestoredToDefault() {
         let store = AppSettingsTestStore()
         let settings = AppSettings(store: store)

--- a/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -3724,8 +3724,21 @@ struct EditorDocumentTests {
     @Test
     func projectTreeLocatorMatchesStandardizedPathsAndExpandsParents() {
         let root = URL(fileURLWithPath: "/tmp/lithe-tree-locator-tests")
+        let sourcesDirectory = root.appendingPathComponent("Sources")
         let featureDirectory = root.appendingPathComponent("Sources/Feature")
         let fileURL = featureDirectory.appendingPathComponent("Example.swift")
+        let tree = FileNode(
+            url: root,
+            isDirectory: true,
+            children: [
+                FileNode(
+                    url: featureDirectory,
+                    isDirectory: true,
+                    children: [FileNode(url: fileURL, isDirectory: false, children: nil)],
+                    collapsedAncestorPaths: [sourcesDirectory.path]
+                )
+            ]
+        )
 
         let equivalentFile = root.appendingPathComponent("Sources/Nested/../Feature/Example.swift")
         #expect(ProjectTreeLocator.matchingURL(for: equivalentFile, among: [fileURL]) == fileURL)
@@ -3741,6 +3754,27 @@ struct EditorDocumentTests {
             ProjectTreeLocator.matchingURL(
                 for: root.deletingLastPathComponent().appendingPathComponent("Outside.swift"),
                 among: [fileURL]
+            ) == nil
+        )
+        #expect(ProjectTreeLocator.matchingURL(for: featureDirectory, in: tree) == featureDirectory)
+        #expect(ProjectTreeLocator.matchingURL(for: sourcesDirectory, in: tree) == featureDirectory)
+        #expect(ProjectTreeLocator.matchingURL(for: fileURL, in: tree) == fileURL)
+        #expect(
+            ProjectTreeLocator.expandedDirectoryPaths(
+                for: featureDirectory,
+                rootURL: root,
+                includeItem: true
+            ) == Set([
+                root.standardizedFileURL.path,
+                root.appendingPathComponent("Sources").standardizedFileURL.path,
+                featureDirectory.standardizedFileURL.path
+            ])
+        )
+        #expect(ProjectTreeLocator.matchingURL(for: root.appendingPathComponent("Hidden"), in: tree) == nil)
+        #expect(
+            ProjectTreeLocator.matchingURL(
+                for: root.deletingLastPathComponent().appendingPathComponent("Outside"),
+                in: tree
             ) == nil
         )
     }


### PR DESCRIPTION
## 已完成功能

### 1. 文件树行高可调

- 在“设置 → 编辑器 → 显示”中新增“文件树行高”。
- 支持在 `20–32 pt` 范围内按 `1 pt` 调整。
- 默认值为 `24 pt`，设置会持久化保存。
- 恢复默认设置时，行高恢复为 `24 pt`。
- 移除了文件树节点原有的额外垂直间距，使设置值与实际显示高度一致。

### 2. 编辑器面包屑联动文件树

- 点击编辑器顶部面包屑中的文件，可在文件树中定位并选中该文件。
- 点击面包屑中的目录，可切换到项目文件树并展开到对应目录。
- 支持经过折叠目录压缩后的文件树节点。
- 目标不属于当前工作区时，不会执行错误定位，并显示明确提示。

### 3. Git 工具窗口收起按钮

- 在 Git 底部工具窗口右上角增加收起按钮。
- 按钮固定在工具窗口最右侧区域，不再受 Git 内容布局影响。
- 点击后直接关闭 Git 工具窗口。

### 4. 分隔条拖拽反馈

- 鼠标悬停在左右或上下分隔条的可拖拽区域时，显示对应的缩放光标。
- 拖拽过程中保持缩放光标，结束或离开区域后恢复普通光标。
- 保留侧边栏宽度和底部工具窗口高度的拖拽调整能力。

### 5. 工作区分栏布局调整

- 调整工作区的层级布局，使 Git 收起按钮可以稳定覆盖在正确位置。
- 保持编辑器、侧边栏和底部工具窗口为实时视图，未引入页面截图或整体缓存。
- 继续保存用户调整后的侧边栏宽度和底部面板高度。

### 6. 自动化测试补充

- 增加文件树行高默认值、持久化和恢复默认值测试。
- 增加标准化路径、折叠目录匹配、目录展开范围和工作区边界测试。

## 验证结果

- `./scripts/test-macos.sh`：485 个测试全部通过。
- `./scripts/verify-service-boundaries.sh`：通过。
- `git diff --check`：通过。

## 本次不包含

以下试验性修改已回退，不在当前提交和远端分支中：

- Java/JDTLS 打包与运行状态调整。
- Java 定义、实现和 Command 点击跳转修改。
- Java 参数提示、绿色跳转标记及编辑器 gutter 调整。
- Java 实现选择框和定义结果栏修改。
<img width="1034" height="716" alt="截屏2026-08-20 10 22 58" src="https://github.com/user-attachments/assets/df7d3e8b-2a83-4e97-850e-4b8ad9b4d83b" />
<img width="1343" height="327" alt="截屏2026-08-20 10 28 49" src="https://github.com/user-attachments/assets/5da7c374-ab79-4487-976f-ab6b5439abd9" />
