### PR TITLE
Merge latest Preview 0.3.0 and prepare v0.3.3

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -104,3 +104,6 @@
 "Type" = "Type";
 "Options" = "Options";
 "Default options" = "Default options";
+"Notifications" = "Notifications";
+"Clear All" = "Clear All";
+"No notifications" = "No notifications";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -1208,3 +1208,6 @@
 "Running" = "运行中";
 "Java: Rebuild Index" = "Java：重建索引";
 "Clear the current project's Java index and rebuild it on next use" = "清除当前项目的 Java 索引，并在下次使用时重建";
+"Notifications" = "通知";
+"Clear All" = "全部清除";
+"No notifications" = "暂无通知";

--- a/Sources/Lithe/Models/AppModel/AppModel+Notifications.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel+Notifications.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+extension AppModel {
+    func showNotification(_ message: String) {
+        let notification = WorkbenchNotification(message: message)
+        notifications.insert(notification, at: 0)
+        if notifications.count > 100 {
+            notifications.removeLast(notifications.count - 100)
+        }
+        notificationMessage = message
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            if self?.notifications.first?.id == notification.id,
+               self?.notificationMessage == message {
+                self?.notificationMessage = nil
+            }
+        }
+    }
+
+    func markAllNotificationsRead() {
+        for index in notifications.indices {
+            notifications[index].isRead = true
+        }
+    }
+
+    func clearNotifications() {
+        notifications.removeAll()
+        notificationMessage = nil
+    }
+}

--- a/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -108,6 +108,7 @@ final class AppModel: ObservableObject, Identifiable {
         workspaceFeature.isPerformingProjectItemOperation
     }
     @Published var notificationMessage: String?
+    @Published var notifications: [WorkbenchNotification] = []
     @Published var detectedAIConfigurations: [AIConfigurationSnapshot] = []
     @Published var commitMessage = ""
     @Published var amendCommit = false
@@ -1775,16 +1776,6 @@ final class AppModel: ObservableObject, Identifiable {
     func relativePath(for url: URL) -> String {
         guard let workspaceURL else { return url.lastPathComponent }
         return workspaceRelativePath(for: url, root: workspaceURL) ?? url.lastPathComponent
-    }
-
-    func showNotification(_ message: String) {
-        notificationMessage = message
-        Task {
-            try? await Task.sleep(for: .seconds(2))
-            if notificationMessage == message {
-                notificationMessage = nil
-            }
-        }
     }
 
     func recordSave(_ document: EditorDocument, previousText: String) {

--- a/Sources/Lithe/Models/AppModel/AppModelSupportTypes.swift
+++ b/Sources/Lithe/Models/AppModel/AppModelSupportTypes.swift
@@ -1,6 +1,25 @@
 import Foundation
 import LitheCoreContracts
 
+struct WorkbenchNotification: Identifiable, Equatable {
+    let id: UUID
+    let message: String
+    let createdAt: Date
+    var isRead: Bool
+
+    init(
+        id: UUID = UUID(),
+        message: String,
+        createdAt: Date = Date(),
+        isRead: Bool = false
+    ) {
+        self.id = id
+        self.message = message
+        self.createdAt = createdAt
+        self.isRead = isRead
+    }
+}
+
 enum SidebarDestination: String, CaseIterable, Identifiable {
     case project
     case changes

--- a/Sources/Lithe/Views/Components/FrameCoalescedDragUpdateBuffer.swift
+++ b/Sources/Lithe/Views/Components/FrameCoalescedDragUpdateBuffer.swift
@@ -1,0 +1,28 @@
+import CoreGraphics
+
+/// Stores the newest continuous-drag value while one display-frame delivery
+/// is pending, preventing intermediate pointer events from queuing layouts.
+struct FrameCoalescedDragUpdateBuffer {
+    private(set) var pendingValue: CGFloat?
+    private(set) var hasScheduledDelivery = false
+
+    mutating func submit(_ value: CGFloat) -> Bool {
+        pendingValue = value
+        guard !hasScheduledDelivery else { return false }
+        hasScheduledDelivery = true
+        return true
+    }
+
+    mutating func takePendingValue() -> CGFloat? {
+        defer {
+            pendingValue = nil
+            hasScheduledDelivery = false
+        }
+        return pendingValue
+    }
+
+    mutating func cancel() {
+        pendingValue = nil
+        hasScheduledDelivery = false
+    }
+}

--- a/Sources/Lithe/Views/Components/LitheTextViewportLayout.swift
+++ b/Sources/Lithe/Views/Components/LitheTextViewportLayout.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+enum LitheTextViewportLayout {
+    /// Keep the document wider than the viewport so resizing a surrounding
+    /// pane moves the viewport instead of rewrapping every line in the file.
+    @MainActor
+    static func applyUnwrappedScrolling(
+        to textView: NSTextView,
+        in scrollView: NSScrollView
+    ) {
+        scrollView.hasHorizontalScroller = true
+        textView.isHorizontallyResizable = true
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.minSize = .zero
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.containerSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.widthTracksTextView = false
+    }
+}

--- a/Sources/Lithe/Views/Diff/DiffHorizontalScrollSupport.swift
+++ b/Sources/Lithe/Views/Diff/DiffHorizontalScrollSupport.swift
@@ -12,6 +12,8 @@ struct DiffHorizontalScroller: View {
     @State private var dragStartOffset: CGFloat = 0
     @State private var isDragging = false
     @State private var isHovering = false
+    @State private var dragUpdateBuffer = FrameCoalescedDragUpdateBuffer()
+    @State private var dragUpdateTask: Task<Void, Never>?
 
     private var maximumOffset: CGFloat {
         max(0, contentWidth - viewportWidth)
@@ -51,11 +53,18 @@ struct DiffHorizontalScroller: View {
                                     dragStartOffset = offset
                                 }
                                 guard travel > 0 else { return }
-                                offset = constrained(
+                                scheduleOffsetUpdate(constrained(
                                     dragStartOffset + (value.translation.width / travel) * maximumOffset
-                                )
+                                ))
                             }
-                            .onEnded { _ in
+                            .onEnded { value in
+                                if travel > 0 {
+                                    let finalOffset = constrained(
+                                        dragStartOffset + (value.translation.width / travel) * maximumOffset
+                                    )
+                                    cancelScheduledOffsetUpdate()
+                                    offset = finalOffset
+                                }
                                 isDragging = false
                             }
                     )
@@ -70,6 +79,7 @@ struct DiffHorizontalScroller: View {
         .opacity(maximumOffset > 0.5 ? 1 : 0)
         .allowsHitTesting(maximumOffset > 0.5)
         .accessibilityLabel("Synchronized diff horizontal scroll")
+        .onDisappear(perform: cancelScheduledOffsetUpdate)
         .onChange(of: maximumOffset) { newMaximum in
             offset = min(max(offset, 0), newMaximum)
         }
@@ -77,6 +87,25 @@ struct DiffHorizontalScroller: View {
 
     private func constrained(_ value: CGFloat) -> CGFloat {
         min(max(value, 0), maximumOffset)
+    }
+
+    private func scheduleOffsetUpdate(_ nextOffset: CGFloat) {
+        guard dragUpdateBuffer.submit(nextOffset) else { return }
+        dragUpdateTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(16))
+            guard !Task.isCancelled else { return }
+            let nextOffset = dragUpdateBuffer.takePendingValue()
+            dragUpdateTask = nil
+            if let nextOffset {
+                offset = nextOffset
+            }
+        }
+    }
+
+    private func cancelScheduledOffsetUpdate() {
+        dragUpdateTask?.cancel()
+        dragUpdateTask = nil
+        dragUpdateBuffer.cancel()
     }
 }
 

--- a/Sources/Lithe/Views/Diff/DiffSplitPaneView.swift
+++ b/Sources/Lithe/Views/Diff/DiffSplitPaneView.swift
@@ -19,6 +19,8 @@ struct DiffSplitPaneView<RowOverlay: View>: View {
     let rowOverlay: (DiffRow, DiffSide) -> RowOverlay
 
     @State private var horizontalOffset: CGFloat = 0
+    @State private var wheelUpdateBuffer = FrameCoalescedDragUpdateBuffer()
+    @State private var wheelUpdateTask: Task<Void, Never>?
 
     init(
         displayRows: [DiffDisplayRow],
@@ -100,15 +102,17 @@ struct DiffSplitPaneView<RowOverlay: View>: View {
         .frame(width: viewportWidth, height: minimumHeight, alignment: .topLeading)
         .background {
             DiffHorizontalScrollWheelMonitor { delta in
-                horizontalOffset = min(
-                    max(horizontalOffset + delta, 0),
-                    maximumHorizontalOffset
+                let pendingOffset = wheelUpdateBuffer.pendingValue ?? horizontalOffset
+                scheduleWheelOffsetUpdate(
+                    min(max(pendingOffset + delta, 0), maximumHorizontalOffset)
                 )
             }
         }
         .onChange(of: contentWidth) { _ in
+            cancelScheduledWheelOffsetUpdate()
             horizontalOffset = min(horizontalOffset, maximumHorizontalOffset)
         }
+        .onDisappear(perform: cancelScheduledWheelOffsetUpdate)
     }
 
     private func sideViewport(
@@ -123,6 +127,25 @@ struct DiffSplitPaneView<RowOverlay: View>: View {
             .frame(width: viewportWidth, height: height, alignment: .topLeading)
             .clipped()
             .background(LitheTheme.editor)
+    }
+
+    private func scheduleWheelOffsetUpdate(_ nextOffset: CGFloat) {
+        guard wheelUpdateBuffer.submit(nextOffset) else { return }
+        wheelUpdateTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(16))
+            guard !Task.isCancelled else { return }
+            let nextOffset = wheelUpdateBuffer.takePendingValue()
+            wheelUpdateTask = nil
+            if let nextOffset {
+                horizontalOffset = nextOffset
+            }
+        }
+    }
+
+    private func cancelScheduledWheelOffsetUpdate() {
+        wheelUpdateTask?.cancel()
+        wheelUpdateTask = nil
+        wheelUpdateBuffer.cancel()
     }
 
     private var centerGutter: some View {

--- a/Sources/Lithe/Views/Editor/CodeEditorView.swift
+++ b/Sources/Lithe/Views/Editor/CodeEditorView.swift
@@ -105,6 +105,23 @@ enum EditorGutterHitTarget: Equatable {
     case gitChange
 }
 
+struct EditorLanguageFeatureTransition: Equatable {
+    let refreshImplementationMarkers: Bool
+    let clearImplementationMarkers: Bool
+
+    init(
+        previous: LanguageServerFeatureSet?,
+        current: LanguageServerFeatureSet
+    ) {
+        let previouslySupportedImplementation = previous?.contains(.implementation) == true
+        let currentlySupportsImplementation = current.contains(.implementation)
+        refreshImplementationMarkers = !previouslySupportedImplementation
+            && currentlySupportsImplementation
+        clearImplementationMarkers = previouslySupportedImplementation
+            && !currentlySupportsImplementation
+    }
+}
+
 struct EditorGutterLayout: Equatable {
     static let lineNumberTrailingPadding: CGFloat = 3
     static let minimumLineNumberWidth: CGFloat = 28
@@ -119,15 +136,15 @@ struct EditorGutterLayout: Equatable {
 
     init(lineNumberTextWidth: CGFloat) {
         breakpointRange = 0..<14
-        implementationRange = breakpointRange.upperBound..<34
         let requiredLineNumberWidth = max(
             Self.minimumLineNumberWidth,
             ceil(lineNumberTextWidth) + Self.lineNumberTrailingPadding
         )
-        lineNumberRange = implementationRange.upperBound..<(
-            implementationRange.upperBound + requiredLineNumberWidth
+        lineNumberRange = breakpointRange.upperBound..<(
+            breakpointRange.upperBound + requiredLineNumberWidth
         )
-        foldRange = lineNumberRange.upperBound..<(lineNumberRange.upperBound + 15)
+        implementationRange = lineNumberRange.upperBound..<(lineNumberRange.upperBound + 20)
+        foldRange = implementationRange.upperBound..<(implementationRange.upperBound + 15)
         gitChangeRange = foldRange.upperBound..<(foldRange.upperBound + 3)
         width = gitChangeRange.upperBound
     }
@@ -242,7 +259,10 @@ struct EditorOverlayUpdatePlan: Equatable {
     let updateCodeVision: Bool
 
     init(codeVisionChanged: Bool, inlayHintsChanged: Bool, layoutChanged: Bool) {
-        updateInlayHints = inlayHintsChanged || layoutChanged
+        // Inlay spacing is part of the attributed document and only changes
+        // when the hints change. Reapplying it for a viewport resize invalidates
+        // the full text layout even though unwrapped glyph positions are stable.
+        updateInlayHints = inlayHintsChanged
         updateCodeVision = codeVisionChanged || inlayHintsChanged || layoutChanged
     }
 }
@@ -360,7 +380,6 @@ struct CodeEditorView: NSViewRepresentable {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.borderType = .noBorder
         scrollView.hasVerticalScroller = true
-        scrollView.hasHorizontalScroller = false
         scrollView.autohidesScrollers = true
         scrollView.drawsBackground = !showsWorkbenchBackground
         scrollView.backgroundColor = palette.background
@@ -394,13 +413,7 @@ struct CodeEditorView: NSViewRepresentable {
         textView.isRichText = false
         textView.importsGraphics = false
         textView.allowsUndo = true
-        textView.isVerticallyResizable = true
-        textView.isHorizontallyResizable = false
-        textView.autoresizingMask = [.width]
-        textView.minSize = NSSize(width: 0, height: 0)
-        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-        textView.textContainer?.containerSize = NSSize(width: scrollView.contentSize.width, height: CGFloat.greatestFiniteMagnitude)
-        textView.textContainer?.widthTracksTextView = true
+        LitheTextViewportLayout.applyUnwrappedScrolling(to: textView, in: scrollView)
         textView.textContainerInset = NSSize(width: EditorLayoutMetrics.leadingInset, height: 0)
         textView.textContainer?.lineFragmentPadding = EditorLayoutMetrics.lineFragmentPadding
         textView.font = LitheTheme.editorFont(size: settings.editorFontSize)
@@ -1014,6 +1027,10 @@ struct CodeEditorView: NSViewRepresentable {
                     changed = true
                 }
                 if appliedLanguageFeatures != languageFeatures {
+                    let featureTransition = EditorLanguageFeatureTransition(
+                        previous: appliedLanguageFeatures,
+                        current: languageFeatures
+                    )
                     codeTextView.languageServerFeatures = languageFeatures
                     codeTextView.isLanguageNavigationEnabled = !languageFeatures.intersection([
                         .definition, .references, .implementation
@@ -1022,6 +1039,13 @@ struct CodeEditorView: NSViewRepresentable {
                         .hover, .completion, .rename, .formatting, .codeActions
                     ]).isEmpty
                     appliedLanguageFeatures = languageFeatures
+                    if featureTransition.refreshImplementationMarkers {
+                        scheduleJavaNavigationMarkerRefresh()
+                    } else if featureTransition.clearImplementationMarkers,
+                              !implementationMarkers.isEmpty {
+                        implementationMarkers = []
+                        applyFoldState()
+                    }
                     changed = true
                 }
             }

--- a/Sources/Lithe/Views/Editor/EditorAreaView.swift
+++ b/Sources/Lithe/Views/Editor/EditorAreaView.swift
@@ -4,6 +4,18 @@ import LitheTerminalModule
 
 private let editorTabCoordinateSpaceName = "lithe.editor-tab-strip"
 
+enum EditorDocumentIconResolver {
+    static func kind(
+        for url: URL,
+        resolvedJavaKind: LitheIconKind?
+    ) -> LitheIconKind {
+        if url.pathExtension.lowercased() == "java", let resolvedJavaKind {
+            return resolvedJavaKind
+        }
+        return LitheIcons.kind(for: url, isDirectory: false)
+    }
+}
+
 private enum MarkdownViewMode: String, CaseIterable, Identifiable, Equatable {
     case editor
     case split
@@ -44,6 +56,7 @@ struct EditorAreaView: View {
     @State private var markdownScrollPositions: [UUID: MarkdownScrollPosition] = [:]
     @State private var editorViewportStore = EditorViewportStore()
     @State private var hoveredMarkdownMode: MarkdownViewMode?
+    @State private var resolvedJavaDocumentIconKinds: [String: LitheIconKind] = [:]
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -552,10 +565,7 @@ struct EditorAreaView: View {
         isActive: Bool
     ) -> some View {
         let label = HStack(spacing: 7) {
-            LitheIcon(
-                kind: LitheIcons.kind(for: document.url, isDirectory: false),
-                size: 13
-            )
+            editorDocumentIcon(document, size: 13)
             editorTabTitle(document)
             EditorTabDirtyIndicator(document: document)
         }
@@ -622,11 +632,8 @@ struct EditorAreaView: View {
 
     private func editorTabDragPreview(_ document: EditorDocument) -> some View {
         HStack(spacing: 7) {
-            LitheIcon(
-                kind: LitheIcons.kind(for: document.url, isDirectory: false),
-                size: 13
-            )
-            .foregroundStyle(LitheTheme.accent)
+            editorDocumentIcon(document, size: 13)
+                .foregroundStyle(LitheTheme.accent)
 
             Text(document.displayName)
                 .font(.system(size: 12.5, weight: .medium))
@@ -962,10 +969,7 @@ struct EditorAreaView: View {
         VStack(spacing: 0) {
             if showsHeader, let document {
                 HStack(spacing: 7) {
-                    LitheIcon(
-                        kind: LitheIcons.kind(for: document.url, isDirectory: false),
-                        size: 13
-                    )
+                    editorDocumentIcon(document, size: 13)
                     Text(document.displayName)
                         .font(.system(size: 11.5, weight: .medium))
                         .foregroundStyle(LitheTheme.primaryText)
@@ -1000,6 +1004,28 @@ struct EditorAreaView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func editorDocumentIcon(
+        _ document: EditorDocument,
+        size: CGFloat
+    ) -> some View {
+        let path = document.url.standardizedFileURL.path
+        let resolvedKind = resolvedJavaDocumentIconKinds[path]
+        return LitheIcon(
+            kind: EditorDocumentIconResolver.kind(
+                for: document.url,
+                resolvedJavaKind: resolvedKind
+            ),
+            size: size
+        )
+        .task(id: path) {
+            guard document.url.pathExtension.lowercased() == "java",
+                  resolvedKind == nil else { return }
+            let kind = await model.javaIconKind(for: document.url)
+            guard !Task.isCancelled, let kind else { return }
+            resolvedJavaDocumentIconKinds[path] = kind
+        }
     }
 
     @ViewBuilder

--- a/Sources/Lithe/Views/Git/ChangesSidebarView.swift
+++ b/Sources/Lithe/Views/Git/ChangesSidebarView.swift
@@ -197,8 +197,12 @@ struct ChangesSidebarView: View {
                             maximum: maximumCommitHeight
                         )
                     },
-                    onDragEnded: {
-                        commitAreaHeight = resolvedCommitHeight
+                    onDragEnded: { translation in
+                        commitAreaHeight = constrained(
+                            commitAreaDragStart - translation,
+                            minimum: minimumCommitHeight,
+                            maximum: maximumCommitHeight
+                        )
                     }
                 )
                 commitArea

--- a/Sources/Lithe/Views/Git/GitLogView.swift
+++ b/Sources/Lithe/Views/Git/GitLogView.swift
@@ -92,7 +92,13 @@ struct GitLogView: View {
                                 maximum: maximumReferencePaneWidth
                             )
                         },
-                        onDragEnded: {}
+                        onDragEnded: { translation in
+                            referencePaneWidth = constrained(
+                                referencePaneDragStart + translation,
+                                minimum: minimumReferencePaneWidth,
+                                maximum: maximumReferencePaneWidth
+                            )
+                        }
                     )
 
                     commitPane
@@ -110,7 +116,13 @@ struct GitLogView: View {
                                 maximum: maximumDetailPaneWidth
                             )
                         },
-                        onDragEnded: {}
+                        onDragEnded: { translation in
+                            detailPaneWidth = constrained(
+                                detailPaneDragStart - translation,
+                                minimum: minimumDetailPaneWidth,
+                                maximum: maximumDetailPaneWidth
+                            )
+                        }
                     )
 
                     detailPane
@@ -790,7 +802,13 @@ struct GitLogView: View {
                             maximum: maximumFilesPaneHeight
                         )
                     },
-                    onDragEnded: {}
+                    onDragEnded: { translation in
+                        filesPaneHeight = constrained(
+                            filesPaneDragStart + translation,
+                            minimum: minimumFilesPaneHeight,
+                            maximum: maximumFilesPaneHeight
+                        )
+                    }
                 )
 
                 commitDetail

--- a/Sources/Lithe/Views/Language/LanguageTestsView.swift
+++ b/Sources/Lithe/Views/Language/LanguageTestsView.swift
@@ -11,6 +11,7 @@ struct LanguageTestsView: View {
     @State private var collapsedProviderIDs: Set<String> = []
     @AppStorage("lithe.tests.itemListWidth") private var itemListWidth = 250.0
     @AppStorage("lithe.tests.itemListCollapsed") private var isItemListCollapsed = false
+    @State private var liveItemListWidth: CGFloat?
     @State private var itemListDragStart: CGFloat = 250
 
     var body: some View {
@@ -30,7 +31,7 @@ struct LanguageTestsView: View {
                         geometry.size.width - SplitHandleView.thickness - minimumContentWidth
                     )
                     let resolvedListWidth = min(
-                        max(CGFloat(itemListWidth), minimumListWidth),
+                        max(liveItemListWidth ?? CGFloat(itemListWidth), minimumListWidth),
                         maximumListWidth
                     )
 
@@ -48,14 +49,19 @@ struct LanguageTestsView: View {
                                 axis: .horizontal,
                                 onDragStarted: { itemListDragStart = resolvedListWidth },
                                 onDragChanged: { translation in
-                                    itemListWidth = Double(
-                                        min(
-                                            max(itemListDragStart + translation, minimumListWidth),
-                                            maximumListWidth
-                                        )
+                                    liveItemListWidth = min(
+                                        max(itemListDragStart + translation, minimumListWidth),
+                                        maximumListWidth
                                     )
                                 },
-                                onDragEnded: {}
+                                onDragEnded: { translation in
+                                    let finalWidth = min(
+                                        max(itemListDragStart + translation, minimumListWidth),
+                                        maximumListWidth
+                                    )
+                                    itemListWidth = Double(finalWidth)
+                                    liveItemListWidth = nil
+                                }
                             )
                         }
 

--- a/Sources/Lithe/Views/Run/RunView.swift
+++ b/Sources/Lithe/Views/Run/RunView.swift
@@ -9,6 +9,7 @@ struct RunView: View {
     @AppStorage("lithe.run.pinnedConfigurationIDs") private var pinnedConfigurationTokens = ""
     @AppStorage("lithe.run.configurationListWidth") private var configurationListWidth = 230.0
     @AppStorage("lithe.run.configurationListCollapsed") private var isConfigurationListCollapsed = false
+    @State private var liveConfigurationListWidth: CGFloat?
     @State private var configurationListDragStart: CGFloat = 230
     /// The configuration whose editor popover is open. Held separately from the list
     /// selection so opening an editor does not switch which log is shown.
@@ -48,7 +49,7 @@ struct RunView: View {
                         min(420, geometry.size.width - SplitHandleView.thickness - minimumContentWidth)
                     )
                     let resolvedListWidth = constrained(
-                        CGFloat(configurationListWidth),
+                        liveConfigurationListWidth ?? CGFloat(configurationListWidth),
                         minimum: minimumListWidth,
                         maximum: maximumListWidth
                     )
@@ -70,15 +71,21 @@ struct RunView: View {
                                     configurationListDragStart = resolvedListWidth
                                 },
                                 onDragChanged: { translation in
-                                    configurationListWidth = Double(
-                                        constrained(
-                                            configurationListDragStart + translation,
-                                            minimum: minimumListWidth,
-                                            maximum: maximumListWidth
-                                        )
+                                    liveConfigurationListWidth = constrained(
+                                        configurationListDragStart + translation,
+                                        minimum: minimumListWidth,
+                                        maximum: maximumListWidth
                                     )
                                 },
-                                onDragEnded: {}
+                                onDragEnded: { translation in
+                                    let finalWidth = constrained(
+                                        configurationListDragStart + translation,
+                                        minimum: minimumListWidth,
+                                        maximum: maximumListWidth
+                                    )
+                                    configurationListWidth = Double(finalWidth)
+                                    liveConfigurationListWidth = nil
+                                }
                             )
                         }
 

--- a/Sources/Lithe/Views/Workbench/OutputTextView.swift
+++ b/Sources/Lithe/Views/Workbench/OutputTextView.swift
@@ -385,9 +385,12 @@ private struct OutputTextStorageView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSScrollView {
         let textContainer = NSTextContainer(
-            containerSize: NSSize(width: 1, height: CGFloat.greatestFiniteMagnitude)
+            containerSize: NSSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
         )
-        textContainer.widthTracksTextView = true
+        textContainer.widthTracksTextView = false
         let layoutManager = NSLayoutManager()
         layoutManager.allowsNonContiguousLayout = true
         layoutManager.addTextContainer(textContainer)
@@ -400,14 +403,6 @@ private struct OutputTextStorageView: NSViewRepresentable {
         textView.isRichText = true
         textView.drawsBackground = false
         textView.textContainerInset = NSSize(width: 12, height: 12)
-        textView.isHorizontallyResizable = false
-        textView.isVerticallyResizable = true
-        textView.autoresizingMask = NSView.AutoresizingMask.width
-        textView.minSize = NSSize.zero
-        textView.maxSize = NSSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        )
         textView.linkTextAttributes = [
             NSAttributedString.Key.foregroundColor: LitheTheme.nsColor(
                 .accent,
@@ -421,6 +416,7 @@ private struct OutputTextStorageView: NSViewRepresentable {
         scrollView.drawsBackground = false
         scrollView.hasVerticalScroller = true
         scrollView.autohidesScrollers = true
+        LitheTextViewportLayout.applyUnwrappedScrolling(to: textView, in: scrollView)
         scrollView.documentView = textView
         scrollView.contentView.postsBoundsChangedNotifications = true
         context.coordinator.attach(scrollView: scrollView, textView: textView)

--- a/Sources/Lithe/Views/Workbench/SplitHandleView.swift
+++ b/Sources/Lithe/Views/Workbench/SplitHandleView.swift
@@ -16,11 +16,13 @@ struct SplitHandleView: View {
     let trailingBackground: Color
     let onDragStarted: () -> Void
     let onDragChanged: (CGFloat) -> Void
-    let onDragEnded: () -> Void
+    let onDragEnded: (CGFloat) -> Void
 
     @State private var isHovering = false
     @State private var isDragging = false
     @State private var lastTranslation: CGFloat = 0
+    @State private var dragUpdateBuffer = FrameCoalescedDragUpdateBuffer()
+    @State private var dragUpdateTask: Task<Void, Never>?
     @State private var cursor = SplitHandleCursor()
 
     init(
@@ -29,7 +31,7 @@ struct SplitHandleView: View {
         trailingBackground: Color = .clear,
         onDragStarted: @escaping () -> Void,
         onDragChanged: @escaping (CGFloat) -> Void,
-        onDragEnded: @escaping () -> Void
+        onDragEnded: @escaping (CGFloat) -> Void
     ) {
         self.axis = axis
         self.leadingBackground = leadingBackground
@@ -62,17 +64,23 @@ struct SplitHandleView: View {
                         onDragStarted()
                     }
                     let currentTranslation = axis == .horizontal ? value.translation.width : value.translation.height
-                    // Only report changes larger than 1pt to reduce update frequency
+                    // Pointer devices can deliver substantially more events than the
+                    // display can present. Keep only the newest translation for the
+                    // next frame instead of forcing every intermediate layout.
                     if abs(currentTranslation - lastTranslation) >= 1 {
                         lastTranslation = currentTranslation
-                        onDragChanged(currentTranslation)
+                        scheduleDragUpdate(currentTranslation)
                     }
                 }
-                .onEnded { _ in
+                .onEnded { value in
+                    let finalTranslation = axis == .horizontal
+                        ? value.translation.width
+                        : value.translation.height
+                    cancelScheduledDragUpdate()
                     isDragging = false
                     lastTranslation = 0
                     cursor.update(isResizing: isHovering, cursor: resizeCursor)
-                    onDragEnded()
+                    onDragEnded(finalTranslation)
                 }
         )
         .onHover { isInside in
@@ -81,6 +89,7 @@ struct SplitHandleView: View {
             cursor.update(isResizing: isInside || isDragging, cursor: resizeCursor)
         }
         .onDisappear {
+            cancelScheduledDragUpdate()
             cursor.update(isResizing: false, cursor: resizeCursor)
         }
         .help(axis == .horizontal ? "Drag left or right to resize" : "Drag up or down to resize")
@@ -108,25 +117,43 @@ struct SplitHandleView: View {
 
     @ViewBuilder
     private var dividerLine: some View {
-        let color = isDragging
-            ? LitheTheme.accent.opacity(0.72)
-            : LitheTheme.divider
+        let isHighlighted = isHovering || isDragging
+        let color = isHighlighted ? LitheTheme.accent : LitheTheme.divider
 
         if axis == .horizontal {
             Rectangle()
                 .fill(color)
-                .frame(width: isDragging ? 3 : (isHovering ? 2 : 1))
+                .frame(width: isDragging ? 3 : 1)
                 .frame(maxHeight: .infinity)
         } else {
             Rectangle()
                 .fill(color)
-                .frame(height: isDragging ? 3 : (isHovering ? 2 : 1))
+                .frame(height: isDragging ? 3 : 1)
                 .frame(maxWidth: .infinity)
         }
     }
 
     private var resizeCursor: NSCursor {
         axis == .horizontal ? .resizeLeftRight : .resizeUpDown
+    }
+
+    private func scheduleDragUpdate(_ translation: CGFloat) {
+        guard dragUpdateBuffer.submit(translation) else { return }
+        dragUpdateTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(16))
+            guard !Task.isCancelled else { return }
+            let translation = dragUpdateBuffer.takePendingValue()
+            dragUpdateTask = nil
+            if let translation {
+                onDragChanged(translation)
+            }
+        }
+    }
+
+    private func cancelScheduledDragUpdate() {
+        dragUpdateTask?.cancel()
+        dragUpdateTask = nil
+        dragUpdateBuffer.cancel()
     }
 }
 

--- a/Sources/Lithe/Views/Workbench/WorkbenchView.swift
+++ b/Sources/Lithe/Views/Workbench/WorkbenchView.swift
@@ -2,9 +2,15 @@ import AppKit
 import SwiftUI
 import LitheGitModule
 
+enum WorkbenchLayoutMetrics {
+    static let rightActivityBarWidth: CGFloat = 40
+    static let rightActivityBarDividerWidth: CGFloat = 1
+    static let workspaceTrailingInset = rightActivityBarWidth + rightActivityBarDividerWidth
+}
+
 private enum ActivityBarMetrics {
     static let width: CGFloat = 38
-    static let rightWidth: CGFloat = 40
+    static let rightWidth = WorkbenchLayoutMetrics.rightActivityBarWidth
     static let buttonWidth: CGFloat = 30
     static let buttonHeight: CGFloat = 30
     static let spacing: CGFloat = 4
@@ -30,6 +36,7 @@ struct WorkbenchView: View {
     @State private var pendingTopBarPushReference: GitReference?
     @State private var isProjectSwitcherPresented = false
     @State private var isPluginPanelPresented = false
+    @State private var isNotificationCenterPresented = false
     @State private var didRestoreLayout = false
     @State private var hoveredProjectTabID: UUID?
     @State private var workbenchBackgroundImage: NSImage?
@@ -51,6 +58,7 @@ struct WorkbenchView: View {
                     .fill(LitheTheme.divider)
                     .frame(width: 1)
                 workspaceArea
+                    .padding(.trailing, WorkbenchLayoutMetrics.workspaceTrailingInset)
             }
             .frame(maxHeight: .infinity)
             .overlay(alignment: .trailing) {
@@ -613,6 +621,44 @@ struct WorkbenchView: View {
 
     private var pluginActivityBar: some View {
         VStack {
+            Button {
+                isNotificationCenterPresented.toggle()
+                if isNotificationCenterPresented {
+                    model.markAllNotificationsRead()
+                }
+            } label: {
+                ZStack(alignment: .topTrailing) {
+                    Image(systemName: unreadNotificationCount > 0 ? "bell.fill" : "bell")
+                        .frame(width: ActivityBarMetrics.buttonWidth, height: ActivityBarMetrics.buttonHeight)
+                        .litheRowHover(
+                            isActive: isNotificationCenterPresented,
+                            cornerRadius: 4,
+                            activeBackground: LitheTheme.subtleSelection
+                        )
+
+                    if unreadNotificationCount > 0 {
+                        Circle()
+                            .fill(LitheTheme.error)
+                            .frame(width: 7, height: 7)
+                            .overlay(Circle().stroke(LitheTheme.titlebar, lineWidth: 1))
+                            .offset(x: -2, y: 3)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+            .lithePointer()
+            .foregroundStyle(
+                unreadNotificationCount > 0 || isNotificationCenterPresented
+                    ? LitheTheme.primaryText
+                    : LitheTheme.secondaryText
+            )
+            .help(LocalizedStringKey("Notifications"))
+            .accessibilityLabel("Notifications")
+            .popover(isPresented: $isNotificationCenterPresented, arrowEdge: .trailing) {
+                WorkbenchNotificationCenterView()
+                    .environmentObject(model)
+            }
+
             ForEach(model.rightSidebarContributions) { contribution in
                 if let renderer = moduleUIRegistry.renderer(for: contribution),
                    renderer.isVisible(model) {
@@ -658,6 +704,10 @@ struct WorkbenchView: View {
         .padding(.top, ActivityBarMetrics.edgeInset)
         .frame(width: ActivityBarMetrics.rightWidth)
         .background(model.workbenchBackgroundFeature.hasImage ? Color.clear : LitheTheme.titlebar)
+    }
+
+    private var unreadNotificationCount: Int {
+        model.notifications.lazy.filter { !$0.isRead }.count
     }
 
     private var rightHoverRegion: some View {
@@ -1047,6 +1097,93 @@ struct WorkbenchView: View {
 
 }
 
+private struct WorkbenchNotificationCenterView: View {
+    @EnvironmentObject private var model: AppModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Notifications")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(LitheTheme.primaryText)
+
+                Spacer()
+
+                Button("Clear All") {
+                    model.clearNotifications()
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(
+                    model.notifications.isEmpty
+                        ? LitheTheme.tertiaryText
+                        : LitheTheme.accent
+                )
+                .disabled(model.notifications.isEmpty)
+            }
+            .padding(.horizontal, 14)
+            .frame(height: 38)
+
+            Rectangle()
+                .fill(LitheTheme.divider)
+                .frame(height: 1)
+
+            if model.notifications.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "bell")
+                        .font(.system(size: 22, weight: .regular))
+                        .foregroundStyle(LitheTheme.tertiaryText)
+                    Text("No notifications")
+                        .font(.system(size: 12))
+                        .foregroundStyle(LitheTheme.secondaryText)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(model.notifications) { notification in
+                            HStack(alignment: .top, spacing: 10) {
+                                Image(systemName: "info.circle.fill")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(LitheTheme.accent)
+                                    .padding(.top, 2)
+
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(LocalizedStringKey(notification.message))
+                                        .font(.system(size: 12))
+                                        .foregroundStyle(LitheTheme.primaryText)
+                                        .fixedSize(horizontal: false, vertical: true)
+
+                                    Text(notification.createdAt, style: .relative)
+                                        .font(.system(size: 10.5))
+                                        .foregroundStyle(LitheTheme.tertiaryText)
+                                }
+
+                                Spacer(minLength: 0)
+                            }
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 10)
+
+                            Rectangle()
+                                .fill(LitheTheme.divider.opacity(0.7))
+                                .frame(height: 1)
+                                .padding(.leading, 37)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(width: 340, height: 360)
+        .background(LitheTheme.raised)
+        .onAppear {
+            model.markAllNotificationsRead()
+        }
+        .onChange(of: model.notifications.count) { _ in
+            model.markAllNotificationsRead()
+        }
+    }
+}
+
 private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTool: View>: View {
     let sidebarWidth: CGFloat
     let topPaneHeight: CGFloat?
@@ -1142,9 +1279,14 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
                                     maximum: maximumSidebarWidth
                                 )
                             },
-                            onDragEnded: {
-                                liveSidebarWidth = resolvedSidebarWidth
-                                onSidebarWidthCommitted(resolvedSidebarWidth)
+                            onDragEnded: { translation in
+                                let finalWidth = constrained(
+                                    sidebarDragStart + translation,
+                                    minimum: minimumSidebarWidth,
+                                    maximum: maximumSidebarWidth
+                                )
+                                liveSidebarWidth = finalWidth
+                                onSidebarWidthCommitted(finalWidth)
                             }
                         )
                         .offset(x: resolvedSidebarWidth - SplitHandleView.thickness / 2)
@@ -1164,9 +1306,14 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
                                     maximum: maximumTopPaneHeight
                                 )
                             },
-                            onDragEnded: {
-                                liveTopPaneHeight = resolvedTopPaneHeight
-                                onTopPaneHeightCommitted(resolvedTopPaneHeight)
+                            onDragEnded: { translation in
+                                let finalHeight = constrained(
+                                    topPaneDragStart + translation,
+                                    minimum: minimumTopPaneHeight,
+                                    maximum: maximumTopPaneHeight
+                                )
+                                liveTopPaneHeight = finalHeight
+                                onTopPaneHeightCommitted(finalHeight)
                             }
                         )
                         .padding(.horizontal, 6)

--- a/Tests/LitheTests/EditorGutterLayoutTests.swift
+++ b/Tests/LitheTests/EditorGutterLayoutTests.swift
@@ -59,6 +59,17 @@ struct EditorGutterLayoutTests {
     }
 
     @Test
+    func viewportResizeDoesNotReapplyInlaySpacing() {
+        let plan = EditorOverlayUpdatePlan(
+            codeVisionChanged: false,
+            inlayHintsChanged: false,
+            layoutChanged: true
+        )
+        #expect(!plan.updateInlayHints)
+        #expect(plan.updateCodeVision)
+    }
+
+    @Test
     func codeVisionUsesTheSymbolAsItsVisualLineAnchor() {
         #expect(EditorOverlayLayout.codeVisionAnchorCharacterOffset(
             lineStart: 100,
@@ -85,8 +96,8 @@ struct EditorGutterLayoutTests {
     func columnsHaveDistinctHitTargets() {
         let layout = EditorGutterLayout(lineNumberTextWidth: 24)
         #expect(layout.hitTarget(at: 6, hasGitChange: false) == .breakpoint)
-        #expect(layout.hitTarget(at: 22, hasGitChange: false) == .implementation)
-        #expect(layout.hitTarget(at: 45, hasGitChange: false) == .lineNumber)
+        #expect(layout.hitTarget(at: 22, hasGitChange: false) == .lineNumber)
+        #expect(layout.hitTarget(at: 48, hasGitChange: false) == .implementation)
         #expect(layout.hitTarget(at: 68, hasGitChange: false) == .fold)
         #expect(layout.hitTarget(at: 78, hasGitChange: true) == .gitChange)
     }
@@ -98,10 +109,41 @@ struct EditorGutterLayoutTests {
     }
 
     @Test
+    func implementationMarkersRefreshWhenLanguageServerBecomesReady() {
+        let transition = EditorLanguageFeatureTransition(
+            previous: [],
+            current: [.definition, .implementation]
+        )
+        #expect(transition.refreshImplementationMarkers)
+        #expect(!transition.clearImplementationMarkers)
+    }
+
+    @Test
+    func implementationMarkersClearWhenLanguageServerStopsSupportingThem() {
+        let transition = EditorLanguageFeatureTransition(
+            previous: [.definition, .implementation],
+            current: [.definition]
+        )
+        #expect(!transition.refreshImplementationMarkers)
+        #expect(transition.clearImplementationMarkers)
+    }
+
+    @Test
+    func unchangedImplementationSupportDoesNotRefreshMarkers() {
+        let transition = EditorLanguageFeatureTransition(
+            previous: [.definition, .implementation],
+            current: [.definition, .implementation]
+        )
+        #expect(!transition.refreshImplementationMarkers)
+        #expect(!transition.clearImplementationMarkers)
+    }
+
+    @Test
     func lineNumberColumnExpandsWithoutOverlappingFollowingColumns() {
         let layout = EditorGutterLayout(lineNumberTextWidth: 34)
         #expect(layout.lineNumberRange.upperBound - layout.lineNumberRange.lowerBound == 37)
-        #expect(layout.lineNumberRange.upperBound == layout.foldRange.lowerBound)
+        #expect(layout.lineNumberRange.upperBound == layout.implementationRange.lowerBound)
+        #expect(layout.implementationRange.upperBound == layout.foldRange.lowerBound)
         #expect(layout.foldRange.upperBound == layout.gitChangeRange.lowerBound)
         #expect(layout.gitChangeRange.upperBound == layout.width)
     }

--- a/Tests/LitheTests/EditorLayoutMetricsTests.swift
+++ b/Tests/LitheTests/EditorLayoutMetricsTests.swift
@@ -17,9 +17,9 @@ struct EditorLayoutMetricsTests {
     @Test
     func standardGutterUsesDistinctBreakpointImplementationLineNumberAndFoldColumns() {
         let layout = EditorGutterLayout(lineNumberTextWidth: 0)
-        #expect(layout.breakpointRange.upperBound == layout.implementationRange.lowerBound)
-        #expect(layout.implementationRange.upperBound == layout.lineNumberRange.lowerBound)
-        #expect(layout.lineNumberRange.upperBound == layout.foldRange.lowerBound)
+        #expect(layout.breakpointRange.upperBound == layout.lineNumberRange.lowerBound)
+        #expect(layout.lineNumberRange.upperBound == layout.implementationRange.lowerBound)
+        #expect(layout.implementationRange.upperBound == layout.foldRange.lowerBound)
         #expect(layout.foldRange.upperBound == layout.gitChangeRange.lowerBound)
         #expect(layout.gitChangeRange.upperBound == EditorLayoutMetrics.standardGutterWidth)
     }

--- a/Tests/LitheTests/EditorTabLayoutTests.swift
+++ b/Tests/LitheTests/EditorTabLayoutTests.swift
@@ -8,6 +8,26 @@ import UniformTypeIdentifiers
 @Suite("Editor tab layout", .serialized)
 struct EditorTabLayoutTests {
     @Test
+    func javaTabsPreferTheSemanticIconResolvedForTheProjectTree() {
+        let url = URL(fileURLWithPath: "/workspace/UploadService.java")
+
+        #expect(
+            EditorDocumentIconResolver.kind(for: url, resolvedJavaKind: .javaInterface)
+                == .javaInterface
+        )
+    }
+
+    @Test
+    func javaTabsUseTheGenericJavaIconUntilSemanticResolutionCompletes() {
+        let url = URL(fileURLWithPath: "/workspace/UploadService.java")
+
+        #expect(
+            EditorDocumentIconResolver.kind(for: url, resolvedJavaKind: nil)
+                == .javaGeneric
+        )
+    }
+
+    @Test
     func flowLayoutWrapsByIntrinsicWidth() {
         let rows = EditorTabFlowPlanner.rows(
             for: [

--- a/Tests/LitheTests/SplitHandleViewTests.swift
+++ b/Tests/LitheTests/SplitHandleViewTests.swift
@@ -1,0 +1,38 @@
+import AppKit
+import Testing
+@testable import Lithe
+
+@Suite("Split handle updates")
+struct SplitHandleViewTests {
+    @Test
+    func pendingDragUpdatesCoalesceToNewestTranslation() {
+        var buffer = FrameCoalescedDragUpdateBuffer()
+
+        let scheduledFirstDelivery = buffer.submit(12)
+        let scheduledSecondDelivery = buffer.submit(28)
+        let scheduledThirdDelivery = buffer.submit(41)
+        let deliveredTranslation = buffer.takePendingValue()
+
+        #expect(scheduledFirstDelivery)
+        #expect(!scheduledSecondDelivery)
+        #expect(!scheduledThirdDelivery)
+        #expect(deliveredTranslation == 41)
+        #expect(!buffer.hasScheduledDelivery)
+    }
+
+    @Test
+    func cancelledDragUpdateDoesNotLeakIntoNextDrag() {
+        var buffer = FrameCoalescedDragUpdateBuffer()
+        let scheduledCancelledDelivery = buffer.submit(24)
+        #expect(scheduledCancelledDelivery)
+
+        buffer.cancel()
+
+        #expect(buffer.pendingValue == nil)
+        #expect(!buffer.hasScheduledDelivery)
+        let scheduledNextDelivery = buffer.submit(7)
+        let deliveredTranslation = buffer.takePendingValue()
+        #expect(scheduledNextDelivery)
+        #expect(deliveredTranslation == 7)
+    }
+}

--- a/Tests/LitheTests/TextViewportLayoutTests.swift
+++ b/Tests/LitheTests/TextViewportLayoutTests.swift
@@ -1,0 +1,21 @@
+import AppKit
+import Testing
+@testable import Lithe
+
+@Suite("Text viewport layout")
+@MainActor
+struct TextViewportLayoutTests {
+    @Test
+    func unwrappedViewportKeepsDocumentWidthIndependentFromViewport() throws {
+        let scrollView = NSScrollView()
+        let textView = NSTextView()
+
+        LitheTextViewportLayout.applyUnwrappedScrolling(to: textView, in: scrollView)
+
+        #expect(scrollView.hasHorizontalScroller)
+        #expect(textView.isHorizontallyResizable)
+        let textContainer = try #require(textView.textContainer)
+        #expect(!textContainer.widthTracksTextView)
+        #expect(textContainer.containerSize.width == CGFloat.greatestFiniteMagnitude)
+    }
+}

--- a/Tests/LitheTests/WorkbenchNotificationTests.swift
+++ b/Tests/LitheTests/WorkbenchNotificationTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import Lithe
+
+@Suite("Workbench notifications")
+@MainActor
+struct WorkbenchNotificationTests {
+    @Test
+    func notificationsAreNewestFirstReadableBoundedAndClearable() {
+        let store = WorkbenchNotificationTestStore()
+        let settings = AppSettings(store: store)
+        let services = MacServiceContainer(
+            store: store,
+            settings: settings,
+            moduleLaunchMode: .safeMode
+        ).services
+        let model = AppModel(settings: settings, services: services)
+
+        for index in 0..<101 {
+            model.showNotification("Message \(index)")
+        }
+
+        #expect(model.notifications.count == 100)
+        #expect(model.notifications.first?.message == "Message 100")
+        #expect(model.notifications.last?.message == "Message 1")
+        #expect(model.notifications.allSatisfy { !$0.isRead })
+
+        model.markAllNotificationsRead()
+        #expect(model.notifications.allSatisfy { $0.isRead })
+
+        model.clearNotifications()
+        #expect(model.notifications.isEmpty)
+        #expect(model.notificationMessage == nil)
+    }
+}
+
+private final class WorkbenchNotificationTestStore: KeyValueStore, @unchecked Sendable {
+    private var values: [String: Any] = [:]
+
+    func data(forKey key: String) -> Data? { values[key] as? Data }
+    func object(forKey key: String) -> Any? { values[key] }
+    func string(forKey key: String) -> String? { values[key] as? String }
+    func stringArray(forKey key: String) -> [String]? { values[key] as? [String] }
+    func set(_ value: Any?, forKey key: String) { values[key] = value }
+}

--- a/Tests/LitheTests/WorkbenchRenderingSafetyTests.swift
+++ b/Tests/LitheTests/WorkbenchRenderingSafetyTests.swift
@@ -1,8 +1,18 @@
 import Foundation
 import Testing
+@testable import Lithe
 
 @Suite("Workbench rendering safety")
 struct WorkbenchRenderingSafetyTests {
+    @Test
+    func workspaceReservesTheRightActivityBarAndItsDivider() {
+        #expect(
+            WorkbenchLayoutMetrics.workspaceTrailingInset
+                == WorkbenchLayoutMetrics.rightActivityBarWidth
+                    + WorkbenchLayoutMetrics.rightActivityBarDividerWidth
+        )
+    }
+
     @Test
     func workbenchDoesNotFlattenPlatformBackedViews() throws {
         let repositoryRoot = URL(fileURLWithPath: #filePath)

--- a/docs/releases/v0.3.3.md
+++ b/docs/releases/v0.3.3.md
@@ -1,0 +1,87 @@
+## 中文
+
+Lithe 0.3.3 是一次面向 macOS 工作台体验的性能与一致性更新，重点修复分隔条拖动卡顿、右侧工具栏遮挡，以及 Java 标签和 gutter 标记显示不一致的问题。
+
+### 下载
+
+- **项目主页：** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-arm64.dmg)
+- **macOS Intel：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-x86_64.dmg)
+- **Windows x64（预览版）：** [下载安装程序](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-windows-x64.exe)
+- **全部下载：** [查看 Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.3)
+
+> Windows 版本目前仍处于预览阶段。安装程序在未配置 Authenticode 证书时可能没有数字签名，Windows 可能会显示安全提示。
+
+### 重点更新
+
+- 将高频分隔条拖动和 Diff 横向滚动更新合并到显示帧节奏，显著提升文件树、编辑器、运行窗口和其他工具窗口的缩放流畅度。
+- 编辑器与输出区改用独立文档宽度和横向视口，调整面板宽度时不再反复重排整篇文本。
+- 为工作区预留右侧活动栏空间，修复右上角控件遮挡和穿模，并增加可回看的通知中心。
+- Java 编辑器标签复用项目树的语义图标，并修复行号、implementation 标记和折叠列的排列及语言服务就绪后的刷新。
+- 开发预览包现在与正式包一致地内置 JDTLS 和运行时 JDK。
+
+### 其他改进
+
+- Run 与 Tests 面板仅在拖动结束时保存宽度，减少拖动期间的持久化和状态发布开销。
+- 拖动松手时精确提交最终指针位置，避免按帧合并后出现少量位置偏差。
+- 增加通知历史、拖动事件合并、文本视口、Java 标签图标、gutter 布局和预览依赖打包的回归测试。
+
+### 升级说明
+
+- **macOS DMG：** 退出正在运行的 Lithe，打开对应架构的 DMG，然后将 Lithe 拖入“应用程序”并替换旧版本。
+- **Homebrew：** 运行 `brew update && brew upgrade --cask lithe`。
+- **Windows：** 退出正在运行的 Lithe，然后运行 Windows x64 安装程序并按提示完成安装。
+
+### 兼容性与已知问题
+
+- macOS 需要 macOS 13 或更高版本。
+- Java 项目功能需要 JDK 17 或更高版本，推荐使用 JDK 17 或 JDK 21。
+- macOS 和 Windows 正式安装包均包含 JDTLS，无需单独安装。
+- Windows 版本仍处于预览阶段，部分平台能力和界面细节可能与 macOS 不完全一致。
+
+查看 [v0.3.2 到 v0.3.3 的完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.3.2...v0.3.3)。
+
+---
+
+## English
+
+Lithe 0.3.3 is a macOS workbench performance and consistency update focused on smoother pane resizing, unobstructed right-side controls, and aligned Java tab and gutter presentation.
+
+### Downloads
+
+- **Project homepage:** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-arm64.dmg)
+- **macOS Intel:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-x86_64.dmg)
+- **Windows x64 preview:** [Download installer](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-windows-x64.exe)
+- **All downloads:** [View Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.3)
+
+> The Windows build remains a preview. If an Authenticode certificate is not configured, the installer may be unsigned and Windows may show a security warning.
+
+### Highlights
+
+- Coalesced high-frequency split-handle drags and Diff horizontal scrolling to display-frame cadence, substantially improving resize responsiveness across the project tree, editor, Run view, and other tool windows.
+- Made editor and output document width independent from the viewport so pane resizing no longer relays out the entire text document.
+- Reserved workspace space for the right activity bar, fixing overlapping controls, and added a bounded notification center.
+- Reused project-tree semantic icons in Java editor tabs and fixed the ordering and refresh behavior of line-number, implementation, and folding gutter columns.
+- Bundled JDTLS and its runtime JDK in development preview apps to match official packages.
+
+### Other improvements
+
+- Persist Run and Tests pane widths only after dragging ends, reducing storage and state publication work during interaction.
+- Commit the exact final pointer position when a drag ends, avoiding small offsets introduced by frame coalescing.
+- Added regression coverage for notification history, drag coalescing, text viewport layout, Java tab icons, gutter layout, and preview dependency packaging.
+
+### Upgrade instructions
+
+- **macOS DMG:** Quit Lithe, open the DMG for your Mac architecture, and replace the existing application in the Applications folder.
+- **Homebrew:** Run `brew update && brew upgrade --cask lithe`.
+- **Windows:** Quit Lithe, run the Windows x64 installer, and follow the installation prompts.
+
+### Compatibility and known issues
+
+- macOS requires macOS 13 or later.
+- Java project features require JDK 17 or newer. JDK 17 or JDK 21 is recommended.
+- Release packages for macOS and Windows include JDTLS, so it does not need to be installed separately.
+- The Windows build remains a preview, and some platform capabilities and interface details may differ from macOS.
+
+Review the [full changes from v0.3.2 to v0.3.3](https://github.com/1lck/Lithe-IDEA/compare/v0.3.2...v0.3.3).

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -11,6 +11,8 @@ case "$(uname -m)" in
 esac
 
 scripts/build-macos.sh --configuration debug --triple "$TRIPLE"
+JDTLS_ROOT=$(scripts/prepare-jdtls.sh)
+JDK_ROOT=$(LITHE_JDK_TARGET_ARCH="$(uname -m)" scripts/prepare-jdk.sh)
 
 # 必须打成 .app 再启动：裸可执行文件没有 Info.plist，macOS 不会把它当成
 # 前台应用，窗口能收到鼠标点击但永远拿不到键盘焦点。
@@ -22,8 +24,14 @@ mkdir -p "$PREVIEW_ROOT"
 # project tree and tool windows.
 INSTANCE_DIR=$(mktemp -d "$PREVIEW_ROOT/instance.XXXXXX")
 APP_DIR="$INSTANCE_DIR/Lithe.app"
-mkdir -p "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Resources/OfficialPlugins" "$APP_DIR/Contents/Helpers"
+mkdir -p \
+    "$APP_DIR/Contents/MacOS" \
+    "$APP_DIR/Contents/Resources/LanguageServers" \
+    "$APP_DIR/Contents/Resources/OfficialPlugins" \
+    "$APP_DIR/Contents/Helpers"
 cp ".build/$TRIPLE/debug/Lithe" "$APP_DIR/Contents/MacOS/Lithe"
+cp -R "$JDTLS_ROOT" "$APP_DIR/Contents/Resources/LanguageServers/jdtls"
+cp -R "$JDK_ROOT" "$APP_DIR/Contents/Resources/LanguageServers/jdk"
 plugin_root=$(scripts/build-official-plugins.sh --configuration debug --triple "$TRIPLE")
 for plugin_package in "$plugin_root"/*(/N); do
     cp -R "$plugin_package" "$APP_DIR/Contents/Resources/OfficialPlugins/${plugin_package:t}"

--- a/scripts/test-verify-download-cache.mjs
+++ b/scripts/test-verify-download-cache.mjs
@@ -105,6 +105,19 @@ async function assertMacJdkCacheConfiguration() {
 
   const packageScript = await fs.readFile(path.join(repositoryRoot, "scripts/package-app.sh"), "utf8");
   assert.match(packageScript, /LITHE_JDK_TARGET_ARCH="\$jdk_arch"/, "macOS packages must prepare the target-architecture JDK");
+  const previewScript = await fs.readFile(path.join(repositoryRoot, "scripts/preview.sh"), "utf8");
+  assert.match(previewScript, /prepare-jdtls\.sh/, "macOS previews must prepare JDTLS");
+  assert.match(previewScript, /prepare-jdk\.sh/, "macOS previews must prepare the bundled JDK");
+  assert.match(
+    previewScript,
+    /Contents\/Resources\/LanguageServers\/jdtls/,
+    "macOS previews must bundle JDTLS at the runtime lookup path",
+  );
+  assert.match(
+    previewScript,
+    /Contents\/Resources\/LanguageServers\/jdk/,
+    "macOS previews must bundle the JDK at the runtime lookup path",
+  );
   const prepareScript = await fs.readFile(path.join(repositoryRoot, "scripts/prepare-jdk.sh"), "utf8");
   assert.match(prepareScript, /TARGET_ARCH="\$\{LITHE_JDK_TARGET_ARCH:-\$\(uname -m\)\}"/);
   assert.match(prepareScript, /macos-aarch64/);


### PR DESCRIPTION
## Summary

- merge the latest preview/0.3.0 history into main
- include the macOS workbench layout, Java presentation, preview packaging, and resize-performance fixes from #247
- add bilingual v0.3.3 release notes for macOS and Windows assets

## Validation

- #247 passed all macOS, Windows, Rust Core, plugin, and database CI gates
- ./scripts/test-macos.sh (621 tests, 74 suites)
- ./scripts/verify-service-boundaries.sh
- node scripts/test-verify-download-cache.mjs
- git diff --check

After this PR merges, dispatch the macOS and Windows release workflows with version 0.3.3.