### PR TITLE
fix(windows): 稳定滚动区域视口引用

### DIFF
--- a/windows/tauri/src/ui/scroll-area.tsx
+++ b/windows/tauri/src/ui/scroll-area.tsx
@@ -1,5 +1,5 @@
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
-import { useLayoutEffect, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import type * as React from "react";
 import {
   bindOverlayWheelToScrollContainer,
@@ -46,14 +46,17 @@ function ScrollArea({
     return bindOverlayWheelToScrollContainer(rootNode, () => viewportNode);
   }, [rootNode, viewportNode]);
 
-  const setViewportRef = (node: HTMLDivElement | null) => {
-    setViewportNode(node);
-    if (typeof viewportRef === "function") {
-      viewportRef(node);
-    } else if (viewportRef) {
-      viewportRef.current = node;
-    }
-  };
+  const setViewportRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      setViewportNode(node);
+      if (typeof viewportRef === "function") {
+        viewportRef(node);
+      } else if (viewportRef) {
+        viewportRef.current = node;
+      }
+    },
+    [viewportRef],
+  );
 
   return (
     <ScrollAreaPrimitive.Root


### PR DESCRIPTION
## Summary

- keep the shared scroll-area viewport ref callback stable across renders
- avoid Base UI ref cleanup/rebind churn that can trigger React maximum update depth error #185
- preserve forwarded callback and object refs

## Verification

- `bun test src` (297 passed)
- `bun run typecheck`
- `bunx vp lint src/ui/scroll-area.tsx`
- `bun run build`
- `cargo test --manifest-path windows/tauri/src-tauri/Cargo.toml` (76 passed)
- Windows Release runtime smoke test: JDTLS reached `ServiceReady`; no React #185, WebView send failure, or LSP initialization error in the new session log