### PR TITLE
feat(macOS): 统一文件与终端标签拖拽及双向停靠

### DIFF
--- a/Sources/Lithe/Application/Features/DocumentFeatureModel.swift
+++ b/Sources/Lithe/Application/Features/DocumentFeatureModel.swift
@@ -413,6 +413,19 @@ final class DocumentFeatureModel: ObservableObject {
         onDocumentCollectionChanged?()
     }
 
+    func reorderDocuments(orderedIDs: [UUID]) {
+        let documentsByID = Dictionary(uniqueKeysWithValues: openDocuments.map { ($0.id, $0) })
+        var includedIDs: Set<UUID> = []
+        var next = orderedIDs.compactMap { id -> EditorDocument? in
+            guard includedIDs.insert(id).inserted else { return nil }
+            return documentsByID[id]
+        }
+        next.append(contentsOf: openDocuments.filter { !includedIDs.contains($0.id) })
+        guard next.map(\.id) != openDocuments.map(\.id) else { return }
+        openDocuments = next
+        onDocumentCollectionChanged?()
+    }
+
     func requestCloseDocument(_ document: EditorDocument) {
         isPendingProjectClose = false
         pendingCloseQueue = []

--- a/Sources/Lithe/Application/Features/EditorTabOrderFeatureModel.swift
+++ b/Sources/Lithe/Application/Features/EditorTabOrderFeatureModel.swift
@@ -1,0 +1,101 @@
+import Combine
+import Foundation
+
+/// Owns only the mixed presentation order of document and terminal tabs.
+/// Resource lifecycle and active selection remain with their existing features.
+@MainActor
+final class EditorTabOrderFeatureModel: ObservableObject {
+    @Published private(set) var items: [EditorTabItem] = []
+
+    var documentIDs: [UUID] {
+        items.compactMap {
+            guard case .document(let id) = $0 else { return nil }
+            return id
+        }
+    }
+
+    var terminalIDs: [UUID] {
+        items.compactMap {
+            guard case .terminal(let id) = $0 else { return nil }
+            return id
+        }
+    }
+
+    func contains(_ item: EditorTabItem) -> Bool {
+        items.contains(item)
+    }
+
+    func moveToEnd(_ item: EditorTabItem) {
+        var next = items
+        next.removeAll { $0 == item }
+        next.append(item)
+        guard next != items else { return }
+        items = next
+    }
+
+    func remove(_ item: EditorTabItem) {
+        items.removeAll { $0 == item }
+    }
+
+    func removeAllTerminals() {
+        items.removeAll {
+            guard case .terminal = $0 else { return false }
+            return true
+        }
+    }
+
+    @discardableResult
+    func move(_ item: EditorTabItem, before target: EditorTabItem) -> Bool {
+        move(item, relativeTo: target, insertAfter: false)
+    }
+
+    @discardableResult
+    func move(_ item: EditorTabItem, after target: EditorTabItem) -> Bool {
+        move(item, relativeTo: target, insertAfter: true)
+    }
+
+    /// Reconciles document membership and relative order while leaving terminal
+    /// slots untouched. This lets the document feature remain the resource owner.
+    func reconcileDocuments(orderedIDs: [UUID]) {
+        let openDocumentIDs = Set(orderedIDs)
+        let representedDocumentIDs = Set(documentIDs)
+        let reorderedExistingIDs = orderedIDs.filter { representedDocumentIDs.contains($0) }
+        var existingIndex = 0
+        var next: [EditorTabItem] = []
+
+        for item in items {
+            switch item {
+            case .document(let id):
+                guard openDocumentIDs.contains(id),
+                      reorderedExistingIDs.indices.contains(existingIndex) else { continue }
+                next.append(.document(reorderedExistingIDs[existingIndex]))
+                existingIndex += 1
+            case .terminal:
+                next.append(item)
+            }
+        }
+
+        let alreadyRepresented = Set(reorderedExistingIDs)
+        next.append(contentsOf: orderedIDs.compactMap { id in
+            alreadyRepresented.contains(id) ? nil : .document(id)
+        })
+
+        guard next != items else { return }
+        items = next
+    }
+
+    private func move(
+        _ item: EditorTabItem,
+        relativeTo target: EditorTabItem,
+        insertAfter: Bool
+    ) -> Bool {
+        guard item != target, items.contains(target) else { return false }
+        var next = items
+        next.removeAll { $0 == item }
+        guard let targetIndex = next.firstIndex(of: target) else { return false }
+        next.insert(item, at: targetIndex + (insertAfter ? 1 : 0))
+        guard next != items else { return false }
+        items = next
+        return true
+    }
+}

--- a/Sources/Lithe/Application/Features/TerminalPlacementFeatureModel.swift
+++ b/Sources/Lithe/Application/Features/TerminalPlacementFeatureModel.swift
@@ -51,6 +51,17 @@ final class TerminalPlacementFeatureModel: ObservableObject {
         activeEditorSessionID = nil
     }
 
+    func reorderEditorSessions(orderedIDs: [UUID]) {
+        let editorIDs = Set(editorSessionIDs)
+        var includedIDs: Set<UUID> = []
+        var next = orderedIDs.filter { id in
+            editorIDs.contains(id) && includedIDs.insert(id).inserted
+        }
+        next.append(contentsOf: editorSessionIDs.filter { !includedIDs.contains($0) })
+        guard next != editorSessionIDs else { return }
+        editorSessionIDs = next
+    }
+
     func removeSession(_ sessionID: UUID) {
         toolSessionIDs.removeAll { $0 == sessionID }
         editorSessionIDs.removeAll { $0 == sessionID }

--- a/Sources/Lithe/Models/AppModel/AppModel+FeatureState.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel+FeatureState.swift
@@ -71,12 +71,58 @@ extension AppModel {
         }
     }
 
+    var editorTabItems: [EditorTabItem] { editorTabOrderFeature.items }
+
     func moveOpenDocument(_ documentID: UUID, before targetDocumentID: UUID) {
-        documentFeature.moveDocument(documentID, before: targetDocumentID)
+        moveEditorTab(.document(documentID), before: .document(targetDocumentID))
     }
 
     func moveOpenDocument(_ documentID: UUID, after targetDocumentID: UUID) {
-        documentFeature.moveDocument(documentID, after: targetDocumentID)
+        moveEditorTab(.document(documentID), after: .document(targetDocumentID))
+    }
+
+    func moveEditorTab(_ item: EditorTabItem, before target: EditorTabItem) {
+        moveEditorTab(item, relativeTo: target, insertAfter: false)
+    }
+
+    func moveEditorTab(_ item: EditorTabItem, after target: EditorTabItem) {
+        moveEditorTab(item, relativeTo: target, insertAfter: true)
+    }
+
+    private func moveEditorTab(
+        _ item: EditorTabItem,
+        relativeTo target: EditorTabItem,
+        insertAfter: Bool
+    ) {
+        guard item != target, editorTabOrderFeature.contains(target) else { return }
+        let moved = insertAfter
+            ? editorTabOrderFeature.move(item, after: target)
+            : editorTabOrderFeature.move(item, before: target)
+        guard moved else { return }
+
+        switch item {
+        case .document(let documentID):
+            guard openDocuments.contains(where: { $0.id == documentID }) else {
+                editorTabOrderFeature.remove(item)
+                return
+            }
+            documentFeature.reorderDocuments(orderedIDs: editorTabOrderFeature.documentIDs)
+        case .terminal(let sessionID):
+            guard let session = terminalSessions.first(where: { $0.id == sessionID }) else {
+                editorTabOrderFeature.remove(item)
+                return
+            }
+            let wasAlreadyInEditor = terminalPlacementFeature.editorSessionIDs.contains(sessionID)
+            if !wasAlreadyInEditor {
+                terminalPlacementFeature.moveToEditor(sessionID)
+            }
+            terminalPlacementFeature.reorderEditorSessions(
+                orderedIDs: editorTabOrderFeature.terminalIDs
+            )
+            if !wasAlreadyInEditor {
+                _ = terminalFeature?.selectSession(session)
+            }
+        }
     }
     var pendingCloseDocument: EditorDocument? { documentFeature.pendingCloseDocument }
     var isPendingProjectClose: Bool { documentFeature.isPendingProjectClose }

--- a/Sources/Lithe/Models/AppModel/AppModel+FeatureState.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel+FeatureState.swift
@@ -102,11 +102,12 @@ extension AppModel {
 
         switch item {
         case .document(let documentID):
-            guard openDocuments.contains(where: { $0.id == documentID }) else {
+            guard let document = openDocuments.first(where: { $0.id == documentID }) else {
                 editorTabOrderFeature.remove(item)
                 return
             }
             documentFeature.reorderDocuments(orderedIDs: editorTabOrderFeature.documentIDs)
+            selectEditorDocument(document)
         case .terminal(let sessionID):
             guard let session = terminalSessions.first(where: { $0.id == sessionID }) else {
                 editorTabOrderFeature.remove(item)
@@ -119,9 +120,7 @@ extension AppModel {
             terminalPlacementFeature.reorderEditorSessions(
                 orderedIDs: editorTabOrderFeature.terminalIDs
             )
-            if !wasAlreadyInEditor {
-                _ = terminalFeature?.selectSession(session)
-            }
+            selectEditorTerminalSession(session)
         }
     }
     var pendingCloseDocument: EditorDocument? { documentFeature.pendingCloseDocument }

--- a/Sources/Lithe/Models/AppModel/AppModel+Terminal.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel+Terminal.swift
@@ -119,23 +119,24 @@ extension AppModel {
     func moveTerminalToEditor(_ sessionID: UUID) {
         guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
         terminalPlacementFeature.moveToEditor(sessionID)
+        editorTabOrderFeature.moveToEnd(.terminal(sessionID))
+        terminalPlacementFeature.reorderEditorSessions(
+            orderedIDs: editorTabOrderFeature.terminalIDs
+        )
         _ = terminalFeature?.selectSession(session)
     }
 
     func moveTerminalToEditor(_ sessionID: UUID, before targetSessionID: UUID) {
-        guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
-        terminalPlacementFeature.moveToEditor(sessionID, before: targetSessionID)
-        _ = terminalFeature?.selectSession(session)
+        moveEditorTab(.terminal(sessionID), before: .terminal(targetSessionID))
     }
 
     func moveTerminalToEditor(_ sessionID: UUID, after targetSessionID: UUID) {
-        guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
-        terminalPlacementFeature.moveToEditor(sessionID, after: targetSessionID)
-        _ = terminalFeature?.selectSession(session)
+        moveEditorTab(.terminal(sessionID), after: .terminal(targetSessionID))
     }
 
     func moveTerminalToTool(_ sessionID: UUID) {
         guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
+        editorTabOrderFeature.remove(.terminal(sessionID))
         terminalPlacementFeature.moveToTool(sessionID)
         _ = terminalFeature?.selectSession(session)
         isTerminalVisible = true
@@ -143,6 +144,7 @@ extension AppModel {
 
     func moveTerminalToTool(_ sessionID: UUID, before targetSessionID: UUID) {
         guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
+        editorTabOrderFeature.remove(.terminal(sessionID))
         terminalPlacementFeature.moveToTool(sessionID, before: targetSessionID)
         _ = terminalFeature?.selectSession(session)
         isTerminalVisible = true
@@ -150,6 +152,7 @@ extension AppModel {
 
     func moveTerminalToTool(_ sessionID: UUID, after targetSessionID: UUID) {
         guard let session = terminalSessions.first(where: { $0.id == sessionID }) else { return }
+        editorTabOrderFeature.remove(.terminal(sessionID))
         terminalPlacementFeature.moveToTool(sessionID, after: targetSessionID)
         _ = terminalFeature?.selectSession(session)
         isTerminalVisible = true
@@ -157,6 +160,7 @@ extension AppModel {
 
     func closeTerminalSession(_ session: TerminalSession) {
         guard terminalSessions.contains(where: { $0.id == session.id }) else { return }
+        editorTabOrderFeature.remove(.terminal(session.id))
         terminalPlacementFeature.removeSession(session.id)
         terminalFeature?.closeSession(session)
         if terminalSessions.isEmpty {
@@ -168,6 +172,7 @@ extension AppModel {
     func restartActiveTerminal() { terminalFeature?.restartActiveSession() }
     func restartActiveTerminal(using shellPath: String) { terminalFeature?.restartActiveSession(using: shellPath) }
     func stopTerminalSessions() {
+        editorTabOrderFeature.removeAllTerminals()
         terminalPlacementFeature.reset()
         terminalFeature?.stopAllSessions()
     }

--- a/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -162,6 +162,7 @@ final class AppModel: ObservableObject, Identifiable {
     let workspaceFeature: WorkspaceFeatureModel
     let githubFeature: GitHubFeatureModel
     let discourseCommunityFeature: DiscourseCommunityFeatureModel
+    let editorTabOrderFeature = EditorTabOrderFeatureModel()
     let terminalPlacementFeature: TerminalPlacementFeatureModel
     private struct CachedModuleCapability {
         let moduleID: ModuleID
@@ -275,7 +276,9 @@ final class AppModel: ObservableObject, Identifiable {
     private var workspaceFeatureObservation: AnyCancellable?
     private var githubFeatureObservation: AnyCancellable?
     private var runtimeFeatureObservation: AnyCancellable?
+    private var editorTabOrderFeatureObservation: AnyCancellable?
     private var terminalPlacementObservation: AnyCancellable?
+    private var documentTabCollectionObservation: AnyCancellable?
     private var activeDocumentSelectionObservation: AnyCancellable?
     private var moduleRuntimeObservationID: UUID?
 
@@ -426,6 +429,8 @@ final class AppModel: ObservableObject, Identifiable {
         navigationHistoryFeatureObservation = navigationHistoryFeature.objectWillChange.sink { [weak self] _ in
             self?.scheduleObjectWillChangeRelay()
         }
+        editorTabOrderFeatureObservation = editorTabOrderFeature.objectWillChange
+            .sink { [weak self] _ in self?.scheduleObjectWillChangeRelay() }
         terminalPlacementObservation = terminalPlacementFeature.objectWillChange.sink { [weak self] _ in
             self?.scheduleObjectWillChangeRelay()
         }
@@ -588,6 +593,9 @@ final class AppModel: ObservableObject, Identifiable {
         documentFeatureObservation = documentFeature.objectWillChange.sink { [weak self] _ in
             self?.scheduleObjectWillChangeRelay()
         }
+        documentTabCollectionObservation = documentFeature.$openDocuments
+            .map { $0.map(\.id) }.removeDuplicates()
+            .sink { [weak self] ids in self?.editorTabOrderFeature.reconcileDocuments(orderedIDs: ids) }
         javaFeature.configure(
             documentProvider: { [weak self] in self?.activeDocument },
             caretProvider: { [weak self] in self?.editorCaret },

--- a/Sources/Lithe/Models/Editor/EditorTabItem.swift
+++ b/Sources/Lithe/Models/Editor/EditorTabItem.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Identifies content that participates in the shared editor tab order.
+enum EditorTabItem: Hashable, Identifiable {
+    case document(UUID)
+    case terminal(UUID)
+
+    var id: Self { self }
+}

--- a/Sources/Lithe/Views/Editor/CodeEditorView.swift
+++ b/Sources/Lithe/Views/Editor/CodeEditorView.swift
@@ -444,9 +444,6 @@ struct CodeEditorView: NSViewRepresentable {
         textView.onPasteImage = { [weak coordinator = context.coordinator] in
             coordinator?.pasteMarkdownImage() ?? false
         }
-        textView.onTerminalTabDrop = { [weak coordinator = context.coordinator] sessionID in
-            coordinator?.moveTerminalToEditor(sessionID) ?? false
-        }
         textView.onLayoutGeometryChanged = { [weak coordinator = context.coordinator] in
             coordinator?.scheduleEditorOverlayRelayout()
         }
@@ -877,15 +874,6 @@ struct CodeEditorView: NSViewRepresentable {
                     model.showNotification("Could not paste image: \(error.localizedDescription)")
                 }
             }
-            return true
-        }
-
-        func moveTerminalToEditor(_ sessionID: UUID) -> Bool {
-            guard let model,
-                  model.terminalSessions.contains(where: { $0.id == sessionID }) else {
-                return false
-            }
-            model.moveTerminalToEditor(sessionID)
             return true
         }
 
@@ -1486,7 +1474,6 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
     var onFormatRequested: (() -> Void)?
     var onCodeActionsRequested: ((Int, Int) -> Void)?
     var onPasteImage: (() -> Bool)?
-    var onTerminalTabDrop: ((UUID) -> Bool)?
 
     private var findMatchRanges: [NSRange] = []
     private var currentFindMatchIndex = 0
@@ -1556,43 +1543,29 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
     }
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard isTerminalTabDrag(sender) else { return super.draggingEntered(sender) }
-        return terminalTabDragOperation(sender)
+        guard !isTerminalTabDrag(sender) else { return [] }
+        return super.draggingEntered(sender)
     }
 
     override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard isTerminalTabDrag(sender) else { return super.draggingUpdated(sender) }
-        return terminalTabDragOperation(sender)
+        guard !isTerminalTabDrag(sender) else { return [] }
+        return super.draggingUpdated(sender)
     }
 
     override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        guard isTerminalTabDrag(sender) else { return super.prepareForDragOperation(sender) }
-        return onTerminalTabDrop != nil
+        guard !isTerminalTabDrag(sender) else { return false }
+        return super.prepareForDragOperation(sender)
     }
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        guard isTerminalTabDrag(sender) else { return super.performDragOperation(sender) }
-        return performTerminalTabDrop(from: sender.draggingPasteboard)
-    }
-
-    func performTerminalTabDrop(from pasteboard: NSPasteboard) -> Bool {
-        guard let sessionID = TerminalTabDragPayload.sessionID(from: pasteboard),
-              let onTerminalTabDrop else { return false }
-        return onTerminalTabDrop(sessionID)
+        guard !isTerminalTabDrag(sender) else { return false }
+        return super.performDragOperation(sender)
     }
 
     private func isTerminalTabDrag(_ sender: NSDraggingInfo) -> Bool {
         sender.draggingPasteboard.availableType(
             from: [TerminalTabDragPayload.pasteboardType]
         ) != nil
-    }
-
-    private func terminalTabDragOperation(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard onTerminalTabDrop != nil else { return [] }
-        let sourceMask = sender.draggingSourceOperationMask
-        if sourceMask.contains(.move) { return .move }
-        if sourceMask.contains(.copy) { return .copy }
-        return []
     }
 
     override func setSelectedRange(_ charRange: NSRange) {
@@ -2998,7 +2971,6 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
         let textStorage = NSTextStorage()
         textStorage.addLayoutManager(layoutManager)
         super.init(frame: frameRect, textContainer: textContainer)
-        registerForDraggedTypes([TerminalTabDragPayload.pasteboardType])
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleFindQueryChanged(_:)),

--- a/Sources/Lithe/Views/Editor/EditorAreaView.swift
+++ b/Sources/Lithe/Views/Editor/EditorAreaView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import LitheGitModule
 import LitheTerminalModule
 
+private let editorTabCoordinateSpaceName = "lithe.editor-tab-strip"
+
 private enum MarkdownViewMode: String, CaseIterable, Identifiable, Equatable {
     case editor
     case split
@@ -32,6 +34,11 @@ struct EditorAreaView: View {
     @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @State private var hoveredTabID: UUID?
     @State private var tabDragState = EditorTabDragState.idle
+    @State private var editorTabFrames: [EditorTabItem: CGRect] = [:]
+    @State private var tabDragStartFrames: [EditorTabItem: CGRect] = [:]
+    @State private var tabDragOffsetX: CGFloat = 0
+    @State private var tabReorderTarget: EditorTabReorderTarget?
+    @State private var isTerminalTabBarDropTargeted = false
     @State private var splitDocumentID: UUID?
     @State private var markdownViewModes: [UUID: MarkdownViewMode] = [:]
     @State private var markdownScrollPositions: [UUID: MarkdownScrollPosition] = [:]
@@ -57,7 +64,7 @@ struct EditorAreaView: View {
                     DiffReviewView(change: selectedChange)
                 } else {
                     VStack(spacing: 0) {
-                        if model.openDocuments.isEmpty && model.editorTerminalSessions.isEmpty {
+                        if model.editorTabItems.isEmpty {
                             emptyState
                         } else {
                             editorWorkspace
@@ -81,12 +88,16 @@ struct EditorAreaView: View {
             markdownViewModes = markdownViewModes.filter { ids.contains($0.key) }
             markdownScrollPositions = markdownScrollPositions.filter { ids.contains($0.key) }
             editorViewportStore.retain(documentIDs: Set(ids))
-            if let draggedDocumentID = tabDragState.draggedDocumentID,
-               !ids.contains(draggedDocumentID) {
+        }
+        .onChange(of: model.editorTabItems) { items in
+            isTerminalTabBarDropTargeted = false
+            if let draggedItem = tabDragState.draggedItem,
+               !items.contains(draggedItem) {
                 finishTabDrag()
             }
         }
         .onDisappear {
+            isTerminalTabBarDropTargeted = false
             finishTabDrag()
         }
         .onChange(of: settings.editorTabLayoutMode) { _ in
@@ -135,7 +146,40 @@ struct EditorAreaView: View {
             }
         }
         .frame(minHeight: LitheTheme.Metrics.tabHeight, alignment: .top)
-        .background(LitheTheme.sidebar)
+        .contentShape(Rectangle())
+        .background(
+            isTerminalTabBarDropTargeted
+                ? LitheTheme.accent.opacity(0.08)
+                : LitheTheme.sidebar
+        )
+        .onDrop(
+            of: [TerminalTabDragPayload.type],
+            delegate: EditorTabBarDropDelegate(
+                setTargeted: { isTerminalTabBarDropTargeted = $0 },
+                updateTarget: { location in
+                    updateTerminalTabBarDropTarget(at: location)
+                },
+                clearTarget: { clearTerminalTabBarDropTarget() },
+                resolveTarget: { location in
+                    terminalTabBarDropTarget(at: location)
+                },
+                finish: { finishTabDrag() },
+                receiveTerminal: { sessionID, target in
+                    guard let target,
+                          model.editorTabItems.contains(target.item) else {
+                        if !model.editorTerminalSessions.contains(where: { $0.id == sessionID }) {
+                            model.moveTerminalToEditor(sessionID)
+                        }
+                        return
+                    }
+                    if target.side == .after {
+                        model.moveEditorTab(.terminal(sessionID), after: target.item)
+                    } else {
+                        model.moveEditorTab(.terminal(sessionID), before: target.item)
+                    }
+                }
+            )
+        )
     }
 
     @ViewBuilder
@@ -153,18 +197,13 @@ struct EditorAreaView: View {
                 multipleRowsEditorTabLayout
             }
         }
-        // A live flow-layout reorder can leave the pointer in the empty area
-        // next to the last tab. In that case no individual tab receives
-        // performDrop, so the tab bar itself must finish the session.
-        .onDrop(
-            of: [EditorTabDragPayload.type, TerminalTabDragPayload.type],
-            delegate: EditorTabBarDropDelegate(
-                finish: { finishTabDrag() },
-                receiveTerminal: { sessionID in
-                    model.moveTerminalToEditor(sessionID)
-                }
-            )
-        )
+        .coordinateSpace(name: editorTabCoordinateSpaceName)
+        .onPreferenceChange(EditorTabFramePreferenceKey.self) { frames in
+            guard tabDragState.draggedItem == nil else { return }
+            editorTabFrames = frames
+        }
+        .clipped()
+        .animation(tabAnimation, value: model.editorTabItems)
     }
 
     private var multipleRowsEditorTabLayout: some View {
@@ -178,20 +217,30 @@ struct EditorAreaView: View {
 
     @ViewBuilder
     private var editorTabItems: some View {
-        ForEach(Array(model.openDocuments.enumerated()), id: \.element.id) { index, document in
-            editorTab(document, at: index)
-        }
-        ForEach(model.editorTerminalSessions) { session in
-            editorTerminalTab(session)
+        ForEach(model.editorTabItems) { item in
+            switch item {
+            case .document(let documentID):
+                if let index = model.openDocuments.firstIndex(where: { $0.id == documentID }) {
+                    editorTab(model.openDocuments[index], at: index)
+                }
+            case .terminal(let sessionID):
+                if let session = model.terminalSessions.first(where: { $0.id == sessionID }) {
+                    editorTerminalTab(session)
+                }
+            }
         }
     }
 
     private func editorTab(_ document: EditorDocument, at index: Int) -> some View {
+        let tabItem = EditorTabItem.document(document.id)
         let dropSide: EditorTabDropSide? = {
+            if tabReorderTarget?.item == tabItem {
+                return tabReorderTarget?.side
+            }
             guard tabDragState.dropTarget?.documentID == document.id else { return nil }
             return tabDragState.dropTarget?.side
         }()
-        let isDragged = tabDragState.draggedDocumentID == document.id
+        let isDragged = tabDragState.draggedItem == tabItem
         let dragSessionID = tabDragState.sessionID
         let dropTargetRevision = tabDragState.dropTargetRevision
 
@@ -217,7 +266,7 @@ struct EditorAreaView: View {
                     .onDrop(
                         of: [EditorTabDragPayload.type, TerminalTabDragPayload.type],
                         delegate: EditorTabDropDelegate(
-                            draggedDocumentID: tabDragState.draggedDocumentID,
+                            draggedItem: tabDragState.draggedItem,
                             targetDocumentID: document.id,
                             targetWidth: geometry.size.width,
                             dragSessionID: dragSessionID,
@@ -225,15 +274,21 @@ struct EditorAreaView: View {
                             updateTarget: { target, sessionID, revision in
                                 guard tabDragState.sessionID == sessionID,
                                       tabDragState.dropTargetRevision == revision,
-                                      let source = tabDragState.draggedDocumentID,
-                                      source != target.documentID,
+                                      let source = tabDragState.draggedItem,
+                                      source != .document(target.documentID),
                                       tabDragState.dropTarget != target else { return }
                                 withAnimation(tabAnimation) {
                                     tabDragState.updateTarget(target)
                                     if target.side == .after {
-                                        model.moveOpenDocument(source, after: target.documentID)
+                                        model.moveEditorTab(
+                                            source,
+                                            after: .document(target.documentID)
+                                        )
                                     } else {
-                                        model.moveOpenDocument(source, before: target.documentID)
+                                        model.moveEditorTab(
+                                            source,
+                                            before: .document(target.documentID)
+                                        )
                                     }
                                 }
                             },
@@ -249,21 +304,51 @@ struct EditorAreaView: View {
                                     )
                                 }
                             },
+                            updateTerminalTarget: { target in
+                                updateTerminalTabBarDropTarget(target)
+                            },
+                            clearTerminalTarget: { item in
+                                clearTerminalTabBarDropTarget(matching: item)
+                            },
+                            resolveTerminalSide: { proposedSide in
+                                resolveTerminalDropSide(
+                                    proposedSide,
+                                    target: .document(document.id)
+                                )
+                            },
                             finish: { finishTabDrag() },
-                            receiveTerminal: { sessionID in
-                                model.moveTerminalToEditor(sessionID)
+                            receiveTerminal: { sessionID, side in
+                                if side == .after {
+                                    model.moveEditorTab(
+                                        .terminal(sessionID),
+                                        after: .document(document.id)
+                                    )
+                                } else {
+                                    model.moveEditorTab(
+                                        .terminal(sessionID),
+                                        before: .document(document.id)
+                                    )
+                                }
                             }
                         )
                     )
             }
         }
-        .opacity(isDragged ? 0.34 : 1)
-        .scaleEffect(isDragged ? 0.98 : 1)
+        .background {
+            editorTabFrameReader(for: tabItem)
+        }
+        .opacity(isDragged ? 0.92 : 1)
+        .scaleEffect(isDragged ? 0.99 : 1)
+        .offset(x: isDragged ? tabDragOffsetX : 0)
+        .zIndex(isDragged ? 1 : 0)
         .animation(tabAnimation, value: isDragged)
     }
 
     private func editorTerminalTab(_ session: TerminalSession) -> some View {
         let isActive = model.activeEditorTerminalSession?.id == session.id
+        let tabItem = EditorTabItem.terminal(session.id)
+        let isDragged = tabDragState.draggedItem == tabItem
+        let dropSide = tabReorderTarget?.item == tabItem ? tabReorderTarget?.side : nil
 
         return HStack(spacing: 0) {
             HStack(spacing: 7) {
@@ -279,18 +364,22 @@ struct EditorAreaView: View {
             .padding(.leading, 11)
             .frame(height: LitheTheme.Metrics.tabHeight)
             .contentShape(Rectangle())
-            .contentShape(
-                .dragPreview,
-                RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius)
-            )
             .onTapGesture {
                 model.selectEditorTerminalSession(session)
                 session.focus()
             }
+            // Keep a compact native marker for cross-container drops without
+            // bringing back the free-floating tab card. The clipped tab strip
+            // provides the horizontal snap feedback.
             .onDrag {
                 TerminalTabDragPayload.provider(for: session.id)
             } preview: {
-                editorTerminalDragPreview(session)
+                Image(systemName: "terminal")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(LitheTheme.accent)
+                    .frame(width: 20, height: 20)
+                    .background(LitheTheme.activeTabBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel(model.terminalTitle(for: session))
@@ -316,10 +405,28 @@ struct EditorAreaView: View {
             .allowsHitTesting(isActive || hoveredTabID == session.id)
             .padding(.trailing, 4)
         }
-        .background(isActive ? LitheTheme.activeTabBackground : LitheTheme.inactiveTabBackground)
+        .background(
+            isActive
+                ? LitheTheme.activeTabBackground
+                : (dropSide == nil
+                    ? LitheTheme.inactiveTabBackground
+                    : LitheTheme.accent.opacity(0.13))
+        )
         .overlay(alignment: .bottom) {
             if isActive {
                 Rectangle().fill(LitheTheme.accent).frame(height: 2)
+            }
+        }
+        .overlay(alignment: .leading) {
+            if dropSide == .some(.before) {
+                tabDropInsertionIndicator
+                    .padding(.vertical, 5)
+            }
+        }
+        .overlay(alignment: .trailing) {
+            if dropSide == .some(.after) {
+                tabDropInsertionIndicator
+                    .padding(.vertical, 5)
             }
         }
         .background {
@@ -327,28 +434,47 @@ struct EditorAreaView: View {
                 Color.clear
                     .contentShape(Rectangle())
                     .onDrop(
-                        of: [TerminalTabDragPayload.type],
+                        of: [EditorTabDragPayload.type, TerminalTabDragPayload.type],
                         delegate: EditorTerminalTabDropDelegate(
+                            draggedItem: tabDragState.draggedItem,
                             targetSessionID: session.id,
                             targetWidth: geometry.size.width,
-                            moveBefore: { sourceID in
+                            moveItemBefore: { item in
+                                model.moveEditorTab(item, before: tabItem)
+                            },
+                            moveItemAfter: { item in
+                                model.moveEditorTab(item, after: tabItem)
+                            },
+                            moveTerminalBefore: { sourceID in
                                 model.moveTerminalToEditor(sourceID, before: session.id)
                             },
-                            moveAfter: { sourceID in
+                            moveTerminalAfter: { sourceID in
                                 model.moveTerminalToEditor(sourceID, after: session.id)
-                            }
+                            },
+                            updateTerminalTarget: { target in
+                                updateTerminalTabBarDropTarget(target)
+                            },
+                            clearTerminalTarget: { item in
+                                clearTerminalTabBarDropTarget(matching: item)
+                            },
+                            resolveTerminalSide: { proposedSide in
+                                resolveTerminalDropSide(
+                                    proposedSide,
+                                    target: .terminal(session.id)
+                                )
+                            },
+                            finish: { finishTabDrag() }
                         )
                     )
             }
+        }
+        .background {
+            editorTabFrameReader(for: tabItem)
         }
         .onHover { isHovering in
             hoveredTabID = isHovering ? session.id : nil
         }
         .contextMenu {
-            Button("Move to Terminal") {
-                model.moveTerminalToTool(session.id)
-            }
-            Divider()
             Button("Interrupt", action: session.interrupt)
             Button("Restart", action: session.restart)
             Button("Clear", action: session.clear)
@@ -357,23 +483,11 @@ struct EditorAreaView: View {
                 model.closeTerminalSession(session)
             }
         }
-    }
-
-    private func editorTerminalDragPreview(_ session: TerminalSession) -> some View {
-        HStack(spacing: 7) {
-            Image(systemName: "terminal")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(LitheTheme.accent)
-            Text(model.terminalTitle(for: session))
-                .font(.system(size: 12.5, weight: .medium))
-                .foregroundStyle(LitheTheme.primaryText)
-                .lineLimit(1)
-        }
-        .padding(.horizontal, 11)
-        .frame(height: LitheTheme.Metrics.tabHeight)
-        .background(LitheTheme.activeTabBackground)
-        .clipShape(RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius))
-        .shadow(color: .black.opacity(0.42), radius: 10, y: 6)
+        .opacity(isDragged ? 0.92 : 1)
+        .scaleEffect(isDragged ? 0.99 : 1)
+        .offset(x: isDragged ? tabDragOffsetX : 0)
+        .zIndex(isDragged ? 1 : 0)
+        .animation(tabAnimation, value: isDragged)
     }
 
     private func editorTabContent(
@@ -396,22 +510,14 @@ struct EditorAreaView: View {
             .padding(.leading, 11)
             .frame(height: LitheTheme.Metrics.tabHeight)
             .contentShape(Rectangle())
-            .contentShape(
-                .dragPreview,
-                RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius)
-            )
             // Keep the drag source on a plain view. On macOS a nested Button
-            // can win the mouse gesture before a parent onDrag creates a
-            // dragging session.
+            // can win the mouse gesture before a parent drag gesture starts.
             .onTapGesture {
                 model.selectEditorDocument(document)
             }
-            .onDrag {
-                beginTabDrag(document.id)
-                return EditorTabDragPayload.provider(for: document.id)
-            } preview: {
-                editorTabDragPreview(document)
-            }
+            .highPriorityGesture(
+                horizontalTabDragGesture(for: .document(document.id))
+            )
             .accessibilityElement(children: .combine)
             .accessibilityLabel(document.displayName)
             .accessibilityAddTraits(.isButton)
@@ -485,52 +591,223 @@ struct EditorAreaView: View {
             .transition(.opacity.combined(with: .scale))
     }
 
-    private func editorTabDragPreview(_ document: EditorDocument) -> some View {
-        HStack(spacing: 7) {
-            LitheIcon(
-                kind: LitheIcons.kind(for: document.url, isDirectory: false),
-                size: 13
-            )
-            .foregroundStyle(LitheTheme.accent)
-
-            Text(document.displayName)
-                .font(.system(size: 12.5, weight: .medium))
-                .foregroundStyle(LitheTheme.primaryText)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .frame(maxWidth: 240, alignment: .leading)
-
-            if document.isDirty {
-                Circle()
-                    .fill(LitheTheme.primaryText)
-                    .frame(width: 6, height: 6)
-            }
-        }
-        .padding(.leading, 11)
-        .padding(.trailing, 9)
-        .fixedSize(horizontal: true, vertical: false)
-        .frame(height: LitheTheme.Metrics.tabHeight, alignment: .leading)
-        .background(LitheTheme.activeTabBackground)
-        .clipShape(RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius))
-        .shadow(color: .black.opacity(0.42), radius: 10, y: 6)
-        .compositingGroup()
-    }
-
     private var tabAnimation: Animation? {
-        accessibilityReduceMotion ? nil : .easeOut(duration: 0.14)
+        accessibilityReduceMotion
+            ? nil
+            : .interactiveSpring(response: 0.22, dampingFraction: 0.86, blendDuration: 0.10)
     }
 
-    private func beginTabDrag(_ documentID: UUID) {
+    private func editorTabFrameReader(for item: EditorTabItem) -> some View {
+        GeometryReader { geometry in
+            Color.clear.preference(
+                key: EditorTabFramePreferenceKey.self,
+                value: [
+                    item: geometry.frame(in: .named(editorTabCoordinateSpaceName))
+                ]
+            )
+        }
+    }
+
+    private func horizontalTabDragGesture(for item: EditorTabItem) -> some Gesture {
+        DragGesture(
+            minimumDistance: 8,
+            coordinateSpace: .named(editorTabCoordinateSpaceName)
+        )
+        .onChanged { value in
+            if tabDragState.draggedItem != item {
+                beginTabDrag(item)
+            }
+            updateHorizontalTabDrag(item, translationX: value.translation.width)
+        }
+        .onEnded { value in
+            finishHorizontalTabDrag(item, translationX: value.translation.width)
+        }
+    }
+
+    private func beginTabDrag(_ item: EditorTabItem) {
+        tabDragStartFrames = editorTabFrames
+        tabDragOffsetX = 0
+        tabReorderTarget = nil
         withAnimation(tabAnimation) {
-            tabDragState.begin(documentID: documentID)
+            tabDragState.begin(item: item)
+        }
+    }
+
+    private func updateHorizontalTabDrag(
+        _ item: EditorTabItem,
+        translationX: CGFloat
+    ) {
+        guard tabDragState.draggedItem == item,
+              let plan = horizontalTabDragPlan(for: item, translationX: translationX) else { return }
+        tabDragOffsetX = plan.offset
+        guard tabReorderTarget != plan.target else { return }
+        withAnimation(tabAnimation) {
+            tabReorderTarget = plan.target
+        }
+    }
+
+    private func finishHorizontalTabDrag(
+        _ item: EditorTabItem,
+        translationX: CGFloat
+    ) {
+        guard tabDragState.draggedItem == item else {
+            finishTabDrag()
+            return
+        }
+        let target = horizontalTabDragPlan(for: item, translationX: translationX)?.target
+        withAnimation(tabAnimation) {
+            if let target {
+                if target.side == .after {
+                    model.moveEditorTab(item, after: target.item)
+                } else {
+                    model.moveEditorTab(item, before: target.item)
+                }
+            }
+            tabDragOffsetX = 0
+            tabReorderTarget = nil
+            tabDragState.finish()
+        }
+        tabDragStartFrames = [:]
+    }
+
+    private func horizontalTabDragPlan(
+        for item: EditorTabItem,
+        translationX: CGFloat
+    ) -> (offset: CGFloat, target: EditorTabReorderTarget?)? {
+        guard let sourceFrame = tabDragStartFrames[item] else { return nil }
+        let rowFrames = tabDragStartFrames.filter { _, frame in
+            frame.maxY > sourceFrame.minY && frame.minY < sourceFrame.maxY
+        }
+        guard let rowMinX = rowFrames.values.map(\.minX).min(),
+              let rowMaxX = rowFrames.values.map(\.maxX).max() else { return nil }
+
+        let offset = min(
+            max(translationX, rowMinX - sourceFrame.minX),
+            rowMaxX - sourceFrame.maxX
+        )
+        let candidates = rowFrames.filter { $0.key != item }
+        let target: EditorTabReorderTarget?
+
+        if offset > 0 {
+            let probeX = sourceFrame.maxX + offset
+            target = candidates
+                .filter { _, frame in
+                    frame.midX > sourceFrame.midX
+                        && probeX > frame.midX
+                            + frame.width * EditorTabDropGeometry.hoverDeadZoneRatio
+                }
+                .max { $0.value.midX < $1.value.midX }
+                .map { EditorTabReorderTarget(item: $0.key, side: .after) }
+        } else if offset < 0 {
+            let probeX = sourceFrame.minX + offset
+            target = candidates
+                .filter { _, frame in
+                    frame.midX < sourceFrame.midX
+                        && probeX < frame.midX
+                            - frame.width * EditorTabDropGeometry.hoverDeadZoneRatio
+                }
+                .min { $0.value.midX < $1.value.midX }
+                .map { EditorTabReorderTarget(item: $0.key, side: .before) }
+        } else {
+            target = nil
+        }
+
+        return (offset, target)
+    }
+
+    private func updateTerminalTabBarDropTarget(at location: CGPoint) {
+        guard let target = terminalTabBarDropTarget(at: location) else {
+            clearTerminalTabBarDropTarget()
+            return
+        }
+        updateTerminalTabBarDropTarget(target)
+    }
+
+    private func terminalTabBarDropTarget(at location: CGPoint) -> EditorTabReorderTarget? {
+        let activeTerminalItem = TerminalTabDragPayload.activeSessionID.map {
+            EditorTabItem.terminal($0)
+        }
+        if let activeTerminalItem,
+           let sourceFrame = editorTabFrames[activeTerminalItem],
+           sourceFrame.contains(location) {
+            return nil
+        }
+        let candidates = editorTabFrames.filter { item, _ in
+            item != tabDragState.draggedItem && item != activeTerminalItem
+        }
+        guard let nearest = candidates.min(by: { lhs, rhs in
+            tabDropDistance(from: location, to: lhs.value)
+                < tabDropDistance(from: location, to: rhs.value)
+        }) else { return nil }
+
+        let frame = nearest.value
+        let side: EditorTabDropSide
+        if let activeTerminalItem,
+           let sourceIndex = model.editorTabItems.firstIndex(of: activeTerminalItem),
+           let targetIndex = model.editorTabItems.firstIndex(of: nearest.key) {
+            side = targetIndex < sourceIndex ? .before : .after
+        } else if location.x <= frame.minX {
+            side = .before
+        } else if location.x >= frame.maxX {
+            side = .after
+        } else {
+            side = EditorTabDropGeometry.finalSide(
+                locationX: location.x - frame.minX,
+                width: frame.width
+            )
+        }
+        return EditorTabReorderTarget(item: nearest.key, side: side)
+    }
+
+    private func updateTerminalTabBarDropTarget(_ target: EditorTabReorderTarget) {
+        guard tabReorderTarget != target else { return }
+        withAnimation(tabAnimation) {
+            tabReorderTarget = target
+        }
+    }
+
+    private func resolveTerminalDropSide(
+        _ proposedSide: EditorTabDropSide,
+        target: EditorTabItem
+    ) -> EditorTabDropSide {
+        guard let sessionID = TerminalTabDragPayload.activeSessionID,
+              let sourceIndex = model.editorTabItems.firstIndex(of: .terminal(sessionID)),
+              let targetIndex = model.editorTabItems.firstIndex(of: target) else {
+            return proposedSide
+        }
+        return targetIndex < sourceIndex ? .before : .after
+    }
+
+    private func tabDropDistance(from location: CGPoint, to frame: CGRect) -> CGFloat {
+        let horizontalDistance = max(
+            max(frame.minX - location.x, location.x - frame.maxX),
+            0
+        )
+        let verticalDistance = max(
+            max(frame.minY - location.y, location.y - frame.maxY),
+            0
+        )
+        return horizontalDistance * horizontalDistance + verticalDistance * verticalDistance
+    }
+
+    private func clearTerminalTabBarDropTarget(matching item: EditorTabItem? = nil) {
+        guard let currentTarget = tabReorderTarget,
+              item == nil || currentTarget.item == item else { return }
+        withAnimation(tabAnimation) {
+            tabReorderTarget = nil
         }
     }
 
     private func finishTabDrag() {
-        guard tabDragState != .idle else { return }
+        guard tabDragState != .idle
+            || tabReorderTarget != nil
+            || tabDragOffsetX != 0 else { return }
         withAnimation(tabAnimation) {
+            tabDragOffsetX = 0
+            tabReorderTarget = nil
             tabDragState.finish()
         }
+        tabDragStartFrames = [:]
     }
 
     private var markdownModePicker: some View {
@@ -615,13 +892,6 @@ struct EditorAreaView: View {
                 activeEditor
             }
         }
-        .contentShape(Rectangle())
-        .onDrop(
-            of: [TerminalTabDragPayload.type],
-            delegate: EditorTerminalDropDelegate { sessionID in
-                model.moveTerminalToEditor(sessionID)
-            }
-        )
     }
 
     @ViewBuilder
@@ -832,76 +1102,124 @@ struct EditorAreaView: View {
                 .foregroundStyle(LitheTheme.secondaryText)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .contentShape(Rectangle())
-        .onDrop(
-            of: [TerminalTabDragPayload.type],
-            delegate: EditorTerminalDropDelegate { sessionID in
-                model.moveTerminalToEditor(sessionID)
-            }
-        )
     }
 
 }
 
+private struct EditorTabFramePreferenceKey: PreferenceKey {
+    static let defaultValue: [EditorTabItem: CGRect] = [:]
+
+    static func reduce(
+        value: inout [EditorTabItem: CGRect],
+        nextValue: () -> [EditorTabItem: CGRect]
+    ) {
+        value.merge(nextValue()) { _, next in next }
+    }
+}
+
 private struct EditorTabBarDropDelegate: DropDelegate {
+    let setTargeted: (Bool) -> Void
+    let updateTarget: (CGPoint) -> Void
+    let clearTarget: () -> Void
+    let resolveTarget: (CGPoint) -> EditorTabReorderTarget?
     let finish: () -> Void
-    let receiveTerminal: @MainActor (UUID) -> Void
+    let receiveTerminal: @MainActor (UUID, EditorTabReorderTarget?) -> Void
+
+    func dropEntered(info: DropInfo) {
+        setTargeted(true)
+        updateTarget(info.location)
+    }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: .move)
+        setTargeted(true)
+        updateTarget(info.location)
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) {
+        setTargeted(false)
+        clearTarget()
     }
 
     func performDrop(info: DropInfo) -> Bool {
+        setTargeted(false)
+        updateTarget(info.location)
         let terminalProviders = info.itemProviders(for: [TerminalTabDragPayload.type])
         if !terminalProviders.isEmpty {
+            let target = resolveTarget(info.location)
             finish()
-            return TerminalTabDragPayload.loadSessionID(
-                from: terminalProviders,
-                completion: receiveTerminal
-            )
+            return TerminalTabDragPayload.loadSessionID(from: terminalProviders) { sessionID in
+                receiveTerminal(sessionID, target)
+            }
         }
         finish()
         return true
     }
 
     func validateDrop(info: DropInfo) -> Bool {
-        !info.itemProviders(for: [EditorTabDragPayload.type, TerminalTabDragPayload.type]).isEmpty
+        !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty
     }
 }
 
 private struct EditorTabDropDelegate: DropDelegate {
-    let draggedDocumentID: UUID?
+    let draggedItem: EditorTabItem?
     let targetDocumentID: UUID
     let targetWidth: CGFloat
     let dragSessionID: UUID?
     let dropTargetRevision: UInt
     let updateTarget: (EditorTabDropTarget, UUID?, UInt) -> Void
     let clearTarget: (UUID, UUID?, UInt) -> Void
+    let updateTerminalTarget: (EditorTabReorderTarget) -> Void
+    let clearTerminalTarget: (EditorTabItem) -> Void
+    let resolveTerminalSide: (EditorTabDropSide) -> EditorTabDropSide
     let finish: () -> Void
-    let receiveTerminal: @MainActor (UUID) -> Void
+    let receiveTerminal: @MainActor (UUID, EditorTabDropSide) -> Void
 
     func dropEntered(info: DropInfo) {
+        updateTerminalTargetIfNeeded(using: info)
         updateTargetIfNeeded(using: info)
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
+        updateTerminalTargetIfNeeded(using: info)
         updateTargetIfNeeded(using: info)
         return DropProposal(operation: .move)
     }
 
     func dropExited(info: DropInfo) {
+        if draggedItem == nil,
+           !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty {
+            clearTerminalTarget(.document(targetDocumentID))
+        }
         guard !info.itemProviders(for: [EditorTabDragPayload.type]).isEmpty else { return }
         clearTarget(targetDocumentID, dragSessionID, dropTargetRevision)
     }
 
     func performDrop(info: DropInfo) -> Bool {
+        if draggedItem != nil,
+           !info.itemProviders(for: [EditorTabDragPayload.type]).isEmpty {
+            updateTargetIfNeeded(using: info, settlesDrop: true)
+            finish()
+            return true
+        }
         let terminalProviders = info.itemProviders(for: [TerminalTabDragPayload.type])
         if !terminalProviders.isEmpty {
-            finish()
-            return TerminalTabDragPayload.loadSessionID(
-                from: terminalProviders,
-                completion: receiveTerminal
+            let side = resolveTerminalSide(
+                EditorTabDropGeometry.finalSide(
+                    locationX: info.location.x,
+                    width: targetWidth
+                )
             )
+            updateTerminalTarget(
+                EditorTabReorderTarget(
+                    item: .document(targetDocumentID),
+                    side: side
+                )
+            )
+            finish()
+            return TerminalTabDragPayload.loadSessionID(from: terminalProviders) { sessionID in
+                receiveTerminal(sessionID, side)
+            }
         }
         finish()
         return true
@@ -911,66 +1229,157 @@ private struct EditorTabDropDelegate: DropDelegate {
         !info.itemProviders(for: [EditorTabDragPayload.type, TerminalTabDragPayload.type]).isEmpty
     }
 
-    private func updateTargetIfNeeded(using info: DropInfo) {
-        guard let draggedDocumentID,
-              draggedDocumentID != targetDocumentID,
+    private func updateTargetIfNeeded(using info: DropInfo, settlesDrop: Bool = false) {
+        guard let draggedItem,
+              draggedItem != .document(targetDocumentID),
               !info.itemProviders(for: [EditorTabDragPayload.type]).isEmpty else { return }
+        let side: EditorTabDropSide
+        if settlesDrop {
+            side = EditorTabDropGeometry.finalSide(
+                locationX: info.location.x,
+                width: targetWidth
+            )
+        } else {
+            guard let hoverSide = EditorTabDropGeometry.hoverSide(
+                locationX: info.location.x,
+                width: targetWidth
+            ) else { return }
+            side = hoverSide
+        }
         updateTarget(
             EditorTabDropTarget(
                 documentID: targetDocumentID,
-                side: targetWidth > 0 && info.location.x > targetWidth / 2 ? .after : .before
+                side: side
             ),
             dragSessionID,
             dropTargetRevision
         )
     }
-}
 
-private struct EditorTerminalDropDelegate: DropDelegate {
-    let receive: @MainActor (UUID) -> Void
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: .move)
-    }
-
-    func validateDrop(info: DropInfo) -> Bool {
-        !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        TerminalTabDragPayload.loadSessionID(
-            from: info.itemProviders(for: [TerminalTabDragPayload.type]),
-            completion: receive
+    private func updateTerminalTargetIfNeeded(using info: DropInfo) {
+        guard draggedItem == nil,
+              !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty else { return }
+        updateTerminalTarget(
+            EditorTabReorderTarget(
+                item: .document(targetDocumentID),
+                side: resolveTerminalSide(
+                    EditorTabDropGeometry.finalSide(
+                        locationX: info.location.x,
+                        width: targetWidth
+                    )
+                )
+            )
         )
     }
 }
 
 private struct EditorTerminalTabDropDelegate: DropDelegate {
+    let draggedItem: EditorTabItem?
     let targetSessionID: UUID
     let targetWidth: CGFloat
-    let moveBefore: @MainActor (UUID) -> Void
-    let moveAfter: @MainActor (UUID) -> Void
+    let moveItemBefore: @MainActor (EditorTabItem) -> Void
+    let moveItemAfter: @MainActor (EditorTabItem) -> Void
+    let moveTerminalBefore: @MainActor (UUID) -> Void
+    let moveTerminalAfter: @MainActor (UUID) -> Void
+    let updateTerminalTarget: (EditorTabReorderTarget) -> Void
+    let clearTerminalTarget: (EditorTabItem) -> Void
+    let resolveTerminalSide: (EditorTabDropSide) -> EditorTabDropSide
+    let finish: () -> Void
+
+    func dropEntered(info: DropInfo) {
+        updateTerminalTargetIfNeeded(using: info)
+        moveItemIfNeeded(using: info)
+    }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: .move)
+        updateTerminalTargetIfNeeded(using: info)
+        moveItemIfNeeded(using: info)
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) {
+        guard draggedItem == nil,
+              !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty else { return }
+        clearTerminalTarget(.terminal(targetSessionID))
     }
 
     func validateDrop(info: DropInfo) -> Bool {
-        !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty
+        !info.itemProviders(for: [EditorTabDragPayload.type, TerminalTabDragPayload.type]).isEmpty
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        let insertAfter = info.location.x >= targetWidth / 2
-        return TerminalTabDragPayload.loadSessionID(
-            from: info.itemProviders(for: [TerminalTabDragPayload.type])
-        ) { sourceSessionID in
+        if draggedItem != nil,
+           !info.itemProviders(for: [EditorTabDragPayload.type]).isEmpty {
+            moveItemIfNeeded(using: info, settlesDrop: true)
+            finish()
+            return true
+        }
+        let terminalProviders = info.itemProviders(for: [TerminalTabDragPayload.type])
+        guard !terminalProviders.isEmpty else {
+            finish()
+            return !info.itemProviders(for: [EditorTabDragPayload.type]).isEmpty
+        }
+        let side = resolveTerminalSide(
+            EditorTabDropGeometry.finalSide(
+                locationX: info.location.x,
+                width: targetWidth
+            )
+        )
+        updateTerminalTarget(
+            EditorTabReorderTarget(
+                item: .terminal(targetSessionID),
+                side: side
+            )
+        )
+        finish()
+        return TerminalTabDragPayload.loadSessionID(from: terminalProviders) { sourceSessionID in
             guard sourceSessionID != targetSessionID else { return }
-            if insertAfter {
-                moveAfter(sourceSessionID)
+            if side == .after {
+                moveTerminalAfter(sourceSessionID)
             } else {
-                moveBefore(sourceSessionID)
+                moveTerminalBefore(sourceSessionID)
             }
         }
+    }
+
+    private func moveItemIfNeeded(using info: DropInfo, settlesDrop: Bool = false) {
+        guard let draggedItem,
+              draggedItem != .terminal(targetSessionID),
+              !info.itemProviders(for: [EditorTabDragPayload.type]).isEmpty else { return }
+        let side: EditorTabDropSide
+        if settlesDrop {
+            side = EditorTabDropGeometry.finalSide(
+                locationX: info.location.x,
+                width: targetWidth
+            )
+        } else {
+            guard let hoverSide = EditorTabDropGeometry.hoverSide(
+                locationX: info.location.x,
+                width: targetWidth
+            ) else { return }
+            side = hoverSide
+        }
+        if side == .after {
+            moveItemAfter(draggedItem)
+        } else {
+            moveItemBefore(draggedItem)
+        }
+    }
+
+    private func updateTerminalTargetIfNeeded(using info: DropInfo) {
+        guard draggedItem == nil,
+              !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty else { return }
+        updateTerminalTarget(
+            EditorTabReorderTarget(
+                item: .terminal(targetSessionID),
+                side: resolveTerminalSide(
+                    EditorTabDropGeometry.finalSide(
+                        locationX: info.location.x,
+                        width: targetWidth
+                    )
+                )
+            )
+        )
     }
 }
 

--- a/Sources/Lithe/Views/Editor/EditorAreaView.swift
+++ b/Sources/Lithe/Views/Editor/EditorAreaView.swift
@@ -271,14 +271,18 @@ struct EditorAreaView: View {
                             targetWidth: geometry.size.width,
                             dragSessionID: dragSessionID,
                             dropTargetRevision: dropTargetRevision,
-                            updateTarget: { target, sessionID, revision in
+                            updateTarget: { target, sessionID, revision, settlesDrop in
                                 guard tabDragState.sessionID == sessionID,
                                       tabDragState.dropTargetRevision == revision,
                                       let source = tabDragState.draggedItem,
-                                      source != .document(target.documentID),
-                                      tabDragState.dropTarget != target else { return }
+                                      source != .document(target.documentID) else { return }
+                                if tabDragState.dropTarget != target {
+                                    withAnimation(tabAnimation) {
+                                        tabDragState.updateTarget(target)
+                                    }
+                                }
+                                guard settlesDrop else { return }
                                 withAnimation(tabAnimation) {
-                                    tabDragState.updateTarget(target)
                                     if target.side == .after {
                                         model.moveEditorTab(
                                             source,
@@ -498,33 +502,7 @@ struct EditorAreaView: View {
             && model.activeDocumentID == document.id
 
         return HStack(spacing: 0) {
-            HStack(spacing: 7) {
-                LitheIcon(
-                    kind: LitheIcons.kind(for: document.url, isDirectory: false),
-                    size: 13
-                )
-                editorTabTitle(document)
-                EditorTabDirtyIndicator(document: document)
-            }
-            .foregroundStyle(isActive ? LitheTheme.primaryText : LitheTheme.secondaryText)
-            .padding(.leading, 11)
-            .frame(height: LitheTheme.Metrics.tabHeight)
-            .contentShape(Rectangle())
-            // Keep the drag source on a plain view. On macOS a nested Button
-            // can win the mouse gesture before a parent drag gesture starts.
-            .onTapGesture {
-                model.selectEditorDocument(document)
-            }
-            .highPriorityGesture(
-                horizontalTabDragGesture(for: .document(document.id))
-            )
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(document.displayName)
-            .accessibilityAddTraits(.isButton)
-            .accessibilityAction {
-                model.selectEditorDocument(document)
-            }
-            .lithePointer()
+            editorDocumentTabDragSource(document, isActive: isActive)
 
             Button {
                 model.requestCloseDocument(document)
@@ -569,6 +547,57 @@ struct EditorAreaView: View {
     }
 
     @ViewBuilder
+    private func editorDocumentTabDragSource(
+        _ document: EditorDocument,
+        isActive: Bool
+    ) -> some View {
+        let label = HStack(spacing: 7) {
+            LitheIcon(
+                kind: LitheIcons.kind(for: document.url, isDirectory: false),
+                size: 13
+            )
+            editorTabTitle(document)
+            EditorTabDirtyIndicator(document: document)
+        }
+        .foregroundStyle(isActive ? LitheTheme.primaryText : LitheTheme.secondaryText)
+        .padding(.leading, 11)
+        .frame(height: LitheTheme.Metrics.tabHeight)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            model.selectEditorDocument(document)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(document.displayName)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction {
+            model.selectEditorDocument(document)
+        }
+        .lithePointer()
+
+        if settings.editorTabLayoutMode == .multipleRows {
+            // Native dragging carries the tab between flow-layout rows. The
+            // custom single-line gesture intentionally remains horizontal.
+            label
+                .contentShape(
+                    .dragPreview,
+                    RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius)
+                )
+                .onDrag {
+                    beginTabDrag(.document(document.id))
+                    return EditorTabDragPayload.provider(for: document.id)
+                } preview: {
+                    editorTabDragPreview(document)
+                }
+        } else {
+            // Keep the drag source on a plain view. On macOS a nested Button
+            // can win the mouse gesture before a parent drag gesture starts.
+            label.highPriorityGesture(
+                horizontalTabDragGesture(for: .document(document.id))
+            )
+        }
+    }
+
+    @ViewBuilder
     private func editorTabTitle(_ document: EditorDocument) -> some View {
         if settings.editorTabLayoutMode == .multipleRows {
             Text(document.displayName)
@@ -589,6 +618,37 @@ struct EditorAreaView: View {
             .frame(width: 3)
             .shadow(color: LitheTheme.accent.opacity(0.7), radius: 4)
             .transition(.opacity.combined(with: .scale))
+    }
+
+    private func editorTabDragPreview(_ document: EditorDocument) -> some View {
+        HStack(spacing: 7) {
+            LitheIcon(
+                kind: LitheIcons.kind(for: document.url, isDirectory: false),
+                size: 13
+            )
+            .foregroundStyle(LitheTheme.accent)
+
+            Text(document.displayName)
+                .font(.system(size: 12.5, weight: .medium))
+                .foregroundStyle(LitheTheme.primaryText)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: 240, alignment: .leading)
+
+            if document.isDirty {
+                Circle()
+                    .fill(LitheTheme.primaryText)
+                    .frame(width: 6, height: 6)
+            }
+        }
+        .padding(.leading, 11)
+        .padding(.trailing, 9)
+        .fixedSize(horizontal: true, vertical: false)
+        .frame(height: LitheTheme.Metrics.tabHeight, alignment: .leading)
+        .background(LitheTheme.activeTabBackground)
+        .clipShape(RoundedRectangle(cornerRadius: LitheTheme.Metrics.cornerRadius))
+        .shadow(color: .black.opacity(0.42), radius: 10, y: 6)
+        .compositingGroup()
     }
 
     private var tabAnimation: Animation? {
@@ -1167,7 +1227,7 @@ private struct EditorTabDropDelegate: DropDelegate {
     let targetWidth: CGFloat
     let dragSessionID: UUID?
     let dropTargetRevision: UInt
-    let updateTarget: (EditorTabDropTarget, UUID?, UInt) -> Void
+    let updateTarget: (EditorTabDropTarget, UUID?, UInt, Bool) -> Void
     let clearTarget: (UUID, UUID?, UInt) -> Void
     let updateTerminalTarget: (EditorTabReorderTarget) -> Void
     let clearTerminalTarget: (EditorTabItem) -> Void
@@ -1252,7 +1312,8 @@ private struct EditorTabDropDelegate: DropDelegate {
                 side: side
             ),
             dragSessionID,
-            dropTargetRevision
+            dropTargetRevision,
+            settlesDrop
         )
     }
 
@@ -1298,8 +1359,9 @@ private struct EditorTerminalTabDropDelegate: DropDelegate {
     }
 
     func dropExited(info: DropInfo) {
-        guard draggedItem == nil,
-              !info.itemProviders(for: [TerminalTabDragPayload.type]).isEmpty else { return }
+        guard !info.itemProviders(
+            for: [EditorTabDragPayload.type, TerminalTabDragPayload.type]
+        ).isEmpty else { return }
         clearTerminalTarget(.terminal(targetSessionID))
     }
 
@@ -1359,6 +1421,13 @@ private struct EditorTerminalTabDropDelegate: DropDelegate {
             ) else { return }
             side = hoverSide
         }
+        updateTerminalTarget(
+            EditorTabReorderTarget(
+                item: .terminal(targetSessionID),
+                side: side
+            )
+        )
+        guard settlesDrop else { return }
         if side == .after {
             moveItemAfter(draggedItem)
         } else {

--- a/Sources/Lithe/Views/Editor/EditorTabFlowLayout.swift
+++ b/Sources/Lithe/Views/Editor/EditorTabFlowLayout.swift
@@ -5,10 +5,10 @@ import UniformTypeIdentifiers
 /// The small amount of state needed to make a tab drag observable and
 /// cancellable from the surrounding SwiftUI view.
 struct EditorTabDragState: Equatable {
-    /// Identifies one native drag session. A stale DropDelegate callback from
+    /// Identifies one tab-reorder gesture. A stale DropDelegate callback from
     /// a previous session must never mutate the next session's state.
     var sessionID: UUID?
-    var draggedDocumentID: UUID?
+    var draggedItem: EditorTabItem?
     var dropTarget: EditorTabDropTarget?
     /// Incremented whenever the current target changes. This lets us ignore
     /// dropExited callbacks emitted by a tab view that was rebuilt during
@@ -17,14 +17,24 @@ struct EditorTabDragState: Equatable {
 
     static let idle = EditorTabDragState(
         sessionID: nil,
-        draggedDocumentID: nil,
+        draggedItem: nil,
         dropTarget: nil,
         dropTargetRevision: 0
     )
 
+    var draggedDocumentID: UUID? {
+        guard let draggedItem,
+              case .document(let documentID) = draggedItem else { return nil }
+        return documentID
+    }
+
     mutating func begin(documentID: UUID) {
+        begin(item: .document(documentID))
+    }
+
+    mutating func begin(item: EditorTabItem) {
         sessionID = UUID()
-        draggedDocumentID = documentID
+        draggedItem = item
         dropTarget = nil
         dropTargetRevision = 0
     }
@@ -58,9 +68,33 @@ struct EditorTabDropTarget: Equatable {
     let side: EditorTabDropSide
 }
 
+struct EditorTabReorderTarget: Equatable {
+    let item: EditorTabItem
+    let side: EditorTabDropSide
+}
+
 enum EditorTabDropSide: Equatable {
     case before
     case after
+}
+
+/// Keeps live tab reordering away from the midpoint where layout changes can
+/// otherwise make the pointer oscillate between before and after.
+enum EditorTabDropGeometry {
+    static let hoverDeadZoneRatio: CGFloat = 0.10
+
+    static func hoverSide(locationX: CGFloat, width: CGFloat) -> EditorTabDropSide? {
+        guard width > 0 else { return nil }
+        let midpoint = width / 2
+        let deadZone = width * hoverDeadZoneRatio
+        if locationX < midpoint - deadZone { return .before }
+        if locationX > midpoint + deadZone { return .after }
+        return nil
+    }
+
+    static func finalSide(locationX: CGFloat, width: CGFloat) -> EditorTabDropSide {
+        width > 0 && locationX > width / 2 ? .after : .before
+    }
 }
 
 enum EditorTabDragPayload {

--- a/Sources/Lithe/Views/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Lithe/Views/Terminal/TerminalSurfaceView.swift
@@ -39,7 +39,9 @@ private struct TerminalNativeSurface: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> TerminalSurfaceHostView {
-        TerminalSurfaceHostView(frame: .zero)
+        let hostView = TerminalSurfaceHostView(frame: .zero)
+        hostView.attach(nativeView)
+        return hostView
     }
 
     func updateNSView(_ hostView: TerminalSurfaceHostView, context: Context) {
@@ -67,13 +69,28 @@ private final class TerminalSurfaceHostView: NSView {
     private weak var terminalView: NSView?
 
     func attach(_ view: NSView) {
-        guard terminalView !== view || view.superview !== self else { return }
-        terminalView?.removeFromSuperview()
+        // A source host can receive one last update after the persistent
+        // terminal view has already moved to its destination. Do not let that
+        // stale host reclaim the view or detach it while switching sessions.
+        if terminalView === view {
+            guard view.superview === self else { return }
+            view.frame = bounds
+            return
+        }
+        if let terminalView, terminalView.superview === self {
+            terminalView.removeFromSuperview()
+        }
         view.removeFromSuperview()
         terminalView = view
         view.frame = bounds
         view.autoresizingMask = [.width, .height]
         addSubview(view)
+    }
+
+    override func layout() {
+        super.layout()
+        guard let terminalView, terminalView.superview === self else { return }
+        terminalView.frame = bounds
     }
 
     func detachCurrentView() {

--- a/Sources/Lithe/Views/Terminal/TerminalTabDragPayload.swift
+++ b/Sources/Lithe/Views/Terminal/TerminalTabDragPayload.swift
@@ -6,10 +6,15 @@ enum TerminalTabDragPayload {
     static let pasteboardType = NSPasteboard.PasteboardType(type.identifier)
     private static let activeDrag = ActiveTerminalTabDrag()
 
+    static var activeSessionID: UUID? { activeDrag.sessionID }
+
     static func provider(for sessionID: UUID) -> NSItemProvider {
         activeDrag.store(sessionID)
-        let provider = NSItemProvider()
         let data = Data(sessionID.uuidString.utf8)
+        // AppKit needs a concrete standard representation to establish the
+        // native drag session. CodeTextView explicitly rejects providers that
+        // also advertise the private terminal-tab type.
+        let provider = NSItemProvider(object: "Terminal" as NSString)
         provider.registerDataRepresentation(
             forTypeIdentifier: type.identifier,
             visibility: .ownProcess
@@ -40,6 +45,16 @@ enum TerminalTabDragPayload {
         from providers: [NSItemProvider],
         completion: @escaping @MainActor (UUID) -> Void
     ) -> Bool {
+        guard !providers.isEmpty else { return false }
+        // Terminal tab drags are process-local and only one native drag can be
+        // active at a time. Resolve that identity immediately so a promised
+        // representation cannot turn a valid drop into a silent no-op.
+        if let sessionID = activeDrag.sessionID {
+            MainActor.assumeIsolated {
+                completion(sessionID)
+            }
+            return true
+        }
         guard let provider = providers.first(where: {
             $0.hasItemConformingToTypeIdentifier(type.identifier)
         }) else { return false }

--- a/Sources/Lithe/Views/Terminal/TerminalView.swift
+++ b/Sources/Lithe/Views/Terminal/TerminalView.swift
@@ -9,6 +9,16 @@ struct TerminalView: View {
             terminalToolbar
             terminalCanvas
         }
+        .contentShape(Rectangle())
+        .onDrop(
+            of: [TerminalTabDragPayload.type],
+            delegate: TerminalBarDropDelegate { sessionID in
+                guard model.editorTerminalSessions.contains(where: { $0.id == sessionID }) else {
+                    return
+                }
+                model.moveTerminalToTool(sessionID)
+            }
+        )
         .background(LitheTheme.editor)
     }
 

--- a/Tests/LitheTests/EditorTabLayoutTests.swift
+++ b/Tests/LitheTests/EditorTabLayoutTests.swift
@@ -64,14 +64,34 @@ struct EditorTabLayoutTests {
     }
 
     @Test
-    func terminalTabDragPayloadOnlyOffersItsPrivateSessionIdentifier() throws {
+    func terminalTabDragPayloadOffersAConcreteItemAndPrivateSessionIdentifier() throws {
         let sessionID = UUID()
         let provider = TerminalTabDragPayload.provider(for: sessionID)
         let encoded = Data(sessionID.uuidString.utf8)
 
+        #expect(!provider.registeredTypeIdentifiers.contains(EditorTabDragPayload.type.identifier))
         #expect(provider.registeredTypeIdentifiers.contains(TerminalTabDragPayload.type.identifier))
-        #expect(!provider.registeredTypeIdentifiers.contains(UTType.utf8PlainText.identifier))
+        #expect(provider.registeredTypeIdentifiers.contains(UTType.utf8PlainText.identifier))
         #expect(TerminalTabDragPayload.sessionID(from: encoded) == sessionID)
+    }
+
+    @Test
+    func terminalDragUsesTheSharedEditorTabState() {
+        var state = EditorTabDragState.idle
+        let sessionID = UUID()
+
+        state.begin(item: .terminal(sessionID))
+
+        #expect(state.draggedItem == .terminal(sessionID))
+        #expect(state.draggedDocumentID == nil)
+    }
+
+    @Test
+    func liveTabDropKeepsADeadZoneAroundTheMidpoint() {
+        #expect(EditorTabDropGeometry.hoverSide(locationX: 39, width: 100) == .before)
+        #expect(EditorTabDropGeometry.hoverSide(locationX: 50, width: 100) == nil)
+        #expect(EditorTabDropGeometry.hoverSide(locationX: 61, width: 100) == .after)
+        #expect(EditorTabDropGeometry.finalSide(locationX: 51, width: 100) == .after)
     }
 
     @Test

--- a/Tests/LitheTests/EditorTabOrderFeatureModelTests.swift
+++ b/Tests/LitheTests/EditorTabOrderFeatureModelTests.swift
@@ -52,4 +52,49 @@ struct EditorTabOrderFeatureModelTests {
 
         #expect(model.items == [.document(firstDocument), .document(secondDocument)])
     }
+
+    @Test
+    func movingADocumentTabActivatesItsContent() throws {
+        let store = EditorTabOrderTestStore()
+        let settings = AppSettings(store: store)
+        let services = MacServiceContainer(
+            store: store,
+            settings: settings,
+            moduleLaunchMode: .safeMode
+        ).services
+        let appModel = AppModel(settings: settings, services: services)
+        let firstURL = try #require(URL(string: "lithe-test://documents/First.swift"))
+        let secondURL = try #require(URL(string: "lithe-test://documents/Second.swift"))
+        appModel.documentFeature.openVirtualDocument(firstURL, text: "first", displayPath: nil)
+        appModel.documentFeature.openVirtualDocument(secondURL, text: "second", displayPath: nil)
+        let firstDocument = try #require(
+            appModel.openDocuments.first(where: { $0.url == firstURL })
+        )
+        let secondDocument = try #require(
+            appModel.openDocuments.first(where: { $0.url == secondURL })
+        )
+        appModel.selectEditorDocument(secondDocument)
+
+        appModel.moveEditorTab(
+            .document(firstDocument.id),
+            after: .document(secondDocument.id)
+        )
+
+        #expect(appModel.editorTabItems == [
+            .document(secondDocument.id),
+            .document(firstDocument.id)
+        ])
+        #expect(appModel.activeDocumentID == firstDocument.id)
+        #expect(appModel.activeEditorTerminalSession == nil)
+    }
+}
+
+private final class EditorTabOrderTestStore: KeyValueStore, @unchecked Sendable {
+    private var values: [String: Any] = [:]
+
+    func data(forKey key: String) -> Data? { values[key] as? Data }
+    func object(forKey key: String) -> Any? { values[key] }
+    func string(forKey key: String) -> String? { values[key] as? String }
+    func stringArray(forKey key: String) -> [String]? { values[key] as? [String] }
+    func set(_ value: Any?, forKey key: String) { values[key] = value }
 }

--- a/Tests/LitheTests/EditorTabOrderFeatureModelTests.swift
+++ b/Tests/LitheTests/EditorTabOrderFeatureModelTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import Lithe
+
+@Suite("Editor tab order")
+@MainActor
+struct EditorTabOrderFeatureModelTests {
+    @Test
+    func mixesDocumentsAndTerminalsInOneOrder() {
+        let model = EditorTabOrderFeatureModel()
+        let firstDocument = UUID()
+        let secondDocument = UUID()
+        let terminal = UUID()
+        model.reconcileDocuments(orderedIDs: [firstDocument, secondDocument])
+
+        model.move(.terminal(terminal), before: .document(secondDocument))
+
+        #expect(model.items == [
+            .document(firstDocument),
+            .terminal(terminal),
+            .document(secondDocument)
+        ])
+    }
+
+    @Test
+    func documentReconciliationPreservesTerminalSlots() {
+        let model = EditorTabOrderFeatureModel()
+        let firstDocument = UUID()
+        let secondDocument = UUID()
+        let terminal = UUID()
+        model.reconcileDocuments(orderedIDs: [firstDocument, secondDocument])
+        model.move(.terminal(terminal), before: .document(secondDocument))
+
+        model.reconcileDocuments(orderedIDs: [secondDocument, firstDocument])
+
+        #expect(model.items == [
+            .document(secondDocument),
+            .terminal(terminal),
+            .document(firstDocument)
+        ])
+    }
+
+    @Test
+    func removingTerminalsLeavesDocumentOrderUntouched() {
+        let model = EditorTabOrderFeatureModel()
+        let firstDocument = UUID()
+        let secondDocument = UUID()
+        model.reconcileDocuments(orderedIDs: [firstDocument, secondDocument])
+        model.move(.terminal(UUID()), before: .document(secondDocument))
+
+        model.removeAllTerminals()
+
+        #expect(model.items == [.document(firstDocument), .document(secondDocument)])
+    }
+}

--- a/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -2143,36 +2143,10 @@ struct LitheCoreLogicTests {
 
     @Test
     @MainActor
-    func codeEditorRegistersThePrivateTerminalTabDropType() {
+    func codeEditorDoesNotRegisterThePrivateTerminalTabDropType() {
         let textView = CodeTextView(frame: .zero)
 
-        #expect(textView.registeredDraggedTypes.contains(TerminalTabDragPayload.pasteboardType))
-    }
-
-    @Test
-    @MainActor
-    func codeEditorRoutesPrivateTerminalTabDropsWithoutChangingText() {
-        let sessionID = UUID()
-        let textView = CodeTextView(frame: .zero)
-        let pasteboard = NSPasteboard(
-            name: .init("lithe-code-editor-terminal-tab-\(UUID().uuidString)")
-        )
-        pasteboard.clearContents()
-        pasteboard.setData(
-            Data(sessionID.uuidString.utf8),
-            forType: TerminalTabDragPayload.pasteboardType
-        )
-        defer { pasteboard.clearContents() }
-        textView.string = "before"
-        var receivedSessionID: UUID?
-        textView.onTerminalTabDrop = { droppedSessionID in
-            receivedSessionID = droppedSessionID
-            return true
-        }
-
-        #expect(textView.performTerminalTabDrop(from: pasteboard))
-        #expect(receivedSessionID == sessionID)
-        #expect(textView.string == "before")
+        #expect(!textView.registeredDraggedTypes.contains(TerminalTabDragPayload.pasteboardType))
     }
 
     @Test

--- a/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -3621,6 +3621,9 @@ struct EditorDocumentTests {
 
         model.reorderDocuments(orderedPaths: urls.reversed().map(\.path))
         #expect(model.openDocuments.map(\.url.lastPathComponent) == ["C.swift", "B.swift", "A.swift"])
+
+        model.reorderDocuments(orderedIDs: [ids[0], ids[2], ids[1]])
+        #expect(model.openDocuments.map(\.url.lastPathComponent) == ["A.swift", "C.swift", "B.swift"])
     }
 
     @Test

--- a/Tests/LitheTests/TerminalPlacementFeatureModelTests.swift
+++ b/Tests/LitheTests/TerminalPlacementFeatureModelTests.swift
@@ -56,6 +56,21 @@ struct TerminalPlacementFeatureModelTests {
     }
 
     @Test
+    func reconcilesEditorTerminalOrderWithTheMixedTabProjection() {
+        let model = TerminalPlacementFeatureModel()
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+        [first, second, third].forEach(model.registerSession)
+        [first, second, third].forEach(model.moveToEditor)
+
+        model.reorderEditorSessions(orderedIDs: [third, first, second])
+
+        #expect(model.editorSessionIDs == [third, first, second])
+        #expect(model.activeEditorSessionID == third)
+    }
+
+    @Test
     func movingPresentationNeverStopsOrRecreatesTheTerminalTransport() {
         let transport = PlacementTestTerminalTransport()
         let terminalFeature = TerminalFeatureModel(terminalFactory: { transport })


### PR DESCRIPTION
## 变更说明

统一编辑器中的文件标签和终端标签模型，使两类标签能够共享顺序并进行混合重排。

Closes #226

## 主要改动

- 新增统一的 `EditorTabItem` 和标签顺序模型
- 支持文件标签与终端标签混合排列
- 支持终端标签向左、向右拖动重排
- 标签栏内使用横向吸附效果和插入位置指示线
- 终端从工具窗口拖入编辑器时，只有进入标签栏才会触发停靠
- 支持将编辑器终端拖回终端工具窗口
- 编辑器正文区域明确拒绝终端标签拖放
- 移除编辑器终端“移回工具窗口”的右键菜单入口，统一使用拖拽操作
- 修复终端停靠过程中原生 `NSView` 被旧容器移除，导致终端标签打开后内容空白的问题
- 终端迁移和重排不会重建或停止已有终端会话

## 交互行为

### 工具窗口 → 编辑器

必须将终端拖入编辑器标签栏才会完成停靠，拖入编辑器正文区域不会触发。

### 编辑器标签栏内部

终端标签只能沿标签栏横向重排，并显示目标位置的吸附和插入线。

### 编辑器 → 工具窗口

将终端标签拖入终端工具窗口即可恢复为工具窗口终端。

## 验证

已手动验证：

- 文件标签可以正常重排
- 终端标签可以向左、向右重排
- 文件标签和终端标签可以混合排列
- 工具窗口终端可以拖入编辑器标签栏
- 拖入编辑器正文不会触发停靠
- 编辑器终端可以拖回终端工具窗口
- 终端双向迁移后仍可正常显示和输入
- 多终端切换时不会出现原生终端视图空白

自动化测试未运行。

## 提交拆分

1. `feat(editor): 统一文件与终端标签顺序`
2. `fix(editor): 限制终端仅拖入编辑器标签栏`
3. `feat(editor): 支持文件与终端标签横向吸附重排`
4. `fix(terminal): 恢复拖回终端工具窗口`
5. `fix(terminal): 停靠时保留终端原生视图`