### PR TITLE
fix(build): bundle JDK for JDTLS

### DIFF
--- a/.github/actions/prepare-macos-dependency-cache/action.yml
+++ b/.github/actions/prepare-macos-dependency-cache/action.yml
@@ -14,6 +14,14 @@ inputs:
     description: Restore JDTLS and Lombok downloads.
     required: false
     default: "false"
+  jdk:
+    description: Restore the bundled JDTLS runtime JDK download.
+    required: false
+    default: "false"
+  jdk-architecture:
+    description: Target JDK architecture, either arm64 or x86_64.
+    required: false
+    default: ""
   restore-only:
     description: Restore caches without saving them at the end of the job.
     required: false
@@ -30,6 +38,17 @@ runs:
           echo "CARGO_HOME=$GITHUB_WORKSPACE/.artifacts/cargo-home"
           echo "LITHE_SWIFTPM_CACHE_PATH=$GITHUB_WORKSPACE/.artifacts/swiftpm-cache"
         } >> "$GITHUB_ENV"
+
+    - name: Validate JDK cache inputs
+      if: inputs.jdk == 'true'
+      shell: zsh {0}
+      env:
+        JDK_ARCHITECTURE: ${{ inputs.jdk-architecture }}
+      run: |
+        case "$JDK_ARCHITECTURE" in
+          arm64|x86_64) ;;
+          *) print -u2 -- "jdk-architecture must be arm64 or x86_64 when the JDK cache is enabled"; exit 2 ;;
+        esac
 
     - name: Restore SwiftPM repositories
       id: swiftpm_cache
@@ -101,6 +120,28 @@ runs:
         restore-keys: |
           macos-jdtls-downloads-${{ runner.os }}-
 
+    - name: Restore JDK downloads
+      id: jdk_cache
+      if: inputs.jdk == 'true' && inputs.restore-only != 'true'
+      continue-on-error: true
+      uses: actions/cache@v6
+      with:
+        path: .artifacts/jdk-downloads
+        key: macos-jdk-downloads-${{ runner.os }}-${{ inputs.jdk-architecture }}-${{ hashFiles('third_party/jdk/manifest.json') }}
+        restore-keys: |
+          macos-jdk-downloads-${{ runner.os }}-${{ inputs.jdk-architecture }}-
+
+    - name: Restore JDK downloads without saving
+      id: jdk_restore
+      if: inputs.jdk == 'true' && inputs.restore-only == 'true'
+      continue-on-error: true
+      uses: actions/cache/restore@v6
+      with:
+        path: .artifacts/jdk-downloads
+        key: macos-jdk-downloads-${{ runner.os }}-${{ inputs.jdk-architecture }}-${{ hashFiles('third_party/jdk/manifest.json') }}
+        restore-keys: |
+          macos-jdk-downloads-${{ runner.os }}-${{ inputs.jdk-architecture }}-
+
     - name: Validate restored caches or fall back
       shell: zsh {0}
       env:
@@ -113,16 +154,20 @@ runs:
         CARGO_RESTORE_OUTCOME: ${{ steps.cargo_restore.outcome }}
         JDTLS_CACHE_OUTCOME: ${{ steps.jdtls_cache.outcome }}
         JDTLS_RESTORE_OUTCOME: ${{ steps.jdtls_restore.outcome }}
+        JDK_CACHE_OUTCOME: ${{ steps.jdk_cache.outcome }}
+        JDK_RESTORE_OUTCOME: ${{ steps.jdk_restore.outcome }}
       run: |
         swiftpm_outcome="$SWIFTPM_CACHE_OUTCOME"
         swiftpm_hit="$SWIFTPM_CACHE_HIT"
         cargo_outcome="$CARGO_CACHE_OUTCOME"
         jdtls_outcome="$JDTLS_CACHE_OUTCOME"
+        jdk_outcome="$JDK_CACHE_OUTCOME"
         if [[ "$RESTORE_ONLY" == "true" ]]; then
           swiftpm_outcome="$SWIFTPM_RESTORE_OUTCOME"
           swiftpm_hit="$SWIFTPM_RESTORE_HIT"
           cargo_outcome="$CARGO_RESTORE_OUTCOME"
           jdtls_outcome="$JDTLS_RESTORE_OUTCOME"
+          jdk_outcome="$JDK_RESTORE_OUTCOME"
         fi
         "$GITHUB_WORKSPACE/scripts/validate-macos-dependency-caches.sh" \
           --swiftpm-enabled "${{ inputs.swiftpm }}" \
@@ -131,7 +176,9 @@ runs:
           --cargo-enabled "${{ inputs.cargo }}" \
           --cargo-outcome "${cargo_outcome:-skipped}" \
           --jdtls-enabled "${{ inputs.jdtls }}" \
-          --jdtls-outcome "${jdtls_outcome:-skipped}"
+          --jdtls-outcome "${jdtls_outcome:-skipped}" \
+          --jdk-enabled "${{ inputs.jdk }}" \
+          --jdk-outcome "${jdk_outcome:-skipped}"
 
     - name: Resolve SwiftPM dependencies with fallback
       if: inputs.swiftpm == 'true'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -185,6 +185,15 @@ jobs:
           path: .artifacts/jdtls-downloads
           key: lithe-${{ runner.os }}-${{ runner.arch }}-jdtls-v1-${{ hashFiles('third_party/jdtls/manifest.json') }}
 
+      - name: Restore JDK downloads
+        if: needs.changes.outputs.windows == 'true'
+        id: jdk-download-cache
+        continue-on-error: true
+        uses: actions/cache@v6
+        with:
+          path: .artifacts/jdk-downloads
+          key: lithe-${{ runner.os }}-${{ runner.arch }}-jdk-v1-${{ hashFiles('third_party/jdk/manifest.json') }}
+
       - name: Validate restored caches or fall back
         if: always()
         shell: pwsh
@@ -195,6 +204,7 @@ jobs:
             CargoBuildHit = "${{ steps.cargo-build-cache.outputs.cache-hit }}"
             BunOutcome = "${{ steps.bun-download-cache.outcome }}"
             JdtlsOutcome = "${{ steps.jdtls-download-cache.outcome }}"
+            JdkOutcome = "${{ steps.jdk-download-cache.outcome }}"
           }
           if ("${{ needs.changes.outputs.windows }}" -eq "true") {
             $validation.IncludeWindowsAssets = $true

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -85,6 +85,8 @@ jobs:
           swiftpm: "true"
           cargo: "true"
           jdtls: "true"
+          jdk: "true"
+          jdk-architecture: ${{ matrix.architecture }}
           restore-only: "true"
 
       - name: Build and package the App

--- a/.github/workflows/release-preview-macos.yml
+++ b/.github/workflows/release-preview-macos.yml
@@ -64,6 +64,8 @@ jobs:
           swiftpm: "true"
           cargo: "true"
           jdtls: "true"
+          jdk: "true"
+          jdk-architecture: ${{ matrix.architecture }}
 
       - name: Build and package the preview app
         env:

--- a/.github/workflows/release-preview-windows.yml
+++ b/.github/workflows/release-preview-windows.yml
@@ -128,6 +128,14 @@ jobs:
           path: .artifacts/jdtls-downloads
           key: lithe-${{ runner.os }}-${{ runner.arch }}-jdtls-v1-${{ hashFiles('third_party/jdtls/manifest.json') }}
 
+      - name: Restore JDK downloads
+        id: jdk-download-cache
+        continue-on-error: true
+        uses: actions/cache@v6
+        with:
+          path: .artifacts/jdk-downloads
+          key: lithe-${{ runner.os }}-${{ runner.arch }}-jdk-v1-${{ hashFiles('third_party/jdk/manifest.json') }}
+
       - name: Validate restored caches or fall back
         if: always()
         shell: pwsh
@@ -138,6 +146,7 @@ jobs:
             -CargoBuildHit "${{ steps.cargo-build-cache.outputs.cache-hit }}" `
             -BunOutcome "${{ steps.bun-download-cache.outcome }}" `
             -JdtlsOutcome "${{ steps.jdtls-download-cache.outcome }}" `
+            -JdkOutcome "${{ steps.jdk-download-cache.outcome }}" `
             -IncludeWindowsAssets
 
       - name: Import Authenticode certificate

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -112,6 +112,14 @@ jobs:
           path: .artifacts/jdtls-downloads
           key: lithe-${{ runner.os }}-${{ runner.arch }}-jdtls-v1-${{ hashFiles('third_party/jdtls/manifest.json') }}
 
+      - name: Restore JDK downloads
+        id: jdk-download-cache
+        continue-on-error: true
+        uses: actions/cache@v6
+        with:
+          path: .artifacts/jdk-downloads
+          key: lithe-${{ runner.os }}-${{ runner.arch }}-jdk-v1-${{ hashFiles('third_party/jdk/manifest.json') }}
+
       - name: Validate restored caches or fall back
         if: always()
         shell: pwsh
@@ -122,6 +130,7 @@ jobs:
             -CargoBuildHit "${{ steps.cargo-build-cache.outputs.cache-hit }}" `
             -BunOutcome "${{ steps.bun-download-cache.outcome }}" `
             -JdtlsOutcome "${{ steps.jdtls-download-cache.outcome }}" `
+            -JdkOutcome "${{ steps.jdk-download-cache.outcome }}" `
             -IncludeWindowsAssets
 
       - name: Resolve release version

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -9,24 +9,20 @@ $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent $PSScriptRoot
 $windowsApp = Join-Path $root "windows/tauri"
 $bundledExtensionsSource = [System.IO.Path]::GetFullPath((Join-Path $windowsApp "src/extensions/bundled"))
-$preparedJdtlsRoot = $null
-$preparedJdkRoot = $null
 if (-not (Test-Path -LiteralPath $bundledExtensionsSource -PathType Container)) {
     throw "Bundled extensions source directory is missing: $bundledExtensionsSource"
 }
-if ($Configuration -eq "Release") {
-    $prepareOutput = @(& (Join-Path $root "scripts/prepare-jdtls.ps1"))
-    if ($prepareOutput.Count -eq 0) {
-        throw "JDTLS preparation did not return an output directory."
-    }
-    $preparedJdtlsRoot = [System.IO.Path]::GetFullPath([string]$prepareOutput[-1])
-
-    $jdkPrepareOutput = @(& (Join-Path $root "scripts/prepare-jdk.ps1"))
-    if ($jdkPrepareOutput.Count -eq 0) {
-        throw "JDK preparation did not return an output directory."
-    }
-    $preparedJdkRoot = [System.IO.Path]::GetFullPath([string]$jdkPrepareOutput[-1])
+$prepareOutput = @(& (Join-Path $root "scripts/prepare-jdtls.ps1"))
+if ($prepareOutput.Count -eq 0) {
+    throw "JDTLS preparation did not return an output directory."
 }
+$preparedJdtlsRoot = [System.IO.Path]::GetFullPath([string]$prepareOutput[-1])
+
+$jdkPrepareOutput = @(& (Join-Path $root "scripts/prepare-jdk.ps1") -RustTarget $RustTarget)
+if ($jdkPrepareOutput.Count -eq 0) {
+    throw "JDK preparation did not return an output directory."
+}
+$preparedJdkRoot = [System.IO.Path]::GetFullPath([string]$jdkPrepareOutput[-1])
 Set-Location $windowsApp
 
 if ($null -eq (Get-Command bun -ErrorAction SilentlyContinue)) {
@@ -71,7 +67,12 @@ if (-not (Test-Path -LiteralPath (Join-Path $profileRoot "lithe-windows.exe") -P
 }
 
 function Copy-ResourceDirectory {
-    param([string]$Source, [string]$RelativeDestination)
+    param(
+        [string]$Source,
+        [string]$RelativeDestination,
+        [string]$IdentityFile = "",
+        [string[]]$RequiredPaths = @()
+    )
 
     if (-not (Test-Path -LiteralPath $Source -PathType Container)) {
         throw "Bundled resource source directory is missing: $Source"
@@ -80,6 +81,22 @@ function Copy-ResourceDirectory {
     $profilePrefix = $profileRoot.TrimEnd($trimCharacters) + [System.IO.Path]::DirectorySeparatorChar
     if (-not $destination.StartsWith($profilePrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
         throw "Bundled resource destination must stay inside target profile: $destination"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($IdentityFile)) {
+        $sourceIdentity = Join-Path $Source $IdentityFile
+        $destinationIdentity = Join-Path $destination $IdentityFile
+        $canReuse = (Test-Path -LiteralPath $sourceIdentity -PathType Leaf) -and
+            (Test-Path -LiteralPath $destinationIdentity -PathType Leaf) -and
+            (Get-FileHash -Algorithm SHA256 -LiteralPath $sourceIdentity).Hash -eq
+                (Get-FileHash -Algorithm SHA256 -LiteralPath $destinationIdentity).Hash
+        foreach ($requiredPath in $RequiredPaths) {
+            if (-not (Test-Path -LiteralPath (Join-Path $destination $requiredPath))) {
+                $canReuse = $false
+            }
+        }
+        if ($canReuse) {
+            return $destination
+        }
     }
     if (Test-Path -LiteralPath $destination) {
         Remove-Item -Recurse -Force -LiteralPath $destination
@@ -96,19 +113,21 @@ foreach ($relativePath in @("icon-themes", "themes", "icon-themes/idea/extension
     }
 }
 
-if ($Configuration -eq "Release") {
-    $jdtlsDestination = Copy-ResourceDirectory $preparedJdtlsRoot "LanguageServers/jdtls"
-    foreach ($relativePath in @("bin/jdtls.bat", "config_win", "plugins")) {
-        if (-not (Test-Path -LiteralPath (Join-Path $jdtlsDestination $relativePath))) {
-            throw "Bundled JDTLS staging is incomplete: $relativePath"
-        }
+$jdtlsDestination = Copy-ResourceDirectory $preparedJdtlsRoot "LanguageServers/jdtls"
+foreach ($relativePath in @("bin/jdtls.bat", "config_win", "plugins")) {
+    if (-not (Test-Path -LiteralPath (Join-Path $jdtlsDestination $relativePath))) {
+        throw "Bundled JDTLS staging is incomplete: $relativePath"
     }
+}
 
-    $jdkDestination = Copy-ResourceDirectory $preparedJdkRoot "LanguageServers/jdk"
-    foreach ($relativePath in @("bin/java.exe", "lib")) {
-        if (-not (Test-Path -LiteralPath (Join-Path $jdkDestination $relativePath))) {
-            throw "Bundled JDK staging is incomplete: $relativePath"
-        }
+$jdkDestination = Copy-ResourceDirectory `
+    -Source $preparedJdkRoot `
+    -RelativeDestination "LanguageServers/jdk" `
+    -IdentityFile ".lithe-jdk.json" `
+    -RequiredPaths @("bin/java.exe", "lib")
+foreach ($relativePath in @("bin/java.exe", "lib")) {
+    if (-not (Test-Path -LiteralPath (Join-Path $jdkDestination $relativePath))) {
+        throw "Bundled JDK staging is incomplete: $relativePath"
     }
 }
 

--- a/scripts/classify-ci-changes.sh
+++ b/scripts/classify-ci-changes.sh
@@ -293,7 +293,7 @@ while IFS=$'\t' read -r status first_path _; do
         scripts/database-sidecar-smoke.sh|scripts/database-validation-smoke.sh)
             rust_database=true
             ;;
-        scripts/build-macos.sh|scripts/verify-macos-app-build-safety.sh|scripts/verify-macos-package.sh|scripts/macos13sdkcompatibility.h|scripts/ld-macos13-compat.sh|scripts/package-app.sh|scripts/preview.sh|scripts/stamp-macos-app-build-info.sh|scripts/create-dmg.sh|scripts/create-macos-update-manifest.rb|scripts/test-macos-update-manifest.rb|scripts/prepare-jdtls.sh)
+        scripts/build-macos.sh|scripts/verify-macos-app-build-safety.sh|scripts/verify-macos-package.sh|scripts/macos13sdkcompatibility.h|scripts/ld-macos13-compat.sh|scripts/package-app.sh|scripts/preview.sh|scripts/stamp-macos-app-build-info.sh|scripts/create-dmg.sh|scripts/create-macos-update-manifest.rb|scripts/test-macos-update-manifest.rb|scripts/prepare-jdtls.sh|scripts/prepare-jdk.sh)
             macos_release=true
             ;;
         scripts/verify-download-cache.mjs|scripts/test-verify-download-cache.mjs)
@@ -316,7 +316,7 @@ while IFS=$'\t' read -r status first_path _; do
             rust_core=true
             macos_release=true
             ;;
-        scripts/build-windows.ps1|scripts/verify-windows-boundaries.ps1|scripts/verify-windows-boundaries.sh|scripts/prepare-jdtls.ps1|scripts/package-windows.ps1|scripts/install-windows-frontend-dependencies.ps1|scripts/invoke-windows-tauri-build.ps1|scripts/create-windows-updater-manifest.ps1|scripts/test-windows-updater-manifest.ps1)
+        scripts/build-windows.ps1|scripts/verify-windows-boundaries.ps1|scripts/verify-windows-boundaries.sh|scripts/prepare-jdtls.ps1|scripts/prepare-jdk.ps1|scripts/package-windows.ps1|scripts/install-windows-frontend-dependencies.ps1|scripts/invoke-windows-tauri-build.ps1|scripts/create-windows-updater-manifest.ps1|scripts/test-windows-updater-manifest.ps1)
             windows=true
             ;;
         scripts/prepare-lithe-pr-review.mjs|scripts/test-prepare-lithe-pr-review.mjs|scripts/run-lithe-codex-with-timeout.sh|scripts/update-repo-charts.py)

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -22,7 +22,11 @@ esac
 
 cd "$ROOT_DIR"
 JDTLS_ROOT=$("$ROOT_DIR/scripts/prepare-jdtls.sh")
-JDK_ROOT=$("$ROOT_DIR/scripts/prepare-jdk.sh")
+jdk_arch="$ARCH"
+if [[ "$jdk_arch" == "universal" ]]; then
+    jdk_arch="$(uname -m)"
+fi
+JDK_ROOT=$(LITHE_JDK_TARGET_ARCH="$jdk_arch" "$ROOT_DIR/scripts/prepare-jdk.sh")
 if [[ "$ARCH" == "universal" ]]; then
     scripts/build-macos.sh --configuration release --triple "$ARM64_TRIPLE"
     scripts/build-macos.sh --configuration release --triple "$X86_64_TRIPLE"

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -34,7 +34,59 @@ foreach ($relativePath in @("icon-themes", "themes", "icon-themes/idea/extension
     }
 }
 
-& (Join-Path $root "scripts/prepare-jdtls.ps1") | Out-Null
+$preparedJdtlsOutput = @(& (Join-Path $root "scripts/prepare-jdtls.ps1"))
+if ($preparedJdtlsOutput.Count -eq 0) {
+    throw "JDTLS preparation did not return an output directory."
+}
+$preparedJdtlsRoot = [System.IO.Path]::GetFullPath([string]$preparedJdtlsOutput[-1])
+$preparedJdkOutput = @(& (Join-Path $root "scripts/prepare-jdk.ps1") -RustTarget $RustTarget)
+if ($preparedJdkOutput.Count -eq 0) {
+    throw "JDK preparation did not return an output directory."
+}
+$preparedJdkRoot = [System.IO.Path]::GetFullPath([string]$preparedJdkOutput[-1])
+foreach ($requiredPath in @(
+    (Join-Path $preparedJdtlsRoot "bin/jdtls.bat"),
+    (Join-Path $preparedJdtlsRoot "plugins"),
+    (Join-Path $preparedJdkRoot "bin/java.exe"),
+    (Join-Path $preparedJdkRoot "lib")
+)) {
+    if (-not (Test-Path -LiteralPath $requiredPath)) {
+        throw "Bundled Java tooling preparation is incomplete: $requiredPath"
+    }
+}
+
+function Sync-BundleResource {
+    param([string]$Source, [string]$Destination)
+
+    $sourcePath = [System.IO.Path]::GetFullPath($Source)
+    $destinationPath = [System.IO.Path]::GetFullPath($Destination)
+    if ($sourcePath.Equals($destinationPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return
+    }
+    $artifactsRoot = [System.IO.Path]::GetFullPath((Join-Path $root ".artifacts"))
+    $trimCharacters = [char[]]@(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    )
+    $artifactsPrefix = $artifactsRoot.TrimEnd($trimCharacters) +
+        [System.IO.Path]::DirectorySeparatorChar
+    if (-not $destinationPath.StartsWith(
+        $artifactsPrefix,
+        [System.StringComparison]::OrdinalIgnoreCase
+    )) {
+        throw "Bundled Java tooling destination must stay inside $artifactsRoot"
+    }
+    if (Test-Path -LiteralPath $destinationPath) {
+        Remove-Item -Recurse -Force -LiteralPath $destinationPath
+    }
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $destinationPath) | Out-Null
+    Copy-Item -Recurse -Force -LiteralPath $sourcePath -Destination $destinationPath
+}
+
+# tauri.jdtls.conf.json consumes these canonical paths even when a developer
+# supplies a verified external runtime through an environment override.
+Sync-BundleResource $preparedJdtlsRoot (Join-Path $root ".artifacts/jdtls")
+Sync-BundleResource $preparedJdkRoot (Join-Path $root ".artifacts/jdk")
 
 $versionOverrides = @{
     version = $Version

--- a/scripts/prepare-jdk.ps1
+++ b/scripts/prepare-jdk.ps1
@@ -3,7 +3,8 @@
 
 [CmdletBinding()]
 param(
-    [string]$OutputDirectory = ""
+    [string]$OutputDirectory = "",
+    [string]$RustTarget = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -23,21 +24,33 @@ $requestedOutput = if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
 $output = [System.IO.Path]::GetFullPath($requestedOutput)
 $cache = Join-Path $root ".artifacts/jdk-downloads"
 
-# Detect architecture
-$arch = if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq
-    [System.Runtime.InteropServices.Architecture]::Arm64) {
-    "windows-aarch64"
-} else {
+function Resolve-PlatformKey {
+    if (-not [string]::IsNullOrWhiteSpace($RustTarget)) {
+        switch ($RustTarget) {
+            "x86_64-pc-windows-msvc" { return "windows-x86_64" }
+            "aarch64-pc-windows-msvc" { return "windows-aarch64" }
+            default { throw "Unsupported Windows Rust target for the bundled JDK: $RustTarget" }
+        }
+    }
+
+    if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq
+        [System.Runtime.InteropServices.Architecture]::Arm64) {
+        return "windows-aarch64"
+    }
     "windows-x86_64"
 }
 
+$platformKey = Resolve-PlatformKey
+
 $jdkVersion  = $manifest.version
-$platform    = $manifest.platforms.$arch
+$platform    = $manifest.platforms.$platformKey
+if ($null -eq $platform) { throw "The bundled JDK manifest has no platform entry for $platformKey" }
 $archiveUrl  = $platform.url
 $archiveSha256 = $platform.sha256.ToLowerInvariant()
 
 $safeVersion = $jdkVersion -replace '[^A-Za-z0-9._-]', '_'
-$archivePath = Join-Path $cache "jdk-$safeVersion-$arch-$archiveSha256.zip"
+$archivePath = Join-Path $cache "jdk-$safeVersion-$platformKey-$archiveSha256.zip"
+$stampPath = Join-Path $output ".lithe-jdk.json"
 
 function Get-FileSHA256 {
     param([Parameter(Mandatory)][string]$Path)
@@ -76,6 +89,10 @@ function Assert-JdkOutput {
     if (-not (Test-Path -LiteralPath $javaExe -PathType Leaf)) {
         throw "Bundled JDK java.exe is missing: $javaExe"
     }
+    $libDirectory = Join-Path $output "lib"
+    if (-not (Test-Path -LiteralPath $libDirectory -PathType Container)) {
+        throw "Bundled JDK lib directory is missing: $libDirectory"
+    }
 
     # Windows PowerShell 5 surfaces a native process's stderr as an error
     # record. Java writes its version to stderr, so temporarily allow that
@@ -96,10 +113,33 @@ function Assert-JdkOutput {
     }
 }
 
+function Test-PreparedJdk {
+    if (-not (Test-Path -LiteralPath $stampPath -PathType Leaf)) { return $false }
+    try {
+        $stamp = Get-Content -Raw -LiteralPath $stampPath | ConvertFrom-Json
+        if ($stamp.schemaVersion -ne 1 -or
+            $stamp.manifestVersion -ne $jdkVersion -or
+            $stamp.platform -ne $platformKey -or
+            $stamp.archiveSHA256 -ne $archiveSha256) {
+            return $false
+        }
+        Assert-JdkOutput
+        return $true
+    } catch {
+        Write-Warning "Prepared bundled JDK is invalid and will be rebuilt: $($_.Exception.Message)"
+        return $false
+    }
+}
+
 # If LITHE_JDK_ROOT is set externally, just validate and return.
 if (-not [string]::IsNullOrWhiteSpace($env:LITHE_JDK_ROOT) -and
     [string]::IsNullOrWhiteSpace($OutputDirectory)) {
     Assert-JdkOutput
+    Write-Output $output
+    exit 0
+}
+
+if (Test-PreparedJdk) {
     Write-Output $output
     exit 0
 }
@@ -122,6 +162,12 @@ try {
     $inner = Get-ChildItem -LiteralPath $staging -Directory | Select-Object -First 1
     if ($null -eq $inner) { throw "Could not locate JDK directory inside the Temurin archive" }
     Move-Item -LiteralPath $inner.FullName -Destination $output
+    @{
+        schemaVersion = 1
+        manifestVersion = $jdkVersion
+        platform = $platformKey
+        archiveSHA256 = $archiveSha256
+    } | ConvertTo-Json | Set-Content -LiteralPath $stampPath -Encoding ascii
 } finally {
     if (Test-Path -LiteralPath $staging) { Remove-Item -Recurse -Force -LiteralPath $staging }
 }

--- a/scripts/prepare-jdk.sh
+++ b/scripts/prepare-jdk.sh
@@ -9,21 +9,25 @@ ROOT_DIR="${0:A:h:h}"
 MANIFEST="$ROOT_DIR/third_party/jdk/manifest.json"
 OUTPUT_DIR="${LITHE_JDK_ROOT:-$ROOT_DIR/.artifacts/jdk}"
 CACHE_DIR="$ROOT_DIR/.artifacts/jdk-downloads"
+TARGET_ARCH="${LITHE_JDK_TARGET_ARCH:-$(uname -m)}"
 
 manifest_value() {
     /usr/bin/plutil -extract "$1" raw -o - "$MANIFEST"
 }
 
-case "$(uname -m)" in
+case "$TARGET_ARCH" in
     arm64) platform="macos-aarch64" ;;
     x86_64) platform="macos-x86_64" ;;
-    *) print -u2 -- "Unsupported macOS architecture: $(uname -m)"; exit 1 ;;
+    *) print -u2 -- "Unsupported macOS JDK target architecture: $TARGET_ARCH"; exit 1 ;;
 esac
 
 jdk_version="$(manifest_value version)"
 archive_url="$(manifest_value "platforms.$platform.url")"
 archive_sha256="$(manifest_value "platforms.$platform.sha256")"
-archive_path="$CACHE_DIR/jdk-$jdk_version-$platform-$archive_sha256.tar.gz"
+safe_jdk_version="${jdk_version//[^A-Za-z0-9._-]/_}"
+archive_path="$CACHE_DIR/jdk-$safe_jdk_version-$platform-$archive_sha256.tar.gz"
+identity="$jdk_version|$platform|$archive_sha256"
+identity_path="$OUTPUT_DIR/.lithe-jdk"
 
 file_sha256() {
     shasum -a 256 "$1" | awk '{print tolower($1)}'
@@ -63,18 +67,37 @@ download_verified_file() {
 validate_output() {
     [[ -x "$OUTPUT_DIR/bin/java" ]] || { print -u2 -- "Bundled JDK java executable is missing: $OUTPUT_DIR/bin/java"; exit 1; }
     [[ -d "$OUTPUT_DIR/lib" ]] || { print -u2 -- "Bundled JDK lib directory is missing: $OUTPUT_DIR"; exit 1; }
-    local reported_version
-    reported_version="$("$OUTPUT_DIR/bin/java" -version 2>&1 | head -n 1)"
-    case "$reported_version" in
-        *\"21.*) ;;
-        *) print -u2 -- "Bundled JDK reported an unexpected version: $reported_version"; exit 1 ;;
-    esac
+    /usr/bin/lipo "$OUTPUT_DIR/bin/java" -verify_arch "$TARGET_ARCH" >/dev/null 2>&1 || {
+        print -u2 -- "Bundled JDK java executable does not contain $TARGET_ARCH: $OUTPUT_DIR/bin/java"
+        exit 1
+    }
+    [[ -f "$OUTPUT_DIR/release" ]] || { print -u2 -- "Bundled JDK release metadata is missing: $OUTPUT_DIR/release"; exit 1; }
+    grep -Eq '^JAVA_VERSION="21\.' "$OUTPUT_DIR/release" || {
+        print -u2 -- "Bundled JDK release metadata does not report Java 21: $OUTPUT_DIR/release"
+        exit 1
+    }
+}
+
+output_is_valid() {
+    [[ -x "$OUTPUT_DIR/bin/java" ]] &&
+        [[ -d "$OUTPUT_DIR/lib" ]] &&
+        [[ -f "$OUTPUT_DIR/release" ]] &&
+        /usr/bin/lipo "$OUTPUT_DIR/bin/java" -verify_arch "$TARGET_ARCH" >/dev/null 2>&1 &&
+        grep -Eq '^JAVA_VERSION="21\.' "$OUTPUT_DIR/release"
 }
 
 if [[ -n "${LITHE_JDK_ROOT:-}" ]]; then
     validate_output
     print -r -- "$OUTPUT_DIR"
     exit 0
+fi
+
+if [[ -f "$identity_path" && "$(<"$identity_path")" == "$identity" ]]; then
+    if output_is_valid; then
+        print -r -- "$OUTPUT_DIR"
+        exit 0
+    fi
+    print -u2 -- "Prepared bundled JDK is invalid and will be rebuilt: $OUTPUT_DIR"
 fi
 
 mkdir -p "$CACHE_DIR"
@@ -96,6 +119,7 @@ if [[ -z "$home_directory" ]]; then
 fi
 mkdir -p "$(dirname "$OUTPUT_DIR")"
 mv "$home_directory" "$OUTPUT_DIR"
+print -r -- "$identity" > "$identity_path"
 rm -rf "$staging"
 
 validate_output

--- a/scripts/test-verify-download-cache.mjs
+++ b/scripts/test-verify-download-cache.mjs
@@ -45,6 +45,8 @@ async function assertWindowsBunCacheConfiguration() {
     assert.match(contents, /BUN_TMPDIR=.*\.artifacts\/bun-tmp/, `${relativePath} must keep Bun temp files on the cache volume`);
     assert.match(contents, /BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX=1/, `${relativePath} must omit Bun's Windows junction index`);
     assert.match(contents, /bun-\$\{\{ steps\.bun\.outputs\.bun-version \}\}-v2-/, `${relativePath} must isolate the same-volume Bun cache format`);
+    assert.match(contents, /^\s*path: \.artifacts\/jdk-downloads$/m, `${relativePath} must cache JDK downloads`);
+    assert.match(contents, /jdk-v1-\$\{\{ hashFiles\('third_party\/jdk\/manifest\.json'\) \}\}/, `${relativePath} must key JDK downloads by manifest`);
   }
 
   const installer = await fs.readFile(path.join(repositoryRoot, "scripts/install-windows-frontend-dependencies.ps1"), "utf8");
@@ -60,8 +62,63 @@ async function assertWindowsBunCacheConfiguration() {
   assert.match(validator, /\$bunCache = Join-Path \$artifactsRoot "bun-cache"/, "Windows cache validation must use the isolated Bun cache");
 }
 
+async function assertWindowsJavaToolingBuildConfiguration() {
+  const buildScript = await fs.readFile(path.join(repositoryRoot, "scripts/build-windows.ps1"), "utf8");
+  assert.match(buildScript, /prepare-jdtls\.ps1/, "Windows builds must prepare JDTLS");
+  assert.match(buildScript, /prepare-jdk\.ps1[\s\S]*-RustTarget \$RustTarget/, "Windows builds must prepare the target JDK");
+  assert.doesNotMatch(
+    buildScript,
+    /if \(\$Configuration -eq "Release"\) \{[\s\S]{0,1200}prepare-jdk\.ps1/,
+    "Debug builds must not skip JDK preparation",
+  );
+  assert.match(buildScript, /LanguageServers\/jdk/, "Windows builds must stage the JDK next to the executable");
+
+  const packageScript = await fs.readFile(path.join(repositoryRoot, "scripts/package-windows.ps1"), "utf8");
+  assert.match(packageScript, /prepare-jdk\.ps1[\s\S]*-RustTarget \$RustTarget/, "Windows packages must prepare the target JDK");
+  assert.match(packageScript, /bin\/java\.exe/, "Windows packages must validate the bundled java.exe");
+  assert.match(packageScript, /Sync-BundleResource \$preparedJdkRoot[\s\S]*\.artifacts\/jdk/, "Windows packages must stage overrides at Tauri's canonical JDK path");
+
+  const prepareScript = await fs.readFile(path.join(repositoryRoot, "scripts/prepare-jdk.ps1"), "utf8");
+  assert.match(prepareScript, /"x86_64-pc-windows-msvc" \{ return "windows-x86_64" \}/);
+  assert.match(prepareScript, /"aarch64-pc-windows-msvc" \{ return "windows-aarch64" \}/);
+  assert.match(prepareScript, /\.lithe-jdk\.json/, "Prepared JDKs must carry a reusable identity stamp");
+}
+
+async function assertMacJdkCacheConfiguration() {
+  const action = await fs.readFile(
+    path.join(repositoryRoot, ".github/actions/prepare-macos-dependency-cache/action.yml"),
+    "utf8",
+  );
+  assert.match(action, /^  jdk:$/m, "macOS cache action must expose the JDK cache");
+  assert.match(action, /^  jdk-architecture:$/m, "macOS cache action must isolate target architectures");
+  assert.match(action, /path: \.artifacts\/jdk-downloads/);
+  assert.match(action, /macos-jdk-downloads-\$\{\{ runner\.os \}\}-\$\{\{ inputs\.jdk-architecture \}\}-/);
+
+  for (const relativePath of [
+    ".github/workflows/release-preview-macos.yml",
+    ".github/workflows/release-macos.yml",
+  ]) {
+    const workflow = await fs.readFile(path.join(repositoryRoot, relativePath), "utf8");
+    assert.match(workflow, /^\s+jdk: "true"$/m, `${relativePath} must restore JDK downloads`);
+    assert.match(workflow, /^\s+jdk-architecture: \$\{\{ matrix\.architecture \}\}$/m, `${relativePath} must cache the target architecture`);
+  }
+
+  const packageScript = await fs.readFile(path.join(repositoryRoot, "scripts/package-app.sh"), "utf8");
+  assert.match(packageScript, /LITHE_JDK_TARGET_ARCH="\$jdk_arch"/, "macOS packages must prepare the target-architecture JDK");
+  const prepareScript = await fs.readFile(path.join(repositoryRoot, "scripts/prepare-jdk.sh"), "utf8");
+  assert.match(prepareScript, /TARGET_ARCH="\$\{LITHE_JDK_TARGET_ARCH:-\$\(uname -m\)\}"/);
+  assert.match(prepareScript, /macos-aarch64/);
+  assert.match(prepareScript, /macos-x86_64/);
+  assert.match(prepareScript, /lipo.*-verify_arch.*TARGET_ARCH/, "macOS JDK validation must verify its Mach-O architecture");
+
+  const packageVerifier = await fs.readFile(path.join(repositoryRoot, "scripts/verify-macos-package.sh"), "utf8");
+  assert.match(packageVerifier, /LanguageServers\/jdk\/bin\/java/, "macOS package verification must require the bundled JDK");
+}
+
 try {
   await assertWindowsBunCacheConfiguration();
+  await assertWindowsJavaToolingBuildConfiguration();
+  await assertMacJdkCacheConfiguration();
 
   const cargoCache = path.join(testRoot, "cargo-cache", "registry");
   const cargoLock = path.join(testRoot, "Cargo.lock");
@@ -126,6 +183,57 @@ try {
   assert.equal(await fs.readFile(jdtlsArchive, "utf8"), "");
   await assert.rejects(fs.access(unexpected));
   assert.match(diagnostics(result), /not referenced by the JDTLS manifest/);
+
+  const jdkCache = path.join(testRoot, "jdk-cache");
+  const jdkManifest = path.join(testRoot, "jdk-manifest.json");
+  const jdkArchive = path.join(jdkCache, `jdk-21.0.0-windows-x86_64-${emptySha256}.zip`);
+  const macJdkArchive = path.join(jdkCache, `jdk-21.0.0-macos-aarch64-${emptySha256}.tar.gz`);
+  const unexpectedJdk = path.join(jdkCache, "unexpected.download");
+  await fs.mkdir(jdkCache, { recursive: true });
+  await fs.writeFile(
+    jdkManifest,
+    JSON.stringify({
+      version: "21.0.0",
+      platforms: {
+        "windows-x86_64": { sha256: emptySha256 },
+        "macos-aarch64": { sha256: emptySha256 },
+      },
+    }),
+  );
+  await fs.writeFile(jdkArchive, "");
+  await fs.writeFile(macJdkArchive, "");
+  await fs.writeFile(unexpectedJdk, "unexpected");
+
+  result = verify([
+    "--cargo-cache",
+    cargoCache,
+    "--cargo-lock",
+    cargoLock,
+    "--jdk-cache",
+    jdkCache,
+    "--jdk-manifest",
+    jdkManifest,
+  ]);
+  assertSucceeded(result);
+  assert.equal(await fs.readFile(jdkArchive, "utf8"), "");
+  assert.equal(await fs.readFile(macJdkArchive, "utf8"), "");
+  await assert.rejects(fs.access(unexpectedJdk));
+  assert.match(diagnostics(result), /not referenced by the JDK manifest/);
+
+  await fs.writeFile(jdkArchive, "corrupted");
+  result = verify([
+    "--cargo-cache",
+    cargoCache,
+    "--cargo-lock",
+    cargoLock,
+    "--jdk-cache",
+    jdkCache,
+    "--jdk-manifest",
+    jdkManifest,
+  ]);
+  assertSucceeded(result);
+  await assert.rejects(fs.access(jdkArchive));
+  assert.match(diagnostics(result), /JDK cache entry rejected.*SHA-256 mismatch/s);
 
   const fakeBin = path.join(testRoot, "bin");
   const fakeBun = path.join(fakeBin, "bun");

--- a/scripts/validate-macos-dependency-caches.sh
+++ b/scripts/validate-macos-dependency-caches.sh
@@ -9,6 +9,8 @@ CARGO_ENABLED=false
 CARGO_OUTCOME=skipped
 JDTLS_ENABLED=false
 JDTLS_OUTCOME=skipped
+JDK_ENABLED=false
+JDK_OUTCOME=skipped
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -19,6 +21,8 @@ while [[ $# -gt 0 ]]; do
         --cargo-outcome) CARGO_OUTCOME="$2"; shift 2 ;;
         --jdtls-enabled) JDTLS_ENABLED="$2"; shift 2 ;;
         --jdtls-outcome) JDTLS_OUTCOME="$2"; shift 2 ;;
+        --jdk-enabled) JDK_ENABLED="$2"; shift 2 ;;
+        --jdk-outcome) JDK_OUTCOME="$2"; shift 2 ;;
         *) print -u2 -- "Unknown option: $1"; exit 2 ;;
     esac
 done
@@ -50,6 +54,7 @@ clear_artifact_cache() {
 swiftpm_root="$ROOT_DIR/.artifacts/swiftpm-cache"
 cargo_cache="$ROOT_DIR/.artifacts/cargo-home/registry/cache"
 jdtls_cache="$ROOT_DIR/.artifacts/jdtls-downloads"
+jdk_cache="$ROOT_DIR/.artifacts/jdk-downloads"
 
 if [[ "$SWIFTPM_ENABLED" == "true" && "$SWIFTPM_OUTCOME" != "success" ]]; then
     warning "SwiftPM cache restore failed" "GitHub cache restore reported $SWIFTPM_OUTCOME. The isolated cache will be discarded and dependencies will be resolved normally."
@@ -62,6 +67,10 @@ fi
 if [[ "$JDTLS_ENABLED" == "true" && "$JDTLS_OUTCOME" != "success" ]]; then
     warning "JDTLS cache restore failed" "GitHub cache restore reported $JDTLS_OUTCOME. The isolated cache will be discarded and artifacts will be downloaded normally."
     clear_artifact_cache "$jdtls_cache"
+fi
+if [[ "$JDK_ENABLED" == "true" && "$JDK_OUTCOME" != "success" ]]; then
+    warning "JDK cache restore failed" "GitHub cache restore reported $JDK_OUTCOME. The isolated cache will be discarded and artifacts will be downloaded normally."
+    clear_artifact_cache "$jdk_cache"
 fi
 
 verifier_arguments=()
@@ -86,12 +95,19 @@ if [[ "$JDTLS_ENABLED" == "true" ]]; then
         --jdtls-manifest "$ROOT_DIR/third_party/jdtls/manifest.json"
     )
 fi
+if [[ "$JDK_ENABLED" == "true" ]]; then
+    verifier_arguments+=(
+        --jdk-cache "$jdk_cache"
+        --jdk-manifest "$ROOT_DIR/third_party/jdk/manifest.json"
+    )
+fi
 
 if ! node "$ROOT_DIR/scripts/verify-download-cache.mjs" "${verifier_arguments[@]}"; then
     warning "Dependency cache validation failed" "The cache validator failed unexpectedly. All enabled caches will be cleared before the normal dependency path continues."
     [[ "$SWIFTPM_ENABLED" == "true" ]] && clear_artifact_cache "$swiftpm_root"
     [[ "$CARGO_ENABLED" == "true" ]] && clear_artifact_cache "$cargo_cache"
     [[ "$JDTLS_ENABLED" == "true" ]] && clear_artifact_cache "$jdtls_cache"
+    [[ "$JDK_ENABLED" == "true" ]] && clear_artifact_cache "$jdk_cache"
 fi
 
 if [[ -n "${GITHUB_ENV:-}" ]]; then

--- a/scripts/validate-windows-build-caches.ps1
+++ b/scripts/validate-windows-build-caches.ps1
@@ -5,6 +5,7 @@ param(
     [string]$CargoBuildHit = "",
     [string]$BunOutcome = "skipped",
     [string]$JdtlsOutcome = "skipped",
+    [string]$JdkOutcome = "skipped",
     [switch]$IncludeWindowsAssets
 )
 
@@ -14,6 +15,7 @@ $artifactsRoot = [System.IO.Path]::GetFullPath((Join-Path $root ".artifacts"))
 $cargoHome = Join-Path $artifactsRoot "cargo-home"
 $bunCache = Join-Path $artifactsRoot "bun-cache"
 $jdtlsCache = Join-Path $artifactsRoot "jdtls-downloads"
+$jdkCache = Join-Path $artifactsRoot "jdk-downloads"
 
 function Write-CacheWarning {
     param([string]$Title, [string]$Message)
@@ -61,6 +63,10 @@ if ($JdtlsOutcome -eq "failure") {
     Write-CacheWarning "JDTLS cache restore failed" "Discarding the partial JDTLS cache and downloading verified artifacts normally."
     Reset-GeneratedPath $jdtlsCache
 }
+if ($JdkOutcome -eq "failure") {
+    Write-CacheWarning "JDK cache restore failed" "Discarding the partial JDK cache and downloading verified artifacts normally."
+    Reset-GeneratedPath $jdkCache
+}
 
 $validatorArguments = @(
     (Join-Path $root "scripts/verify-download-cache.mjs"),
@@ -77,6 +83,8 @@ if ($IncludeWindowsAssets) {
     $validatorArguments += @(
         "--jdtls-cache", $jdtlsCache,
         "--jdtls-manifest", (Join-Path $root "third_party/jdtls/manifest.json"),
+        "--jdk-cache", $jdkCache,
+        "--jdk-manifest", (Join-Path $root "third_party/jdk/manifest.json"),
         "--bun-version", $bunVersion,
         "--bun-lock", (Join-Path $root "windows/tauri/bun.lock"),
         "--bun-cache", $bunCache
@@ -90,6 +98,7 @@ if ($LASTEXITCODE -ne 0) {
     if ($IncludeWindowsAssets) {
         Reset-GeneratedPath $bunCache
         Reset-GeneratedPath $jdtlsCache
+        Reset-GeneratedPath $jdkCache
     }
 }
 

--- a/scripts/verify-download-cache.mjs
+++ b/scripts/verify-download-cache.mjs
@@ -29,6 +29,8 @@ function parseArguments(argv) {
     skipCargo: false,
     jdtlsCache: null,
     jdtlsManifest: null,
+    jdkCache: null,
+    jdkManifest: null,
     swiftpmCache: null,
     swiftpmResolved: null,
     swiftVersion: null,
@@ -60,6 +62,8 @@ function parseArguments(argv) {
     else if (option === "--cargo-lock") options.cargoLocks.push(value);
     else if (option === "--jdtls-cache") options.jdtlsCache = value;
     else if (option === "--jdtls-manifest") options.jdtlsManifest = value;
+    else if (option === "--jdk-cache") options.jdkCache = value;
+    else if (option === "--jdk-manifest") options.jdkManifest = value;
     else if (option === "--swiftpm-cache") options.swiftpmCache = value;
     else if (option === "--swiftpm-resolved") options.swiftpmResolved = value;
     else if (option === "--swift-version") options.swiftVersion = value;
@@ -204,6 +208,34 @@ async function verifyJdtlsCache(cacheRoot, manifestPath) {
     }
   }
   process.stdout.write(`JDTLS download cache verified: ${verified} artifact(s), ${removed} rejected.\n`);
+}
+
+async function verifyJdkCache(cacheRoot, manifestPath) {
+  if (!cacheRoot || !manifestPath) return;
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  const expected = new Map(
+    Object.entries(manifest.platforms ?? {})
+      .map(([platform, entry]) => [
+        `jdk-${safeVersion(manifest.version)}-${platform}-${entry.sha256.toLowerCase()}${platform.startsWith("windows-") ? ".zip" : ".tar.gz"}`,
+        entry.sha256.toLowerCase(),
+      ]),
+  );
+  let verified = 0;
+  let removed = 0;
+  for (const artifact of await collectFiles(cacheRoot)) {
+    const artifactName = path.basename(artifact);
+    const expectedHash = expected.get(artifactName);
+    const actualHash = expectedHash ? await sha256(artifact) : null;
+    if (!expectedHash || actualHash !== expectedHash) {
+      const reason = expectedHash ? "SHA-256 mismatch" : "not referenced by the JDK manifest";
+      warn("JDK cache entry rejected", `${artifactName}: ${reason}; it will be downloaded normally.`);
+      await fs.rm(artifact, { force: true });
+      removed += 1;
+    } else {
+      verified += 1;
+    }
+  }
+  process.stdout.write(`JDK download cache verified: ${verified} artifact(s), ${removed} rejected.\n`);
 }
 
 function runGit(repository, argumentList) {
@@ -544,6 +576,10 @@ async function main() {
   await verifyJdtlsCache(
     options.jdtlsCache ? path.resolve(options.jdtlsCache) : null,
     options.jdtlsManifest ? path.resolve(options.jdtlsManifest) : null,
+  );
+  await verifyJdkCache(
+    options.jdkCache ? path.resolve(options.jdkCache) : null,
+    options.jdkManifest ? path.resolve(options.jdkManifest) : null,
   );
   await verifySwiftpmCache(
     options.swiftpmCache ? path.resolve(options.swiftpmCache) : null,

--- a/scripts/verify-macos-package.sh
+++ b/scripts/verify-macos-package.sh
@@ -13,6 +13,7 @@ esac
 temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/lithe-package-verification.XXXXXX")
 trap 'rm -rf -- "$temporary_directory"' EXIT
 jdtls_root="$temporary_directory/jdtls"
+jdk_root="$temporary_directory/jdk"
 dist_root="$temporary_directory/dist"
 package_log="$temporary_directory/package.log"
 dmg_log="$temporary_directory/dmg.log"
@@ -39,9 +40,19 @@ LAUNCHER
 : > "$jdtls_root/lombok/lombok.jar"
 : > "$jdtls_root/lombok/LICENSE-MIT.txt"
 
+mkdir -p "$jdk_root/bin" "$jdk_root/lib"
+cat > "$temporary_directory/java.c" <<'SOURCE'
+int main(void) { return 0; }
+SOURCE
+xcrun clang -arch "$ARCH" "$temporary_directory/java.c" -o "$jdk_root/bin/java"
+cat > "$jdk_root/release" <<'RELEASE'
+JAVA_VERSION="21.0.0"
+RELEASE
+
 LITHE_ARCH="$ARCH" \
 LITHE_DIST_ROOT="$dist_root" \
 LITHE_JDTLS_ROOT="$jdtls_root" \
+LITHE_JDK_ROOT="$jdk_root" \
 LITHE_CODESIGN_IDENTITY="-" \
     scripts/package-app.sh | tee "$package_log"
 
@@ -68,6 +79,8 @@ required_resources=(
     "$app_path/Contents/Info.plist"
     "$app_path/Contents/Resources/Lithe_Lithe.bundle"
     "$app_path/Contents/Resources/LanguageServers/jdtls/bin/jdtls"
+    "$app_path/Contents/Resources/LanguageServers/jdk/bin/java"
+    "$app_path/Contents/Resources/LanguageServers/jdk/lib"
 )
 for resource in "${required_resources[@]}"; do
     if [[ ! -e "$resource" ]]; then
@@ -75,6 +88,9 @@ for resource in "${required_resources[@]}"; do
         exit 1
     fi
 done
+/usr/bin/lipo \
+    "$app_path/Contents/Resources/LanguageServers/jdk/bin/java" \
+    -verify_arch "$ARCH"
 
 plugin_manifests=("$app_path/Contents/Resources/OfficialPlugins"/*/plugin.json(N))
 if (( ${#plugin_manifests[@]} == 0 )); then

--- a/windows/tauri/src-tauri/src/lsp.rs
+++ b/windows/tauri/src-tauri/src/lsp.rs
@@ -277,7 +277,7 @@ fn bundled_jdk_root(app: &AppHandle) -> Option<PathBuf> {
 }
 
 fn is_jdk_home(root: &Path) -> bool {
-    root.join("bin").join("java.exe").is_file() || root.join("bin").join("java").is_file()
+    root.join("bin").join("java.exe").is_file()
 }
 
 fn jdtls_version_for_executable(executable: &Path) -> Result<String, String> {
@@ -471,14 +471,18 @@ mod tests {
     use super::*;
     use std::collections::BTreeSet;
     use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEST_TEMP_DIRECTORY_ID: AtomicU64 = AtomicU64::new(1);
 
     fn temp_dir() -> PathBuf {
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
             .as_nanos();
-        let path = std::env::temp_dir().join(format!("lithe-java-lsp-{stamp}"));
+        let id = TEST_TEMP_DIRECTORY_ID.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("lithe-java-lsp-{stamp}-{id}"));
         fs::create_dir_all(&path).expect("temp dir");
         path
     }
@@ -563,6 +567,17 @@ mod tests {
         let resolution = resolve_java_lsp_launch(None, Some(&jdtls_root), &[], Some(&bundled_jdk))
             .expect("resolution");
         assert_eq!(resolution.java_home, bundled_jdk, "bundled JDK should win");
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn windows_bundled_jdk_rejects_a_unix_java_executable() {
+        let root = temp_dir().join("non-windows-jdk-test");
+        let bin = root.join("bin");
+        fs::create_dir_all(&bin).expect("JDK bin");
+        fs::write(bin.join("java"), "").expect("Unix java marker");
+
+        assert!(!is_jdk_home(&root));
         fs::remove_dir_all(root).ok();
     }
 


### PR DESCRIPTION
## Summary
- bundle target-architecture JDKs with Windows and macOS builds
- cache verified JDK downloads in GitHub Actions
- validate packaged JDK paths, versions, and architectures

## Verification
- Windows ARM64 Debug and Release builds passed
- Windows and host JDTLS Rust tests passed (19/19)
- macOS ARM64 app and DMG package verification passed
- actionlint, cache verifier, CI classifier, and shell syntax checks passed

The source commit includes `[skip ci]`; the preview release workflow will be run manually after merge.