### PR TITLE
chore: sync main back into preview 0.3.0

### DIFF
--- a/Casks/lithe.rb
+++ b/Casks/lithe.rb
@@ -1,9 +1,9 @@
 cask "lithe" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "0.3.2"
-  sha256 arm:   "4a75c690008d7e3ade505c3d7f0ef85f1182fe9fa878d6148daf55c865572388",
-         intel: "150d9b3a2527db2ac1648097f4e6143ef4f01b9798e72fff09991b064c7c6e02"
+  version "0.3.3"
+  sha256 arm:   "a1749403bac431b8ae701363df3ea778fd2e4d7005af039027b40183e819bc4e",
+         intel: "28008b9a253ca33216ef27277c2c2b3807328e5e332e94ea652dd047dfb6f194"
 
   url "https://github.com/1lck/Lithe-IDEA/releases/download/v#{version}/Lithe-#{version}-#{arch}.dmg"
   name "Lithe"

--- a/docs/releases/v0.3.3.md
+++ b/docs/releases/v0.3.3.md
@@ -1,0 +1,87 @@
+## 中文
+
+Lithe 0.3.3 是一次面向 macOS 工作台体验的性能与一致性更新，重点修复分隔条拖动卡顿、右侧工具栏遮挡，以及 Java 标签和 gutter 标记显示不一致的问题。
+
+### 下载
+
+- **项目主页：** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-arm64.dmg)
+- **macOS Intel：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-x86_64.dmg)
+- **Windows x64（预览版）：** [下载安装程序](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-windows-x64.exe)
+- **全部下载：** [查看 Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.3)
+
+> Windows 版本目前仍处于预览阶段。安装程序在未配置 Authenticode 证书时可能没有数字签名，Windows 可能会显示安全提示。
+
+### 重点更新
+
+- 将高频分隔条拖动和 Diff 横向滚动更新合并到显示帧节奏，显著提升文件树、编辑器、运行窗口和其他工具窗口的缩放流畅度。
+- 编辑器与输出区改用独立文档宽度和横向视口，调整面板宽度时不再反复重排整篇文本。
+- 为工作区预留右侧活动栏空间，修复右上角控件遮挡和穿模，并增加可回看的通知中心。
+- Java 编辑器标签复用项目树的语义图标，并修复行号、implementation 标记和折叠列的排列及语言服务就绪后的刷新。
+- 开发预览包现在与正式包一致地内置 JDTLS 和运行时 JDK。
+
+### 其他改进
+
+- Run 与 Tests 面板仅在拖动结束时保存宽度，减少拖动期间的持久化和状态发布开销。
+- 拖动松手时精确提交最终指针位置，避免按帧合并后出现少量位置偏差。
+- 增加通知历史、拖动事件合并、文本视口、Java 标签图标、gutter 布局和预览依赖打包的回归测试。
+
+### 升级说明
+
+- **macOS DMG：** 退出正在运行的 Lithe，打开对应架构的 DMG，然后将 Lithe 拖入“应用程序”并替换旧版本。
+- **Homebrew：** 运行 `brew update && brew upgrade --cask lithe`。
+- **Windows：** 退出正在运行的 Lithe，然后运行 Windows x64 安装程序并按提示完成安装。
+
+### 兼容性与已知问题
+
+- macOS 需要 macOS 13 或更高版本。
+- Java 项目功能需要 JDK 17 或更高版本，推荐使用 JDK 17 或 JDK 21。
+- macOS 和 Windows 正式安装包均包含 JDTLS，无需单独安装。
+- Windows 版本仍处于预览阶段，部分平台能力和界面细节可能与 macOS 不完全一致。
+
+查看 [v0.3.2 到 v0.3.3 的完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.3.2...v0.3.3)。
+
+---
+
+## English
+
+Lithe 0.3.3 is a macOS workbench performance and consistency update focused on smoother pane resizing, unobstructed right-side controls, and aligned Java tab and gutter presentation.
+
+### Downloads
+
+- **Project homepage:** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-arm64.dmg)
+- **macOS Intel:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-x86_64.dmg)
+- **Windows x64 preview:** [Download installer](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.3/Lithe-0.3.3-windows-x64.exe)
+- **All downloads:** [View Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.3)
+
+> The Windows build remains a preview. If an Authenticode certificate is not configured, the installer may be unsigned and Windows may show a security warning.
+
+### Highlights
+
+- Coalesced high-frequency split-handle drags and Diff horizontal scrolling to display-frame cadence, substantially improving resize responsiveness across the project tree, editor, Run view, and other tool windows.
+- Made editor and output document width independent from the viewport so pane resizing no longer relays out the entire text document.
+- Reserved workspace space for the right activity bar, fixing overlapping controls, and added a bounded notification center.
+- Reused project-tree semantic icons in Java editor tabs and fixed the ordering and refresh behavior of line-number, implementation, and folding gutter columns.
+- Bundled JDTLS and its runtime JDK in development preview apps to match official packages.
+
+### Other improvements
+
+- Persist Run and Tests pane widths only after dragging ends, reducing storage and state publication work during interaction.
+- Commit the exact final pointer position when a drag ends, avoiding small offsets introduced by frame coalescing.
+- Added regression coverage for notification history, drag coalescing, text viewport layout, Java tab icons, gutter layout, and preview dependency packaging.
+
+### Upgrade instructions
+
+- **macOS DMG:** Quit Lithe, open the DMG for your Mac architecture, and replace the existing application in the Applications folder.
+- **Homebrew:** Run `brew update && brew upgrade --cask lithe`.
+- **Windows:** Quit Lithe, run the Windows x64 installer, and follow the installation prompts.
+
+### Compatibility and known issues
+
+- macOS requires macOS 13 or later.
+- Java project features require JDK 17 or newer. JDK 17 or JDK 21 is recommended.
+- Release packages for macOS and Windows include JDTLS, so it does not need to be installed separately.
+- The Windows build remains a preview, and some platform capabilities and interface details may differ from macOS.
+
+Review the [full changes from v0.3.2 to v0.3.3](https://github.com/1lck/Lithe-IDEA/compare/v0.3.2...v0.3.3).


### PR DESCRIPTION
## Summary
- merge the v0.3.3 release lineage from `main` back into `preview/0.3.0`
- keep the long-lived preview branch based on the latest released history

## Notes
- merge-tree verification completed without conflicts
- this PR contains no product behavior changes beyond the existing main and preview histories