### PR TITLE
fix:修复因为滚动逻辑区域没有完全覆盖所有文件夹导致的滚动异常问题

### DIFF
--- a/Sources/Lithe/Views/Workspace/ProjectSidebarView.swift
+++ b/Sources/Lithe/Views/Workspace/ProjectSidebarView.swift
@@ -24,7 +24,9 @@ struct ProjectSidebarView: View {
                 GeometryReader { geometry in
                     ScrollViewReader { proxy in
                         ScrollView([.vertical, .horizontal]) {
-                            LazyVStack(alignment: .leading, spacing: 1) {
+                            // The recursive tree is one scroll-content child. An eager stack
+                            // must measure its full height so AppKit receives a real scroll range.
+                            VStack(alignment: .leading, spacing: 1) {
                                 ProjectFileTreeContent(
                                     root: root,
                                     availableWidth: geometry.size.width,


### PR DESCRIPTION
修改一部分内容，主要是滚动区域异常的问题，这个好像在 win 那边也有问题但是我没有稳定复现，因此仅仅修改了 MacOS 部分