### PR TITLE
ci: parallelize PR reviews with Codex

### DIFF
--- a/.github/lithe-review/README.md
+++ b/.github/lithe-review/README.md
@@ -1,37 +1,47 @@
 # Lithe PR 审查机器人配置
 
 `Lithe PR review` 工作流只响应 PR 对话区中完全匹配 `@lithe review` 的
-评论，普通 Issue 不会触发。审查会锁定 PR 的准确 head 提交，并读取完整 Git
+评论，普通 Issue 不会触发。审查锁定 PR 的准确 base/head，并读取完整 Git
 历史、关联 Issue、PR 讨论、Review 和 CI 检查结果。
 
-使用前，请在仓库 Actions 中配置以下 Secrets：
+## Codex 中转站
 
-- `LITHE_ANTHROPIC_API_KEY`：Anthropic 或兼容中转站的 API Key。
-- `LITHE_ANTHROPIC_BASE_URL`：Anthropic Messages 兼容的 Base URL。它不是
-  OpenAI `/v1/responses` 地址，是否包含 `/v1` 以服务商说明为准。
+在仓库 Actions 中配置以下 Secrets：
 
-为兼容原有配置，未提供上述 Secret 时会复用 `LITHE_OPENAI_API_KEY`，并从
-`LITHE_OPENAI_RESPONSES_URL` 中去掉末尾的 `/v1/responses` 后作为 Claude Base
-URL。中转站仍需支持 Anthropic `/v1/messages` 协议。
+- `LITHE_CODEX_API_KEY`：Codex Responses API 兼容中转站的 API Key。
+- `LITHE_CODEX_RESPONSES_URL`：完整的 Responses API 地址，通常以
+  `/v1/responses` 结尾。服务必须接受 `Authorization: Bearer <key>`，并支持
+  Codex 所需的流式响应、工具调用和结构化输出。
 
-审查固定使用 `claude-opus-5` 模型和 `high` 思考强度，无需额外配置模型变量。
+不要把 API Key、私人中转地址或其他凭据提交到仓库。工作流通过官方
+`openai/codex-action@v1` 的安全代理把 Secret 传给中转站。
 
-默认只有仓库所有者能够触发审查。如需指定白名单，请创建 Actions 仓库变量
-`LITHE_ALLOWED_REVIEWERS`，值为 GitHub 用户名组成的 JSON 数组：
+所有阶段固定使用 `gpt-5.6-sol`。planner 和最终 aggregator 使用 `xhigh`
+reasoning effort，三个并行 reviewer 使用 `medium`。中转站必须支持这一模型名和
+两种思考强度。
+
+## 审查流水线
+
+授权召唤按以下阶段执行：
+
+1. `prepare` 构建可信上下文并发布占位评论。
+2. `planner` 理解变更，为三个固定审查视角分配重点；模型失败时使用确定性默认计划。
+3. `reviewers` 从正确性、架构契约、韧性安全三个视角并行审查，最大并发为 2。
+4. `aggregate` 重新读取代码验证候选发现、去重并生成最终评论。
+5. `publish` 更新对应 head SHA 的机器人评论。
+
+各模型阶段都 checkout 相同的不可变 head SHA，使用只读 sandbox，并通过 JSON
+Schema 交换结构化结果。planner、每个 reviewer 和 aggregator 位于独立 job，拥有
+独立超时和 artifact；单个 reviewer 失败不会阻止其余结果进入最终聚合。planner、
+reviewer 和聚合产物保留 14 天，便于定位中转站或模型失败。
+
+默认只有仓库所有者能够触发审查。如需指定白名单，请创建 Actions repository
+variable `LITHE_ALLOWED_REVIEWERS`，值为 GitHub 用户名组成的 JSON 数组：
 
 ```json
 ["1lck", "maintainer"]
 ```
 
-显式白名单会替代默认的仓库所有者规则。每个 PR head SHA 只保留一条机器人
-评论；对同一个 head 重复召唤时会更新原评论。
-
-每次授权召唤会先添加 👀 reaction，并创建一条“正在审查”的占位评论。准备、
-模型执行和评论发布使用三个独立 job，模型 job 卡死不会阻止发布 job 更新失败
-状态。Claude 通过官方 `anthropics/claude-code-action@v1` 以只读 GitHub 权限
-运行，仅允许读取仓库和执行 `git` 命令。Claude execution output、最终消息和
-诊断摘要会作为 artifact 保留 14 天；即使模型失败或超时，占位评论也会附上
-本次 Actions 运行链接。
-
-GitHub 只从仓库默认分支加载 `issue_comment` 工作流，因此这些文件进入默认
-分支后，机器人才能正式响应评论。
+显式白名单会替代默认规则。同一 head SHA 重复召唤时会更新原评论。GitHub 只从
+仓库默认分支加载 `issue_comment` 工作流，因此这些文件进入默认分支后机器人才能
+使用新流程。

--- a/.github/lithe-review/final.schema.json
+++ b/.github/lithe-review/final.schema.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "review_markdown": { "type": "string" }
+  },
+  "required": ["review_markdown"],
+  "additionalProperties": false
+}

--- a/.github/lithe-review/planner.schema.json
+++ b/.github/lithe-review/planner.schema.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "change_summary": { "type": "string" },
+    "assignments": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "properties": {
+          "role_id": { "type": "string", "enum": ["correctness", "architecture", "resilience"] },
+          "focus_paths": { "type": "array", "items": { "type": "string" } },
+          "questions": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["role_id", "focus_paths", "questions"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["change_summary", "assignments"],
+  "additionalProperties": false
+}

--- a/.github/lithe-review/reviewer.schema.json
+++ b/.github/lithe-review/reviewer.schema.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "role_id": { "type": "string", "enum": ["correctness", "architecture", "resilience"] },
+    "summary": { "type": "string" },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "priority": { "type": "string", "enum": ["P0", "P1", "P2", "P3"] },
+          "title": { "type": "string" },
+          "path": { "type": "string" },
+          "line": { "type": ["integer", "null"], "minimum": 1 },
+          "evidence": { "type": "string" },
+          "impact": { "type": "string" },
+          "suggestion": { "type": "string" },
+          "confidence": { "type": "string", "enum": ["high", "medium", "low"] }
+        },
+        "required": ["priority", "title", "path", "line", "evidence", "impact", "suggestion", "confidence"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["role_id", "summary", "findings"],
+  "additionalProperties": false
+}

--- a/.github/workflows/lithe-pr-review.yml
+++ b/.github/workflows/lithe-pr-review.yml
@@ -12,8 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  LITHE_CLAUDE_MODEL: claude-opus-5
-  LITHE_CLAUDE_EFFORT: high
+  LITHE_CODEX_MODEL: gpt-5.6-sol
 
 jobs:
   prepare:
@@ -30,7 +29,6 @@ jobs:
       authorized: ${{ steps.prepare.outputs.authorized }}
       base_sha: ${{ steps.prepare.outputs.base_sha }}
       head_sha: ${{ steps.prepare.outputs.head_sha }}
-
     steps:
       - name: Check out trusted review tooling
         uses: actions/checkout@v7
@@ -45,7 +43,7 @@ jobs:
           node-version: "24"
 
       - name: Test review context builder
-        run: node --test scripts/test-prepare-lithe-pr-review.mjs
+        run: node --test scripts/test-prepare-lithe-*review*.mjs
 
       - name: Prepare trusted review context
         id: prepare
@@ -64,7 +62,7 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const marker = `<!-- lithe-review:${context.issue.number}:${process.env.LITHE_HEAD_SHA} -->`;
-            const body = `${marker}\n## Lithe Review\n\n⏳ 正在审查当前提交，完成或失败后会更新本评论。`;
+            const body = `${marker}\n## Lithe Review\n\n⏳ 正在规划并行审查，完成或失败后会更新本评论。`;
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -74,21 +72,10 @@ jobs:
             const previous = comments.find((comment) =>
               comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(marker)
             );
-
             if (previous) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: previous.id,
-                body,
-              });
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: previous.id, body });
             } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
             }
 
       - name: Upload trusted review input
@@ -100,19 +87,15 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  review:
+  planner:
     needs: prepare
     if: needs.prepare.outputs.authorized == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     permissions:
       contents: read
-      issues: read
-      pull-requests: read
     outputs:
-      review_outcome: ${{ steps.diagnostics.outputs.review_outcome }}
-      final_message: ${{ steps.result.outputs.final_message }}
-
+      plan_source: ${{ steps.ensure.outputs.plan_source }}
     steps:
       - name: Check out trusted review tooling
         uses: actions/checkout@v7
@@ -121,11 +104,26 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Stage trusted planner tooling
+        env:
+          LITHE_TOOLING: ${{ runner.temp }}/lithe-review-tooling
+        run: |
+          set -euo pipefail
+          mkdir -p "$LITHE_TOOLING"
+          install -m 755 scripts/prepare-lithe-review-stage.mjs "$LITHE_TOOLING/stage.mjs"
+          install -m 600 .github/lithe-review/planner.schema.json "$LITHE_TOOLING/planner.schema.json"
+
       - name: Download trusted review input
         uses: actions/download-artifact@v4
         with:
           name: lithe-review-input-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/lithe-review-input
+
+      - name: Build planner prompt
+        run: >-
+          node "${{ runner.temp }}/lithe-review-tooling/stage.mjs" planner
+          --base-prompt "${{ runner.temp }}/lithe-review-input/lithe-pr-review-prompt.md"
+          --output "${{ runner.temp }}/lithe-review-planner-prompt.md"
 
       - name: Check out the complete pull request head
         uses: actions/checkout@v7
@@ -134,183 +132,302 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Inspect checked-out repository
+      - name: Verify checked-out revision
         env:
           LITHE_BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
           LITHE_HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
         run: |
           set -euo pipefail
-          actual_head="$(git rev-parse HEAD)"
-          if [ "$actual_head" != "$LITHE_HEAD_SHA" ]; then
-            echo "Checked-out HEAD ${actual_head} does not match expected ${LITHE_HEAD_SHA}" >&2
-            exit 1
-          fi
+          test "$(git rev-parse HEAD)" = "$LITHE_HEAD_SHA"
           git cat-file -e "${LITHE_BASE_SHA}^{commit}"
 
-          echo "[lithe-review] repository=${GITHUB_REPOSITORY}"
-          echo "[lithe-review] base_sha=${LITHE_BASE_SHA}"
-          echo "[lithe-review] head_sha=${LITHE_HEAD_SHA}"
-          echo "[lithe-review] commit_count=$(git rev-list --count HEAD)"
-          echo "[lithe-review] tracked_files=$(git ls-files | wc -l | tr -d ' ')"
-          echo "[lithe-review] changed_files=$(git diff --name-only "${LITHE_BASE_SHA}...${LITHE_HEAD_SHA}" | wc -l | tr -d ' ')"
-          echo "[lithe-review] diff_summary=$(git diff --shortstat "${LITHE_BASE_SHA}...${LITHE_HEAD_SHA}" || true)"
-          echo "[lithe-review] git_objects=$(git count-objects -vH | tr '\n' ';')"
-
-      - name: Validate Claude configuration
-        env:
-          LITHE_ANTHROPIC_API_KEY: ${{ secrets.LITHE_ANTHROPIC_API_KEY || secrets.LITHE_OPENAI_API_KEY }}
-          LITHE_ANTHROPIC_BASE_URL: ${{ secrets.LITHE_ANTHROPIC_BASE_URL || secrets.LITHE_OPENAI_RESPONSES_URL }}
-        run: |
-          set -euo pipefail
-          if [ -z "$LITHE_ANTHROPIC_API_KEY" ]; then
-            echo "LITHE_ANTHROPIC_API_KEY is not configured" >&2
-            exit 1
-          fi
-          if [ -z "$LITHE_ANTHROPIC_BASE_URL" ]; then
-            echo "LITHE_ANTHROPIC_BASE_URL is not configured" >&2
-            exit 1
-          fi
-          node <<'NODE'
-          const { appendFileSync } = require('node:fs');
-          const baseUrl = new URL(process.env.LITHE_ANTHROPIC_BASE_URL);
-          const normalizedPath = baseUrl.pathname.replace(/\/$/, '');
-          if (normalizedPath === '/v1/responses') {
-            baseUrl.pathname = '/';
-            baseUrl.search = '';
-            baseUrl.hash = '';
-          }
-          const normalizedBaseUrl = baseUrl.toString().replace(/\/$/, '');
-          appendFileSync(process.env.GITHUB_ENV, `ANTHROPIC_BASE_URL=${normalizedBaseUrl}\n`);
-          NODE
-          echo "[lithe-review] Claude model=${LITHE_CLAUDE_MODEL}"
-          echo "[lithe-review] Claude effort=${LITHE_CLAUDE_EFFORT}"
-
-      - name: Load trusted Claude prompt
-        id: prompt
-        env:
-          LITHE_PROMPT_FILE: ${{ runner.temp }}/lithe-review-input/lithe-pr-review-prompt.md
-        run: |
-          node <<'NODE'
-          const { randomUUID } = require('node:crypto');
-          const { appendFileSync, readFileSync } = require('node:fs');
-          const delimiter = `lithe_${randomUUID()}`;
-          const prompt = readFileSync(process.env.LITHE_PROMPT_FILE, 'utf8');
-          appendFileSync(process.env.GITHUB_OUTPUT, `content<<${delimiter}\n${prompt}\n${delimiter}\n`);
-          NODE
-
-      - name: Run read-only Lithe review with Claude
-        id: claude
+      - name: Plan Lithe review with Codex
+        id: codex
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: openai/codex-action@v1
         with:
-          anthropic_api_key: ${{ secrets.LITHE_ANTHROPIC_API_KEY || secrets.LITHE_OPENAI_API_KEY }}
-          github_token: ${{ github.token }}
-          prompt: ${{ steps.prompt.outputs.content }}
-          include_fix_links: false
-          display_report: false
-          show_full_output: false
-          claude_args: |
-            --model "${{ env.LITHE_CLAUDE_MODEL }}"
-            --effort "${{ env.LITHE_CLAUDE_EFFORT }}"
-            --max-turns 100
-            --allowedTools "Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git log:*),Bash(git grep:*),Bash(git ls-files:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git cat-file:*),Read,Glob,Grep"
-            --json-schema '{"type":"object","properties":{"review_markdown":{"type":"string"}},"required":["review_markdown"],"additionalProperties":false}'
+          openai-api-key: ${{ secrets.LITHE_CODEX_API_KEY }}
+          responses-api-endpoint: ${{ secrets.LITHE_CODEX_RESPONSES_URL }}
+          prompt-file: ${{ runner.temp }}/lithe-review-planner-prompt.md
+          output-file: ${{ runner.temp }}/lithe-review-plan-candidate.json
+          output-schema-file: ${{ runner.temp }}/lithe-review-tooling/planner.schema.json
+          model: ${{ env.LITHE_CODEX_MODEL }}
+          effort: xhigh
+          sandbox: read-only
+          safety-strategy: drop-sudo
+          allow-users: ${{ github.actor }}
 
-      - name: Extract Claude review
-        if: steps.claude.outcome == 'success'
-        id: result
-        env:
-          LITHE_STRUCTURED_OUTPUT: ${{ steps.claude.outputs.structured_output }}
-          LITHE_FINAL_MESSAGE_FILE: ${{ runner.temp }}/lithe-review-final.md
-        run: |
-          node <<'NODE'
-          const { randomUUID } = require('node:crypto');
-          const { appendFileSync, writeFileSync } = require('node:fs');
-          const parsed = JSON.parse(process.env.LITHE_STRUCTURED_OUTPUT || '{}');
-          const message = String(parsed.review_markdown || '').trim();
-          if (!message) {
-            throw new Error('Claude returned an empty review_markdown');
-          }
-          writeFileSync(process.env.LITHE_FINAL_MESSAGE_FILE, `${message}\n`, { mode: 0o600 });
-          const delimiter = `lithe_${randomUUID()}`;
-          appendFileSync(process.env.GITHUB_OUTPUT, `final_message<<${delimiter}\n${message}\n${delimiter}\n`);
-          NODE
-
-      - name: Record review diagnostics
+      - name: Validate or replace planner output
+        id: ensure
         if: always()
-        id: diagnostics
-        env:
-          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
-          EXTRACT_OUTCOME: ${{ steps.result.outcome }}
-          DIAGNOSTICS_FILE: ${{ runner.temp }}/lithe-review-diagnostics.txt
-          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
-          FINAL_MESSAGE_FILE: ${{ runner.temp }}/lithe-review-final.md
-          LITHE_BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
-          LITHE_HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
         run: |
           set -euo pipefail
-          execution_file_exists=false
-          execution_file_bytes=0
-          final_message_exists=false
-          final_message_bytes=0
-          review_outcome=failure
+          plan_source="$(node "${{ runner.temp }}/lithe-review-tooling/stage.mjs" ensure-plan \
+            --candidate "${{ runner.temp }}/lithe-review-plan-candidate.json" \
+            --output "${{ runner.temp }}/lithe-review-plan.json")"
+          echo "plan_source=$plan_source" >> "$GITHUB_OUTPUT"
+          echo "[lithe-review] planner_outcome=${{ steps.codex.outcome }} plan_source=${plan_source}"
 
-          if [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
-            execution_file_exists=true
-            execution_file_bytes="$(wc -c < "$EXECUTION_FILE" | tr -d ' ')"
-          fi
-          if [ -f "$FINAL_MESSAGE_FILE" ]; then
-            final_message_exists=true
-            final_message_bytes="$(wc -c < "$FINAL_MESSAGE_FILE" | tr -d ' ')"
-          fi
-          if [ "$CLAUDE_OUTCOME" = success ] && [ "$EXTRACT_OUTCOME" = success ]; then
-            review_outcome=success
-          fi
-
-          {
-            echo "recorded_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "run_id=${GITHUB_RUN_ID}"
-            echo "run_attempt=${GITHUB_RUN_ATTEMPT}"
-            echo "pull_request=${{ github.event.issue.number }}"
-            echo "base_sha=${LITHE_BASE_SHA}"
-            echo "head_sha=${LITHE_HEAD_SHA}"
-            echo "provider=claude"
-            echo "model=${LITHE_CLAUDE_MODEL}"
-            echo "effort=${LITHE_CLAUDE_EFFORT}"
-            echo "claude_outcome=${CLAUDE_OUTCOME}"
-            echo "extract_outcome=${EXTRACT_OUTCOME}"
-            echo "review_outcome=${review_outcome}"
-            echo "execution_file_exists=${execution_file_exists}"
-            echo "execution_file_bytes=${execution_file_bytes}"
-            echo "final_message_exists=${final_message_exists}"
-            echo "final_message_bytes=${final_message_bytes}"
-          } | tee "$DIAGNOSTICS_FILE"
-
-          echo "review_outcome=${review_outcome}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload review diagnostics
+      - name: Upload review plan
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: lithe-review-diagnostics-${{ github.event.issue.number }}-${{ github.run_attempt }}
+          name: lithe-review-plan-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
-            ${{ runner.temp }}/lithe-review-diagnostics.txt
-            ${{ steps.claude.outputs.execution_file }}
-            ${{ runner.temp }}/lithe-review-final.md
+            ${{ runner.temp }}/lithe-review-plan.json
+            ${{ runner.temp }}/lithe-review-plan-candidate.json
           if-no-files-found: warn
           retention-days: 14
 
-      - name: Report Claude execution failure
-        if: always() && steps.diagnostics.outputs.review_outcome != 'success'
+  reviewers:
+    needs: [prepare, planner]
+    if: needs.prepare.outputs.authorized == 'true'
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include:
+          - role_id: correctness
+            role_title: Correctness and end-to-end behavior
+          - role_id: architecture
+            role_title: Architecture, contracts, and cross-platform behavior
+          - role_id: resilience
+            role_title: Concurrency, security, lifecycle, and diagnostics
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Check out trusted review tooling
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Stage trusted reviewer tooling
         env:
-          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
-          EXTRACT_OUTCOME: ${{ steps.result.outcome }}
+          LITHE_TOOLING: ${{ runner.temp }}/lithe-review-tooling
         run: |
-          echo "Claude review did not complete successfully: claude=${CLAUDE_OUTCOME}, extract=${EXTRACT_OUTCOME}" >&2
+          set -euo pipefail
+          mkdir -p "$LITHE_TOOLING"
+          install -m 755 scripts/prepare-lithe-review-stage.mjs "$LITHE_TOOLING/stage.mjs"
+          install -m 600 .github/lithe-review/reviewer.schema.json "$LITHE_TOOLING/reviewer.schema.json"
+
+      - name: Download trusted review input
+        uses: actions/download-artifact@v4
+        with:
+          name: lithe-review-input-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/lithe-review-input
+
+      - name: Download review plan
+        uses: actions/download-artifact@v4
+        with:
+          name: lithe-review-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/lithe-review-plan
+
+      - name: Build focused reviewer prompt
+        env:
+          LITHE_ROLE_ID: ${{ matrix.role_id }}
+        run: >-
+          node "${{ runner.temp }}/lithe-review-tooling/stage.mjs" reviewer
+          --base-prompt "${{ runner.temp }}/lithe-review-input/lithe-pr-review-prompt.md"
+          --plan "${{ runner.temp }}/lithe-review-plan/lithe-review-plan.json"
+          --role-id "$LITHE_ROLE_ID"
+          --output "${{ runner.temp }}/lithe-reviewer-prompt.md"
+
+      - name: Check out the complete pull request head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify checked-out revision
+        env:
+          LITHE_BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
+          LITHE_HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$LITHE_HEAD_SHA"
+          git cat-file -e "${LITHE_BASE_SHA}^{commit}"
+
+      - name: Run ${{ matrix.role_title }} review
+        id: codex
+        continue-on-error: true
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.LITHE_CODEX_API_KEY }}
+          responses-api-endpoint: ${{ secrets.LITHE_CODEX_RESPONSES_URL }}
+          prompt-file: ${{ runner.temp }}/lithe-reviewer-prompt.md
+          output-file: ${{ runner.temp }}/lithe-review-${{ matrix.role_id }}.json
+          output-schema-file: ${{ runner.temp }}/lithe-review-tooling/reviewer.schema.json
+          model: ${{ env.LITHE_CODEX_MODEL }}
+          effort: medium
+          sandbox: read-only
+          safety-strategy: drop-sudo
+          allow-users: ${{ github.actor }}
+
+      - name: Record reviewer status
+        if: always()
+        env:
+          LITHE_ROLE_ID: ${{ matrix.role_id }}
+          LITHE_CODEX_OUTCOME: ${{ steps.codex.outcome }}
+        run: |
+          set -euo pipefail
+          {
+            echo "role_id=${LITHE_ROLE_ID}"
+            echo "codex_outcome=${LITHE_CODEX_OUTCOME}"
+            echo "base_sha=${{ needs.prepare.outputs.base_sha }}"
+            echo "head_sha=${{ needs.prepare.outputs.head_sha }}"
+            echo "model=${LITHE_CODEX_MODEL}"
+            echo "effort=medium"
+          } > "${{ runner.temp }}/lithe-review-${LITHE_ROLE_ID}.status"
+
+      - name: Upload reviewer result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lithe-review-worker-${{ matrix.role_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/lithe-review-${{ matrix.role_id }}.json
+            ${{ runner.temp }}/lithe-review-${{ matrix.role_id }}.status
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Report reviewer failure
+        if: always() && steps.codex.outcome != 'success'
+        env:
+          LITHE_ROLE_ID: ${{ matrix.role_id }}
+        run: |
+          echo "Codex reviewer ${LITHE_ROLE_ID} did not complete successfully" >&2
           exit 1
 
+  aggregate:
+    needs: [prepare, planner, reviewers]
+    if: >-
+      always() &&
+      needs.prepare.outputs.authorized == 'true' &&
+      needs.planner.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    outputs:
+      final_message: ${{ steps.finalize.outputs.final_message }}
+      review_outcome: ${{ steps.finalize.outputs.review_outcome }}
+    steps:
+      - name: Check out trusted review tooling
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Stage trusted aggregator tooling
+        env:
+          LITHE_TOOLING: ${{ runner.temp }}/lithe-review-tooling
+        run: |
+          set -euo pipefail
+          mkdir -p "$LITHE_TOOLING"
+          install -m 755 scripts/prepare-lithe-review-stage.mjs "$LITHE_TOOLING/stage.mjs"
+          install -m 600 .github/lithe-review/final.schema.json "$LITHE_TOOLING/final.schema.json"
+
+      - name: Download trusted review input
+        uses: actions/download-artifact@v4
+        with:
+          name: lithe-review-input-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/lithe-review-input
+
+      - name: Download review plan
+        uses: actions/download-artifact@v4
+        with:
+          name: lithe-review-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/lithe-review-plan
+
+      - name: Download reviewer results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: lithe-review-worker-*-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/lithe-review-workers
+          merge-multiple: true
+
+      - name: Build aggregation prompt
+        run: >-
+          node "${{ runner.temp }}/lithe-review-tooling/stage.mjs" aggregator
+          --base-prompt "${{ runner.temp }}/lithe-review-input/lithe-pr-review-prompt.md"
+          --plan "${{ runner.temp }}/lithe-review-plan/lithe-review-plan.json"
+          --workers "${{ runner.temp }}/lithe-review-workers"
+          --output "${{ runner.temp }}/lithe-review-aggregator-prompt.md"
+
+      - name: Check out the complete pull request head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify checked-out revision
+        env:
+          LITHE_BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
+          LITHE_HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$LITHE_HEAD_SHA"
+          git cat-file -e "${LITHE_BASE_SHA}^{commit}"
+
+      - name: Verify and aggregate review with Codex
+        id: codex
+        continue-on-error: true
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.LITHE_CODEX_API_KEY }}
+          responses-api-endpoint: ${{ secrets.LITHE_CODEX_RESPONSES_URL }}
+          prompt-file: ${{ runner.temp }}/lithe-review-aggregator-prompt.md
+          output-file: ${{ runner.temp }}/lithe-review-final-candidate.json
+          output-schema-file: ${{ runner.temp }}/lithe-review-tooling/final.schema.json
+          model: ${{ env.LITHE_CODEX_MODEL }}
+          effort: xhigh
+          sandbox: read-only
+          safety-strategy: drop-sudo
+          allow-users: ${{ github.actor }}
+
+      - name: Finalize review output
+        if: always()
+        id: finalize
+        run: >-
+          node "${{ runner.temp }}/lithe-review-tooling/stage.mjs" finalize
+          --candidate "${{ runner.temp }}/lithe-review-final-candidate.json"
+          --workers "${{ runner.temp }}/lithe-review-workers"
+          --base-sha "${{ needs.prepare.outputs.base_sha }}"
+          --head-sha "${{ needs.prepare.outputs.head_sha }}"
+          --output "${{ runner.temp }}/lithe-review-final.md"
+
+      - name: Upload aggregation diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lithe-review-aggregation-${{ github.event.issue.number }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/lithe-review-final-candidate.json
+            ${{ runner.temp }}/lithe-review-final.md
+            ${{ runner.temp }}/lithe-review-plan/lithe-review-plan.json
+            ${{ runner.temp }}/lithe-review-workers
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Report aggregation failure
+        if: always() && steps.finalize.outputs.review_outcome == 'failure'
+        run: |
+          echo "Codex review aggregation did not produce a valid final review" >&2
+          exit 1
+
+      - name: Warn about partial aggregation
+        if: always() && steps.finalize.outputs.review_outcome == 'partial'
+        run: echo "::warning title=Lithe review partially aggregated::Publishing unverified reviewer candidates because the final verifier did not complete"
+
   publish:
-    needs: [prepare, review]
+    needs: [prepare, planner, reviewers, aggregate]
     if: >-
       always() &&
       needs.prepare.outputs.authorized == 'true'
@@ -319,15 +436,14 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-
     steps:
       - name: Publish or update the review
         uses: actions/github-script@v7
         env:
-          LITHE_FINAL_MESSAGE: ${{ needs.review.outputs.final_message }}
+          LITHE_FINAL_MESSAGE: ${{ needs.aggregate.outputs.final_message }}
           LITHE_HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
-          LITHE_REVIEW_OUTCOME: ${{ needs.review.outputs.review_outcome }}
-          LITHE_REVIEW_JOB_RESULT: ${{ needs.review.result }}
+          LITHE_REVIEW_OUTCOME: ${{ needs.aggregate.outputs.review_outcome }}
+          LITHE_AGGREGATE_JOB_RESULT: ${{ needs.aggregate.result }}
           LITHE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ github.token }}
@@ -340,8 +456,8 @@ jobs:
               '',
               '**结论：** ❓ 审查未完成',
               '',
-              `模型执行状态：\`${process.env.LITHE_REVIEW_OUTCOME || process.env.LITHE_REVIEW_JOB_RESULT}\`。`,
-              `请查看[本次 Actions 日志与诊断附件](${process.env.LITHE_RUN_URL})后重新召唤。`,
+              `聚合状态：\`${process.env.LITHE_REVIEW_OUTCOME || process.env.LITHE_AGGREGATE_JOB_RESULT}\`。`,
+              `请查看[本次 Actions 日志与分阶段诊断附件](${process.env.LITHE_RUN_URL})后重新召唤。`,
             ].join('\n');
             const body = `${marker}\n${message || failureMessage}`.slice(0, limit);
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -353,19 +469,8 @@ jobs:
             const previous = comments.find((comment) =>
               comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(marker)
             );
-
             if (previous) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: previous.id,
-                body,
-              });
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: previous.id, body });
             } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
             }

--- a/scripts/prepare-lithe-review-stage.mjs
+++ b/scripts/prepare-lithe-review-stage.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const defaultAssignments = [
+    {
+        role_id: "correctness",
+        title: "正确性与端到端行为",
+        focus: "需求闭环、调用链、状态转换、边界条件、用户可见回归和测试覆盖",
+    },
+    {
+        role_id: "architecture",
+        title: "架构、共享契约与跨平台",
+        focus: "模块所有权、Rust Core 与平台边界、序列化契约、macOS/Windows 一致性和兼容面",
+    },
+    {
+        role_id: "resilience",
+        title: "并发、安全、资源生命周期与诊断",
+        focus: "并发取消、过期结果、资源清理、安全边界、错误传播、结构化日志和 CI 接入",
+    },
+];
+
+function argument(name, fallback = "") {
+    const index = process.argv.indexOf(`--${name}`);
+    return index >= 0 ? process.argv[index + 1] ?? fallback : fallback;
+}
+
+async function readText(filePath) {
+    return readFile(filePath, "utf8");
+}
+
+async function writePrivate(filePath, content) {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, content, { mode: 0o600 });
+}
+
+function parseObject(rawValue) {
+    try {
+        const parsed = JSON.parse(rawValue);
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+function fallbackPlan() {
+    return {
+        change_summary: "Planner 未生成有效计划，使用仓库预设的三个审查视角。",
+        assignments: defaultAssignments.map((assignment) => ({
+            role_id: assignment.role_id,
+            focus_paths: [],
+            questions: [assignment.focus],
+        })),
+    };
+}
+
+function validPlan(candidate) {
+    if (!candidate || !Array.isArray(candidate.assignments)) {
+        return false;
+    }
+    const roleIDs = new Set(candidate.assignments.map((assignment) => assignment?.role_id));
+    return defaultAssignments.every((assignment) => roleIDs.has(assignment.role_id));
+}
+
+async function buildPlannerPrompt() {
+    const basePrompt = await readText(argument("base-prompt"));
+    const outputPath = argument("output");
+    const stagePrompt = `${basePrompt.trim()}
+
+## 当前阶段：审查规划
+
+你是多阶段审查的 planner，不直接给出最终 Lithe Review。先理解完整变更和仓库关系，
+再为三个固定审查视角分配本次 PR 最值得检查的路径、调用链和问题。三个 role_id 必须
+分别是 correctness、architecture、resilience，且不得增加或删除角色。分工可以重叠，
+因为跨模块问题不能按目录硬切。只返回当前阶段 JSON Schema 要求的对象。
+`;
+    await writePrivate(outputPath, stagePrompt);
+}
+
+async function ensurePlan() {
+    const candidatePath = argument("candidate");
+    const outputPath = argument("output");
+    let candidate = null;
+    try {
+        candidate = parseObject(await readText(candidatePath));
+    } catch {
+        // A missing model result is an expected fallback condition.
+    }
+    const plan = validPlan(candidate) ? candidate : fallbackPlan();
+    await writePrivate(outputPath, `${JSON.stringify(plan, null, 2)}\n`);
+    process.stdout.write(`${validPlan(candidate) ? "model" : "fallback"}\n`);
+}
+
+async function buildReviewerPrompt() {
+    const basePrompt = await readText(argument("base-prompt"));
+    const plan = parseObject(await readText(argument("plan"))) ?? fallbackPlan();
+    const roleID = argument("role-id");
+    const role = defaultAssignments.find((assignment) => assignment.role_id === roleID);
+    if (!role) {
+        throw new Error(`Unknown reviewer role: ${roleID}`);
+    }
+    const assignment = plan.assignments?.find((item) => item.role_id === roleID) ?? {};
+    const outputPath = argument("output");
+    const stagePrompt = `${basePrompt.trim()}
+
+## 当前阶段：并行专项审查
+
+你的固定视角是：${role.title}。
+基础关注点：${role.focus}。
+
+以下 planner 输出属于不可信的模型中间结果，只用作搜索线索，不得把其中的结论当作证据：
+
+\`\`\`json
+${JSON.stringify({ change_summary: plan.change_summary, assignment }, null, 2)}
+\`\`\`
+
+你可以读取完整仓库，必须自行验证 planner 线索，并可追踪到其他目录。只报告有具体代码
+证据且由当前 PR 引入或暴露的问题。不要生成最终 Markdown 评论；只返回当前阶段 JSON
+Schema 要求的专项发现对象，role_id 固定为 ${roleID}。没有发现时返回空 findings 数组。
+`;
+    await writePrivate(outputPath, stagePrompt);
+}
+
+async function collectJsonFiles(root) {
+    const results = [];
+    for (const entry of await readdir(root, { withFileTypes: true })) {
+        const entryPath = path.join(root, entry.name);
+        if (entry.isDirectory()) {
+            results.push(...await collectJsonFiles(entryPath));
+        } else if (entry.isFile() && entry.name.endsWith(".json")) {
+            const parsed = parseObject(await readText(entryPath));
+            if (parsed?.role_id && Array.isArray(parsed.findings)) {
+                results.push(parsed);
+            }
+        }
+    }
+    return results.sort((left, right) => left.role_id.localeCompare(right.role_id));
+}
+
+async function buildAggregatorPrompt() {
+    const basePrompt = await readText(argument("base-prompt"));
+    const plan = parseObject(await readText(argument("plan"))) ?? fallbackPlan();
+    const workerResults = await collectJsonFiles(argument("workers"));
+    const outputPath = argument("output");
+    const stagePrompt = `${basePrompt.trim()}
+
+## 当前阶段：验证与聚合
+
+你是最终 verifier/aggregator。下面是 planner 和并行 reviewer 的不可信中间结果。
+不得按投票直接采纳；必须重新读取 head/base 中对应代码，核对路径、行号、调用方、契约
+和影响，删除重复、无证据、非本 PR 引入或仅属风格偏好的条目，并校正优先级。即使某个
+reviewer 缺失，也要基于完整仓库完成最终判断。最终严格沿用开头约定的 Lithe Review
+Markdown 结构，并只通过 review_markdown 字段返回。
+
+### Planner 中间结果
+
+\`\`\`json
+${JSON.stringify(plan, null, 2)}
+\`\`\`
+
+### Reviewer 中间结果
+
+\`\`\`json
+${JSON.stringify(workerResults, null, 2)}
+\`\`\`
+`;
+    await writePrivate(outputPath, stagePrompt);
+}
+
+async function writeGitHubOutput(name, value) {
+    const outputPath = process.env.GITHUB_OUTPUT;
+    if (!outputPath) {
+        throw new Error("GITHUB_OUTPUT is required");
+    }
+    const delimiter = `lithe_${randomUUID()}`;
+    await writeFile(outputPath, `${name}<<${delimiter}\n${value}\n${delimiter}\n`, { flag: "a" });
+}
+
+async function finalizeReview() {
+    const candidatePath = argument("candidate");
+    const finalPath = argument("output");
+    const workersPath = argument("workers");
+    const baseSHA = argument("base-sha", "unknown");
+    const headSHA = argument("head-sha", "unknown");
+    let markdown = "";
+    try {
+        const candidate = parseObject(await readText(candidatePath));
+        markdown = String(candidate?.review_markdown ?? "").trim();
+    } catch {
+        // The publish job will present a durable failure message when aggregation has no result.
+    }
+    if (markdown) {
+        await writePrivate(finalPath, `${markdown}\n`);
+        await writeGitHubOutput("final_message", markdown);
+        await writeGitHubOutput("review_outcome", "success");
+        return;
+    }
+
+    const workerResults = workersPath ? await collectJsonFiles(workersPath) : [];
+    const findings = workerResults.flatMap((result) => result.findings);
+    if (!findings.length) {
+        await writeGitHubOutput("final_message", "");
+        await writeGitHubOutput("review_outcome", "failure");
+        return;
+    }
+
+    const findingMarkdown = findings.map((finding, index) => {
+        const location = finding.line ? `${finding.path}:${finding.line}` : finding.path;
+        return [
+            `${index + 1}. **[${finding.priority}] ${finding.title}**`,
+            `   \`${location}\``,
+            "",
+            `   ${finding.evidence} 影响：${finding.impact}`,
+            `   建议：${finding.suggestion}`,
+        ].join("\n");
+    }).join("\n\n");
+    markdown = [
+        "## Lithe Review",
+        "",
+        "**结论：** ❓ 信息不足",
+        `**依据：** \`${baseSHA.slice(0, 7)} ← ${headSHA.slice(0, 7)}\` · 最终聚合未完成`,
+        "",
+        "### 发现",
+        "",
+        "> 以下条目来自已完成的专项 reviewer，尚未经过最终 verifier 复核，请作为候选问题人工确认。",
+        "",
+        findingMarkdown,
+        "",
+        "### 验证",
+        "",
+        `- 收到 ${workerResults.length} 个专项 reviewer 的结构化结果`,
+        "- 最终聚合模型未完成；本次审查未运行测试",
+    ].join("\n");
+    await writePrivate(finalPath, `${markdown}\n`);
+    await writeGitHubOutput("final_message", markdown);
+    await writeGitHubOutput("review_outcome", "partial");
+}
+
+const commands = {
+    planner: buildPlannerPrompt,
+    "ensure-plan": ensurePlan,
+    reviewer: buildReviewerPrompt,
+    aggregator: buildAggregatorPrompt,
+    finalize: finalizeReview,
+};
+
+const command = process.argv[2];
+if (!commands[command]) {
+    throw new Error(`Unknown command: ${command || "(missing)"}`);
+}
+await commands[command]();

--- a/scripts/test-prepare-lithe-review-stage.mjs
+++ b/scripts/test-prepare-lithe-review-stage.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const scriptPath = path.resolve("scripts/prepare-lithe-review-stage.mjs");
+
+function runStage(argumentsList, environment = {}) {
+    const result = spawnSync(process.execPath, [scriptPath, ...argumentsList], {
+        encoding: "utf8",
+        env: { ...process.env, ...environment },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return result.stdout.trim();
+}
+
+test("uses deterministic assignments when planner output is missing", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "lithe-review-stage-"));
+    const planPath = path.join(directory, "plan.json");
+    const source = runStage([
+        "ensure-plan",
+        "--candidate", path.join(directory, "missing.json"),
+        "--output", planPath,
+    ]);
+    const plan = JSON.parse(await readFile(planPath, "utf8"));
+
+    assert.equal(source, "fallback");
+    assert.deepEqual(
+        plan.assignments.map((assignment) => assignment.role_id),
+        ["correctness", "architecture", "resilience"],
+    );
+});
+
+test("builds focused and aggregate prompts without trusting intermediate findings", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "lithe-review-stage-"));
+    const workersDirectory = path.join(directory, "workers");
+    await mkdir(workersDirectory);
+    const basePromptPath = path.join(directory, "base.md");
+    const planPath = path.join(directory, "plan.json");
+    const reviewerPromptPath = path.join(directory, "reviewer.md");
+    const aggregatorPromptPath = path.join(directory, "aggregator.md");
+    await writeFile(basePromptPath, "Original trusted review instructions.\n");
+    await writeFile(planPath, JSON.stringify({
+        change_summary: "Changes cancellation.",
+        assignments: [
+            { role_id: "correctness", focus_paths: ["Sources/Feature.swift"], questions: ["Is cancellation correct?"] },
+            { role_id: "architecture", focus_paths: [], questions: [] },
+            { role_id: "resilience", focus_paths: [], questions: [] },
+        ],
+    }));
+    await writeFile(path.join(workersDirectory, "correctness.json"), JSON.stringify({
+        role_id: "correctness",
+        summary: "Candidate issue.",
+        findings: [],
+    }));
+
+    runStage([
+        "reviewer",
+        "--base-prompt", basePromptPath,
+        "--plan", planPath,
+        "--role-id", "correctness",
+        "--output", reviewerPromptPath,
+    ]);
+    runStage([
+        "aggregator",
+        "--base-prompt", basePromptPath,
+        "--plan", planPath,
+        "--workers", workersDirectory,
+        "--output", aggregatorPromptPath,
+    ]);
+
+    const reviewerPrompt = await readFile(reviewerPromptPath, "utf8");
+    const aggregatorPrompt = await readFile(aggregatorPromptPath, "utf8");
+    assert.match(reviewerPrompt, /正确性与端到端行为/);
+    assert.match(reviewerPrompt, /不可信的模型中间结果/);
+    assert.match(aggregatorPrompt, /必须重新读取 head\/base/);
+    assert.match(aggregatorPrompt, /Candidate issue/);
+});
+
+test("publishes a clearly marked partial review when final aggregation fails", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "lithe-review-stage-"));
+    const workersDirectory = path.join(directory, "workers");
+    const outputPath = path.join(directory, "final.md");
+    const githubOutputPath = path.join(directory, "github-output.txt");
+    await mkdir(workersDirectory);
+    await writeFile(path.join(workersDirectory, "correctness.json"), JSON.stringify({
+        role_id: "correctness",
+        summary: "Found a regression.",
+        findings: [{
+            priority: "P1",
+            title: "Cancellation result can escape",
+            path: "Sources/Feature.swift",
+            line: 42,
+            evidence: "The completion callback ignores the operation ID.",
+            impact: "A stale result can replace current state.",
+            suggestion: "Check the operation ID before publishing.",
+            confidence: "high",
+        }],
+    }));
+
+    runStage([
+        "finalize",
+        "--candidate", path.join(directory, "missing.json"),
+        "--workers", workersDirectory,
+        "--base-sha", "base1234",
+        "--head-sha", "head5678",
+        "--output", outputPath,
+    ], { GITHUB_OUTPUT: githubOutputPath });
+
+    const markdown = await readFile(outputPath, "utf8");
+    const githubOutput = await readFile(githubOutputPath, "utf8");
+    assert.match(markdown, /❓ 信息不足/);
+    assert.match(markdown, /尚未经过最终 verifier 复核/);
+    assert.match(markdown, /Sources\/Feature\.swift:42/);
+    assert.match(githubOutput, /review_outcome<<.*\npartial\n/s);
+});


### PR DESCRIPTION
## Summary

- replace the Claude review executor with Codex over a configurable Responses API endpoint
- add a planner, three focused parallel reviewers, and a verifying aggregator
- preserve the existing trusted review prompt and add structured schemas, artifacts, fallback planning, and partial-result publishing
- run gpt-5.6-sol at xhigh for planning/aggregation and medium for reviewer workers

## Validation

- `node --test scripts/test-prepare-lithe-*review*.mjs`
- `actionlint .github/workflows/lithe-pr-review.yml`
- `git diff --check`