### PR TITLE
fix(macOS): unify rounded workbench surfaces

### DIFF
--- a/macos/Sources/Lithe/Platform/MacOS/Terminal/MacTerminalTransport.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/Terminal/MacTerminalTransport.swift
@@ -47,9 +47,8 @@ final class LitheTerminalView: LocalProcessTerminalView {
 
     func applyThemeColors() {
         let isDark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-        nativeBackgroundColor = isDark
-            ? NSColor(srgbRed: 0.071, green: 0.075, blue: 0.081, alpha: showsWorkbenchBackground ? 0 : 1)
-            : NSColor(srgbRed: 1, green: 1, blue: 1, alpha: showsWorkbenchBackground ? 0 : 1)
+        nativeBackgroundColor = LitheTheme.nsColor(.editor, isDark: isDark)
+            .withAlphaComponent(showsWorkbenchBackground ? 0 : 1)
         nativeForegroundColor = isDark
             ? NSColor(srgbRed: 0.86, green: 0.87, blue: 0.89, alpha: 1)
             : NSColor(srgbRed: 0.15, green: 0.16, blue: 0.18, alpha: 1)

--- a/macos/Sources/Lithe/Theme/LitheTheme.swift
+++ b/macos/Sources/Lithe/Theme/LitheTheme.swift
@@ -126,18 +126,15 @@ enum LitheTheme {
                 contrast = 0.45
             }
 
-            let chromeAmount = (isDark ? 0.045 : 0.035) * (contrast / 0.45)
             let strongChromeAmount = (isDark ? 0.075 : 0.055) * (contrast / 0.45)
             let subtleAccent = surface.mixed(with: accent, amount: isDark ? 0.20 : 0.11)
 
             return Palette(
                 window: surface,
                 titlebar: surface.mixed(with: ink, amount: strongChromeAmount),
-                toolHeader: surface.mixed(with: ink, amount: chromeAmount),
-                toolHeaderInactive: surface.mixed(with: ink, amount: strongChromeAmount),
-                sidebar: isDark
-                    ? surface.mixed(with: RGBA(0x000000), amount: 0.10)
-                    : surface.mixed(with: ink, amount: chromeAmount),
+                toolHeader: surface,
+                toolHeaderInactive: surface,
+                sidebar: surface,
                 editor: surface,
                 raised: surface.mixed(with: ink, amount: isDark ? 0.085 : 0.018),
                 selection: accent,
@@ -185,9 +182,9 @@ enum LitheTheme {
             return Palette(
                 window: adaptive(light: (0.965, 0.969, 0.976, 1), dark: (0.157, 0.161, 0.173, 1)),
                 titlebar: adaptive(light: (0.925, 0.933, 0.945, 1), dark: (0.157, 0.161, 0.173, 1)),
-                toolHeader: adaptive(light: (0.925, 0.933, 0.945, 1), dark: (0.157, 0.161, 0.173, 1)),
-                toolHeaderInactive: adaptive(light: (0.902, 0.910, 0.925, 1), dark: (0.224, 0.231, 0.251, 1)),
-                sidebar: adaptive(light: (0.925, 0.933, 0.945, 1), dark: (0.157, 0.161, 0.173, 1)),
+                toolHeader: adaptive(light: (1, 1, 1, 1), dark: (0.110, 0.114, 0.122, 1)),
+                toolHeaderInactive: adaptive(light: (1, 1, 1, 1), dark: (0.110, 0.114, 0.122, 1)),
+                sidebar: adaptive(light: (1, 1, 1, 1), dark: (0.110, 0.114, 0.122, 1)),
                 editor: adaptive(light: (1, 1, 1, 1), dark: (0.110, 0.114, 0.122, 1)),
                 raised: adaptive(light: (1, 1, 1, 1), dark: (0.165, 0.175, 0.190, 1)),
                 selection: adaptive(light: (0.275, 0.455, 0.945, 1), dark: (0.208, 0.455, 0.941, 1)),
@@ -229,6 +226,7 @@ enum LitheTheme {
     enum ResolvedColorToken {
         case editor
         case sidebar
+        case toolHeader
         case primaryText
         case secondaryText
         case accent
@@ -250,6 +248,7 @@ enum LitheTheme {
         return switch token {
         case .editor: palette.editor.nsColor
         case .sidebar: palette.sidebar.nsColor
+        case .toolHeader: palette.toolHeader.nsColor
         case .primaryText: palette.primaryText.nsColor
         case .secondaryText: palette.secondaryText.nsColor
         case .accent: palette.accent.nsColor

--- a/macos/Sources/Lithe/Views/Workbench/SplitHandleView.swift
+++ b/macos/Sources/Lithe/Views/Workbench/SplitHandleView.swift
@@ -14,6 +14,7 @@ struct SplitHandleView: View {
     let axis: LitheSplitAxis
     let leadingBackground: Color
     let trailingBackground: Color
+    let showsIdleDivider: Bool
     let onDragStarted: () -> Void
     let onDragChanged: (CGFloat) -> Void
     let onDragEnded: (CGFloat) -> Void
@@ -29,6 +30,7 @@ struct SplitHandleView: View {
         axis: LitheSplitAxis,
         leadingBackground: Color = .clear,
         trailingBackground: Color = .clear,
+        showsIdleDivider: Bool = true,
         onDragStarted: @escaping () -> Void,
         onDragChanged: @escaping (CGFloat) -> Void,
         onDragEnded: @escaping (CGFloat) -> Void
@@ -36,6 +38,7 @@ struct SplitHandleView: View {
         self.axis = axis
         self.leadingBackground = leadingBackground
         self.trailingBackground = trailingBackground
+        self.showsIdleDivider = showsIdleDivider
         self.onDragStarted = onDragStarted
         self.onDragChanged = onDragChanged
         self.onDragEnded = onDragEnded
@@ -118,18 +121,20 @@ struct SplitHandleView: View {
     @ViewBuilder
     private var dividerLine: some View {
         let isHighlighted = isHovering || isDragging
-        let color = isHighlighted ? LitheTheme.accent : LitheTheme.divider
+        if showsIdleDivider || isHighlighted {
+            let color = isHighlighted ? LitheTheme.accent : LitheTheme.divider
 
-        if axis == .horizontal {
-            Rectangle()
-                .fill(color)
-                .frame(width: isDragging ? 3 : 1)
-                .frame(maxHeight: .infinity)
-        } else {
-            Rectangle()
-                .fill(color)
-                .frame(height: isDragging ? 3 : 1)
-                .frame(maxWidth: .infinity)
+            if axis == .horizontal {
+                Rectangle()
+                    .fill(color)
+                    .frame(width: isDragging ? 3 : 1)
+                    .frame(maxHeight: .infinity)
+            } else {
+                Rectangle()
+                    .fill(color)
+                    .frame(height: isDragging ? 3 : 1)
+                    .frame(maxWidth: .infinity)
+            }
         }
     }
 

--- a/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
+++ b/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
@@ -17,6 +17,12 @@ private enum ActivityBarMetrics {
     static let edgeInset: CGFloat = 4
 }
 
+private enum WorkbenchWorkspaceMetrics {
+    static let paneInset: CGFloat = 6
+    static let paneSpacing: CGFloat = 6
+    static let paneCornerRadius: CGFloat = 10
+}
+
 struct WorkbenchView: View {
     private let moduleUIRegistry = WorkbenchModuleUIComposition.builtIn
     @EnvironmentObject private var model: AppModel
@@ -719,11 +725,22 @@ struct WorkbenchView: View {
                 )
                 .environmentObject(linuxDoWebSession)
                 .frame(width: rightSidebarWidth)
-                .background(model.workbenchBackgroundFeature.hasImage ? Color.clear : LitheTheme.sidebar)
-                .overlay(alignment: .leading) {
-                    Rectangle().fill(LitheTheme.panelBorder).frame(width: 1)
-                }
-                .shadow(color: LitheTheme.popupShadow, radius: 14, x: -5, y: 0)
+                .frame(maxHeight: .infinity)
+                .workbenchPaneChrome(
+                    background: model.workbenchBackgroundFeature.hasImage
+                        ? Color.clear
+                        : LitheTheme.editor,
+                    surrounding: model.workbenchBackgroundFeature.hasImage
+                        ? Color.clear
+                        : LitheTheme.titlebar,
+                    roundsCorners: !model.workbenchBackgroundFeature.hasImage
+                )
+                .padding(WorkbenchWorkspaceMetrics.paneInset)
+                .background(
+                    model.workbenchBackgroundFeature.hasImage
+                        ? Color.clear
+                        : LitheTheme.titlebar
+                )
                 .transition(
                     reduceMotion
                         ? .opacity
@@ -914,13 +931,6 @@ struct WorkbenchView: View {
                 }
             }
         }
-        // Do not clip this container: Changes, Search, and Database sidebars
-        // contain AppKit-backed controls that SwiftUI cannot composite through
-        // a mask without showing its yellow unavailable placeholder.
-        .litheRoundedControlBackground(
-            model.workbenchBackgroundFeature.hasImage ? Color.clear : LitheTheme.sidebar,
-            cornerRadius: 10
-        )
     }
 
     private var isBottomToolVisible: Bool {
@@ -1233,8 +1243,12 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
 
     var body: some View {
         GeometryReader { geometry in
-            let horizontalPadding: CGFloat = 6
-            let availableTopWidth = max(0, geometry.size.width - (horizontalPadding * 2))
+            let availableTopWidth = max(
+                0,
+                geometry.size.width
+                    - (WorkbenchWorkspaceMetrics.paneInset * 2)
+                    - WorkbenchWorkspaceMetrics.paneSpacing
+            )
             let minimumSidebarWidth: CGFloat = 220
             let minimumEditorWidth: CGFloat = 400
             let maximumSidebarWidth = max(
@@ -1251,7 +1265,9 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
             let minimumGitPaneHeight: CGFloat = 260
             let maximumTopPaneHeight = max(
                 minimumTopPaneHeight,
-                geometry.size.height - SplitHandleView.thickness - minimumGitPaneHeight
+                geometry.size.height
+                    - WorkbenchWorkspaceMetrics.paneSpacing
+                    - minimumGitPaneHeight
             )
             let resolvedTopPaneHeight = constrained(
                 liveTopPaneHeight ?? max(255, geometry.size.height * 0.40),
@@ -1260,15 +1276,34 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
             )
 
             ZStack(alignment: .topLeading) {
-                VStack(spacing: 0) {
-                    HStack(spacing: 0) {
+                VStack(spacing: isBottomToolVisible ? WorkbenchWorkspaceMetrics.paneSpacing : 0) {
+                    HStack(spacing: WorkbenchWorkspaceMetrics.paneSpacing) {
                         sidebar
                             .frame(width: resolvedSidebarWidth)
+                            .frame(maxHeight: .infinity)
+                            .workbenchPaneChrome(
+                                background: hasWorkbenchBackground ? Color.clear : LitheTheme.editor,
+                                surrounding: hasWorkbenchBackground ? Color.clear : LitheTheme.titlebar,
+                                roundsCorners: !hasWorkbenchBackground
+                            )
                         editor
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .workbenchPaneChrome(
+                                background: hasWorkbenchBackground ? Color.clear : LitheTheme.editor,
+                                surrounding: hasWorkbenchBackground ? Color.clear : LitheTheme.titlebar,
+                                roundsCorners: !hasWorkbenchBackground
+                            )
                     }
+                    .padding(.horizontal, WorkbenchWorkspaceMetrics.paneInset)
+                    .padding(.top, WorkbenchWorkspaceMetrics.paneInset)
+                    .padding(
+                        .bottom,
+                        isBottomToolVisible ? 0 : WorkbenchWorkspaceMetrics.paneInset
+                    )
                     .overlay(alignment: .topLeading) {
                         SplitHandleView(
                             axis: .horizontal,
+                            showsIdleDivider: false,
                             onDragStarted: {
                                 sidebarDragStart = resolvedSidebarWidth
                             },
@@ -1289,40 +1324,64 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
                                 onSidebarWidthCommitted(finalWidth)
                             }
                         )
-                        .offset(x: resolvedSidebarWidth - SplitHandleView.thickness / 2)
+                        .padding(.top, WorkbenchWorkspaceMetrics.paneInset)
+                        .padding(
+                            .bottom,
+                            isBottomToolVisible ? 0 : WorkbenchWorkspaceMetrics.paneInset
+                        )
+                        .offset(
+                            x: WorkbenchWorkspaceMetrics.paneInset
+                                + resolvedSidebarWidth
+                                + WorkbenchWorkspaceMetrics.paneSpacing / 2
+                                - SplitHandleView.thickness / 2
+                        )
                     }
                     .frame(height: isBottomToolVisible ? resolvedTopPaneHeight : geometry.size.height)
 
                     if isBottomToolVisible {
-                        SplitHandleView(
-                            axis: .vertical,
-                            onDragStarted: {
-                                topPaneDragStart = resolvedTopPaneHeight
-                            },
-                            onDragChanged: { translation in
-                                liveTopPaneHeight = constrained(
-                                    topPaneDragStart + translation,
-                                    minimum: minimumTopPaneHeight,
-                                    maximum: maximumTopPaneHeight
-                                )
-                            },
-                            onDragEnded: { translation in
-                                let finalHeight = constrained(
-                                    topPaneDragStart + translation,
-                                    minimum: minimumTopPaneHeight,
-                                    maximum: maximumTopPaneHeight
-                                )
-                                liveTopPaneHeight = finalHeight
-                                onTopPaneHeightCommitted(finalHeight)
-                            }
-                        )
-                        .padding(.horizontal, 6)
-
                         bottomTool
-                            .padding(.horizontal, 6)
-                            .padding(.bottom, 6)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .workbenchPaneChrome(
+                                background: hasWorkbenchBackground ? Color.clear : LitheTheme.editor,
+                                surrounding: hasWorkbenchBackground ? Color.clear : LitheTheme.titlebar,
+                                roundsCorners: !hasWorkbenchBackground
+                            )
+                            .padding(.horizontal, WorkbenchWorkspaceMetrics.paneInset)
+                            .padding(.bottom, WorkbenchWorkspaceMetrics.paneInset)
                             .frame(maxHeight: .infinity)
                     }
+                }
+
+                if isBottomToolVisible {
+                    SplitHandleView(
+                        axis: .vertical,
+                        showsIdleDivider: false,
+                        onDragStarted: {
+                            topPaneDragStart = resolvedTopPaneHeight
+                        },
+                        onDragChanged: { translation in
+                            liveTopPaneHeight = constrained(
+                                topPaneDragStart + translation,
+                                minimum: minimumTopPaneHeight,
+                                maximum: maximumTopPaneHeight
+                            )
+                        },
+                        onDragEnded: { translation in
+                            let finalHeight = constrained(
+                                topPaneDragStart + translation,
+                                minimum: minimumTopPaneHeight,
+                                maximum: maximumTopPaneHeight
+                            )
+                            liveTopPaneHeight = finalHeight
+                            onTopPaneHeightCommitted(finalHeight)
+                        }
+                    )
+                    .padding(.horizontal, WorkbenchWorkspaceMetrics.paneInset)
+                    .offset(
+                        y: resolvedTopPaneHeight
+                            + WorkbenchWorkspaceMetrics.paneSpacing / 2
+                            - SplitHandleView.thickness / 2
+                    )
                 }
 
                 if isBottomToolVisible, showsBottomToolMinimize {
@@ -1335,7 +1394,7 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
                     .accessibilityLabel("Collapse tool window")
                     .position(
                         x: geometry.size.width - ActivityBarMetrics.rightWidth - 20,
-                        y: resolvedTopPaneHeight + SplitHandleView.thickness + 16
+                        y: resolvedTopPaneHeight + WorkbenchWorkspaceMetrics.paneSpacing + 16
                     )
                 }
             }
@@ -1360,6 +1419,62 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
 
     private func constrained(_ value: CGFloat, minimum: CGFloat, maximum: CGFloat) -> CGFloat {
         min(max(value, minimum), maximum)
+    }
+}
+
+private extension View {
+    /// Draws pane rounding without masking AppKit-backed editor and tool views.
+    func workbenchPaneChrome(
+        background: Color,
+        surrounding: Color,
+        roundsCorners: Bool = true
+    ) -> some View {
+        modifier(
+            WorkbenchPaneChromeModifier(
+                background: background,
+                surrounding: surrounding,
+                roundsCorners: roundsCorners
+            )
+        )
+    }
+}
+
+private struct WorkbenchPaneChromeModifier: ViewModifier {
+    let background: Color
+    let surrounding: Color
+    let roundsCorners: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if roundsCorners {
+            content
+                .background(background)
+                .overlay {
+                    WorkbenchPaneCornerCutouts(
+                        cornerRadius: WorkbenchWorkspaceMetrics.paneCornerRadius
+                    )
+                    .fill(surrounding, style: FillStyle(eoFill: true))
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+                }
+        } else {
+            content.background(background)
+        }
+    }
+}
+
+private struct WorkbenchPaneCornerCutouts: Shape {
+    let cornerRadius: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.addRect(rect)
+        path.addRoundedRect(
+            in: rect,
+            cornerSize: CGSize(width: cornerRadius, height: cornerRadius),
+            style: .continuous
+        )
+        return path
     }
 }
 

--- a/macos/Tests/LitheTests/CommitMessageTests.swift
+++ b/macos/Tests/LitheTests/CommitMessageTests.swift
@@ -446,6 +446,20 @@ struct CommitMessageSettingsTests {
         }
     }
 
+    @Test
+    func bundledToolWindowSurfacesMatchTheEditorSurface() {
+        for theme in AppColorTheme.allCases {
+            for isDark in [false, true] {
+                let editor = rgbHex(LitheTheme.nsColor(.editor, theme: theme, isDark: isDark))
+                let sidebar = rgbHex(LitheTheme.nsColor(.sidebar, theme: theme, isDark: isDark))
+                let toolHeader = rgbHex(LitheTheme.nsColor(.toolHeader, theme: theme, isDark: isDark))
+
+                #expect(sidebar == editor)
+                #expect(toolHeader == editor)
+            }
+        }
+    }
+
     private func rgbHex(_ color: NSColor) -> UInt32? {
         guard let color = color.usingColorSpace(.sRGB) else { return nil }
         let red = UInt32((color.redComponent * 255).rounded())


### PR DESCRIPTION
## Summary
- use one editor surface color for the project sidebar, editor, tool headers, and terminal canvas
- add consistent 6px pane gaps and 10px rounded corners without clipping AppKit-backed views
- keep split handles visible on hover and drag while hiding idle divider lines inside the pane gaps
- apply the same pane treatment to the right sidebar

## Validation
- `./scripts/test-macos.sh` (622 tests in 74 suites)
- `./scripts/verify-service-boundaries.sh`
- `git diff --check`
- visual QA: Project, Changes, Terminal, Problems, Git Log, and right sidebar on the latest `preview/0.3.0`