### PR TITLE
fix(lsp): wait for JDTLS service readiness

### DIFF
--- a/rust/lithe-core/src/lsp/interface/engine.rs
+++ b/rust/lithe-core/src/lsp/interface/engine.rs
@@ -833,7 +833,10 @@ impl RuntimeSession {
         let message = {
             let mut state = self.lock_state()?;
             ensure_not_terminal(state.lifecycle)?;
-            if !state.client.initialized {
+            if !state.client.initialized
+                || (waits_for_service_ready(&self.provider_id)
+                    && state.lifecycle != LspLifecycleState::Ready)
+            {
                 state.pending_workspace_file_changes.extend(normalized);
                 return Ok(());
             }
@@ -865,11 +868,14 @@ impl RuntimeSession {
                 }
             }
             state.java_navigation_marker_cache.remove(&uri);
-            // JDT LS has a second readiness phase after standard initialize.
-            // Once the protocol handshake is complete, edits must still reach
-            // the server while project import is finishing so its model cannot
-            // fall behind the editor buffer.
-            if state.client.initialized {
+            // JDT LS associates working copies with the Java project model that
+            // exists when `didOpen` arrives. Opening restored documents before
+            // `ServiceReady` can permanently bind them to an incomplete Maven
+            // model, so retain only their latest text until import finishes.
+            let can_sync_on_wire = state.client.initialized
+                && (!waits_for_service_ready(&self.provider_id)
+                    || state.lifecycle == LspLifecycleState::Ready);
+            if can_sync_on_wire {
                 let response = if state
                     .client
                     .open_documents
@@ -1938,7 +1944,9 @@ impl RuntimeSession {
                     .to_string(),
                 );
             }
-            outbound.extend(self.flush_queued_documents()?);
+            if !waits_for_service_ready(&self.provider_id) {
+                outbound.extend(self.flush_queued_documents()?);
+            }
             self.send_messages_or_fail(outbound, "serverResponse")?;
             let mut state = self.lock_state()?;
             if let Some(info) = ready_server_info {
@@ -1961,18 +1969,23 @@ impl RuntimeSession {
         }
         self.send_messages_or_fail(outbound, "serverResponse")?;
         if service_ready {
-            let mut state = self.lock_state()?;
-            state.initialize_deadline = None;
-            transition_locked(self, &mut state, LspLifecycleState::Ready, None);
-            let capabilities = state.client.server_capabilities.clone();
-            push_features_event(self, &mut state, capabilities);
-            push_log_event(
-                self,
-                &mut state,
-                "info",
-                "Java language service finished project import",
-                None,
-            );
+            let queued_messages = {
+                let mut state = self.lock_state()?;
+                state.initialize_deadline = None;
+                let messages = flush_queued_documents_locked(&mut state)?;
+                transition_locked(self, &mut state, LspLifecycleState::Ready, None);
+                let capabilities = state.client.server_capabilities.clone();
+                push_features_event(self, &mut state, capabilities);
+                push_log_event(
+                    self,
+                    &mut state,
+                    "info",
+                    "Java language service finished project import",
+                    None,
+                );
+                messages
+            };
+            self.send_messages_or_fail(queued_messages, "serviceReady")?;
         }
         Ok(())
     }
@@ -2022,29 +2035,7 @@ impl RuntimeSession {
 
     fn flush_queued_documents(&self) -> Result<Vec<String>, CoreError> {
         let mut state = self.lock_state()?;
-        let queued: Vec<_> = state
-            .client
-            .open_documents
-            .values()
-            .filter(|document| document.version == 0)
-            .cloned()
-            .collect();
-        let mut messages = Vec::new();
-        for document in queued {
-            let response = client_open_document(ClientOpenDocumentRequest {
-                state: state.client.clone(),
-                uri: document.uri,
-                language_id: document.language_id,
-                text: document.text,
-            })?;
-            state.client = response.state;
-            messages.extend(response.messages);
-        }
-        if !state.pending_workspace_file_changes.is_empty() {
-            let changes = std::mem::take(&mut state.pending_workspace_file_changes);
-            messages.push(workspace_file_changes_notification(changes));
-        }
-        Ok(messages)
+        flush_queued_documents_locked(&mut state)
     }
 
     fn expire_deadlines(&self) {
@@ -3003,6 +2994,32 @@ fn clear_runtime_state(session: &RuntimeSession, state: &mut SessionState) {
     push_features_event(session, state, Vec::new());
 }
 
+fn flush_queued_documents_locked(state: &mut SessionState) -> Result<Vec<String>, CoreError> {
+    let queued: Vec<_> = state
+        .client
+        .open_documents
+        .values()
+        .filter(|document| document.version == 0)
+        .cloned()
+        .collect();
+    let mut messages = Vec::new();
+    for document in queued {
+        let response = client_open_document(ClientOpenDocumentRequest {
+            state: state.client.clone(),
+            uri: document.uri,
+            language_id: document.language_id,
+            text: document.text,
+        })?;
+        state.client = response.state;
+        messages.extend(response.messages);
+    }
+    if !state.pending_workspace_file_changes.is_empty() {
+        let changes = std::mem::take(&mut state.pending_workspace_file_changes);
+        messages.push(workspace_file_changes_notification(changes));
+    }
+    Ok(messages)
+}
+
 fn workspace_file_changes_notification(
     changes: BTreeMap<String, WorkspaceFileChangeKind>,
 ) -> String {
@@ -3468,25 +3485,57 @@ mod tests {
     }
 
     #[test]
-    fn java_edits_stay_incremental_while_project_import_is_finishing() {
+    fn java_documents_wait_for_service_ready_and_latest_text_wins() {
         let mut harness = Harness::start(|request| {
             request.provider_id = "java".to_string();
         });
         let uri = "file:///workspace/Main.java";
         harness.sync(uri, "class Main {}");
         harness.server.complete_initialize(ready_capabilities());
-        assert!(harness.server.await_notification("textDocument/didOpen"));
-        harness.sync(uri, "class Main { int value; }");
-        assert!(harness.server.await_notification("textDocument/didChange"));
+        assert!(harness
+            .server
+            .await_notification("workspace/didChangeConfiguration"));
+        assert!(!harness
+            .server
+            .messages()
+            .iter()
+            .any(|message| message["method"] == "textDocument/didOpen"));
 
+        harness.sync(uri, "class Main { int value; }");
         assert_eq!(harness.snapshot().state, LspLifecycleState::Initializing);
-        assert_eq!(harness.snapshot().open_documents[uri].version, 2);
+        assert_eq!(harness.snapshot().open_documents[uri].version, 0);
+        assert!(!harness.server.messages().iter().any(|message| {
+            matches!(
+                message["method"].as_str(),
+                Some("textDocument/didOpen" | "textDocument/didChange")
+            )
+        }));
+
         harness.server.send(json!({
             "jsonrpc": "2.0",
             "method": "language/status",
             "params": { "type": "ServiceReady" }
         }));
         harness.await_state(LspLifecycleState::Ready);
+
+        let document_messages: Vec<_> = harness
+            .server
+            .messages()
+            .into_iter()
+            .filter(|message| {
+                matches!(
+                    message["method"].as_str(),
+                    Some("textDocument/didOpen" | "textDocument/didChange")
+                )
+            })
+            .collect();
+        assert_eq!(document_messages.len(), 1);
+        assert_eq!(document_messages[0]["method"], "textDocument/didOpen");
+        assert_eq!(
+            document_messages[0]["params"]["textDocument"]["text"],
+            "class Main { int value; }"
+        );
+        assert_eq!(harness.snapshot().open_documents[uri].version, 1);
     }
 
     /// Criterion 3: two syncs emit open version 1 then change version 2.
@@ -3594,6 +3643,47 @@ mod tests {
                 { "uri": "file:///workspace/pom.xml", "type": 2 },
                 { "uri": "file:///workspace/src/Main.java", "type": 2 }
             ])
+        );
+    }
+
+    #[test]
+    fn java_workspace_changes_wait_for_service_ready() {
+        let mut harness = Harness::start(|request| {
+            request.provider_id = "java".to_string();
+        });
+        harness
+            .session()
+            .workspace_files_changed(vec![WorkspaceFileChange {
+                uri: "file:///workspace/src/Main.java".to_string(),
+                kind: WorkspaceFileChangeKind::Changed,
+            }])
+            .expect("Java watcher events should queue while project import is pending");
+        harness.server.complete_initialize(ready_capabilities());
+        assert!(harness
+            .server
+            .await_notification("workspace/didChangeConfiguration"));
+        assert!(!harness
+            .server
+            .messages()
+            .iter()
+            .any(|message| { message["method"] == "workspace/didChangeWatchedFiles" }));
+
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "language/status",
+            "params": { "type": "ServiceReady" }
+        }));
+        harness.await_state(LspLifecycleState::Ready);
+
+        let notification = harness
+            .server
+            .messages()
+            .into_iter()
+            .find(|message| message["method"] == "workspace/didChangeWatchedFiles")
+            .expect("queued Java watcher events should flush after project import");
+        assert_eq!(
+            notification["params"]["changes"],
+            json!([{ "uri": "file:///workspace/src/Main.java", "type": 2 }])
         );
     }
 

--- a/rust/lithe-core/src/lsp/interface/engine.rs
+++ b/rust/lithe-core/src/lsp/interface/engine.rs
@@ -444,6 +444,10 @@ struct RuntimeSession {
     provider_id: String,
     #[cfg(test)]
     root_uri: String,
+    /// Serializes protocol-state commits with complete outbound message batches.
+    /// Callers acquire this before `state` whenever an action can write to the
+    /// server, preserving the same order in memory and on the wire.
+    outbound_order: Mutex<()>,
     state: Mutex<SessionState>,
     event_signal: Condvar,
     process: Arc<dyn LspProcessHandle>,
@@ -719,6 +723,7 @@ impl LspEngine {
             provider_id: request.provider_id,
             #[cfg(test)]
             root_uri: request.root_uri,
+            outbound_order: Mutex::new(()),
             state: Mutex::new(SessionState {
                 lifecycle: LspLifecycleState::Created,
                 client: initialize.state,
@@ -758,7 +763,8 @@ impl LspEngine {
             .insert(session_id.clone(), session.clone());
         session.spawn_readers(process.output, process.errors);
         session.spawn_monitor();
-        if let Err(error) = session.send_messages(initialize.messages) {
+        let outbound_order = session.lock_outbound_order()?;
+        if let Err(error) = session.send_messages(&outbound_order, initialize.messages) {
             session.fail(
                 "transportFailed",
                 "initialize",
@@ -830,6 +836,7 @@ impl RuntimeSession {
             // and prevents a watcher burst from causing redundant imports.
             normalized.insert(change.uri, change.kind);
         }
+        let outbound_order = self.lock_outbound_order()?;
         let message = {
             let mut state = self.lock_state()?;
             ensure_not_terminal(state.lifecycle)?;
@@ -842,7 +849,7 @@ impl RuntimeSession {
             }
             workspace_file_changes_notification(normalized)
         };
-        self.send_messages_or_fail(vec![message], "workspaceFilesChanged")
+        self.send_messages_or_fail(&outbound_order, vec![message], "workspaceFilesChanged")
     }
 
     fn sync_document(
@@ -853,6 +860,7 @@ impl RuntimeSession {
         let mut messages = Vec::new();
         let mut stale_cancellations = Vec::new();
         let document_version;
+        let outbound_order = self.lock_outbound_order()?;
         {
             let mut state = self.lock_state()?;
             ensure_not_terminal(state.lifecycle)?;
@@ -928,7 +936,7 @@ impl RuntimeSession {
             }
         }
         messages.extend(stale_cancellations);
-        self.send_messages_or_fail(messages, "documentSync")?;
+        self.send_messages_or_fail(&outbound_order, messages, "documentSync")?;
         Ok(SyncDocumentResponse {
             document_version,
             changed: true,
@@ -938,6 +946,7 @@ impl RuntimeSession {
     fn close_document(&self, uri: &str) -> Result<(), CoreError> {
         let mut messages = Vec::new();
         let cleared;
+        let outbound_order = self.lock_outbound_order()?;
         {
             let mut state = self.lock_state()?;
             ensure_not_terminal(state.lifecycle)?;
@@ -965,7 +974,7 @@ impl RuntimeSession {
                 push_diagnostics_event(self, &mut state, uri, None, Vec::new());
             }
         }
-        self.send_messages_or_fail(messages, "documentClose")
+        self.send_messages_or_fail(&outbound_order, messages, "documentClose")
     }
 
     fn complete_cached_java_navigation_markers(
@@ -1049,6 +1058,7 @@ impl RuntimeSession {
         requested_kind: PendingKind,
         requested_document_version: Option<i64>,
     ) -> Result<(), CoreError> {
+        let outbound_order = self.lock_outbound_order()?;
         let (messages, request_id) = {
             let mut state = self.lock_state()?;
             if state.lifecycle != LspLifecycleState::Ready || !state.client.initialized {
@@ -1227,7 +1237,7 @@ impl RuntimeSession {
                 .insert(operation_id, request_id.clone());
             (response.messages, request_id)
         };
-        if let Err(error) = self.send_messages(messages) {
+        if let Err(error) = self.send_messages(&outbound_order, messages) {
             self.complete_request_with_error(
                 &request_id,
                 "transportFailed",
@@ -1250,6 +1260,7 @@ impl RuntimeSession {
     }
 
     fn cancel_operation(&self, operation_id: &str) -> Result<(), CoreError> {
+        let outbound_order = self.lock_outbound_order()?;
         let request_id = {
             let mut state = self.lock_state()?;
             let request_id = state
@@ -1295,10 +1306,11 @@ impl RuntimeSession {
             "params": { "id": request_id }
         })
         .to_string();
-        self.send_messages_or_fail(vec![cancellation], "requestCancel")
+        self.send_messages_or_fail(&outbound_order, vec![cancellation], "requestCancel")
     }
 
     fn stop(&self) -> Result<(), CoreError> {
+        let outbound_order = self.lock_outbound_order()?;
         let (messages, force_kill) = {
             let mut state = self.lock_state()?;
             if matches!(
@@ -1349,7 +1361,7 @@ impl RuntimeSession {
                 (Vec::new(), true)
             }
         };
-        self.send_messages_or_fail(messages, "shutdown")?;
+        self.send_messages_or_fail(&outbound_order, messages, "shutdown")?;
         if force_kill {
             self.kill_process();
         }
@@ -1531,10 +1543,15 @@ impl RuntimeSession {
             value.get("method").and_then(Value::as_str),
             value.get("params"),
         );
+        let outbound_order = self.lock_outbound_order()?;
 
         if value.get("method").and_then(Value::as_str) == Some("workspace/configuration") {
             if let Some(response) = self.provider_configuration_response(&value)? {
-                return self.send_messages_or_fail(vec![response], "serverRequest");
+                return self.send_messages_or_fail(
+                    &outbound_order,
+                    vec![response],
+                    "serverRequest",
+                );
             }
         }
 
@@ -1947,7 +1964,7 @@ impl RuntimeSession {
             if !waits_for_service_ready(&self.provider_id) {
                 outbound.extend(self.flush_queued_documents()?);
             }
-            self.send_messages_or_fail(outbound, "serverResponse")?;
+            self.send_messages_or_fail(&outbound_order, outbound, "serverResponse")?;
             let mut state = self.lock_state()?;
             if let Some(info) = ready_server_info {
                 push_server_info_event(self, &mut state, info);
@@ -1967,12 +1984,16 @@ impl RuntimeSession {
             }
             return Ok(());
         }
-        self.send_messages_or_fail(outbound, "serverResponse")?;
+        self.send_messages_or_fail(&outbound_order, outbound, "serverResponse")?;
         if service_ready {
             let queued_messages = {
                 let mut state = self.lock_state()?;
                 state.initialize_deadline = None;
-                let messages = flush_queued_documents_locked(&mut state)?;
+                flush_queued_documents_locked(&mut state)?
+            };
+            self.send_messages_or_fail(&outbound_order, queued_messages, "serviceReady")?;
+            {
+                let mut state = self.lock_state()?;
                 transition_locked(self, &mut state, LspLifecycleState::Ready, None);
                 let capabilities = state.client.server_capabilities.clone();
                 push_features_event(self, &mut state, capabilities);
@@ -1983,9 +2004,7 @@ impl RuntimeSession {
                     "Java language service finished project import",
                     None,
                 );
-                messages
-            };
-            self.send_messages_or_fail(queued_messages, "serviceReady")?;
+            }
         }
         Ok(())
     }
@@ -2114,7 +2133,20 @@ impl RuntimeSession {
                 );
             }
         }
-        if !cancellations.is_empty() {
+        if initialize_timeout {
+            // Timeout termination must not wait behind a blocked stdin write;
+            // killing the process is what releases that write.
+            self.fail(
+                "initializeTimeout",
+                "initialize",
+                "Language-server initialization timed out.",
+                None,
+                None,
+            );
+            self.kill_process();
+        } else if shutdown_timeout {
+            self.kill_process();
+        } else if !cancellations.is_empty() {
             let messages = cancellations
                 .into_iter()
                 .map(|id| {
@@ -2126,19 +2158,21 @@ impl RuntimeSession {
                     .to_string()
                 })
                 .collect();
-            let _ = self.send_messages(messages);
-        }
-        if initialize_timeout {
-            self.fail(
-                "initializeTimeout",
-                "initialize",
-                "Language-server initialization timed out.",
-                None,
-                None,
-            );
-            self.kill_process();
-        } else if shutdown_timeout {
-            self.kill_process();
+            match self.lock_outbound_order() {
+                Ok(outbound_order) => {
+                    let _ = self.send_messages(&outbound_order, messages);
+                }
+                Err(error) => {
+                    self.fail(
+                        "transportFailed",
+                        "outboundOrder",
+                        "Language-server outbound ordering failed.",
+                        Some(core_error_detail(&error)),
+                        None,
+                    );
+                    self.kill_process();
+                }
+            }
         }
     }
 
@@ -2268,11 +2302,16 @@ impl RuntimeSession {
         }
     }
 
-    fn send_messages_or_fail(&self, messages: Vec<String>, stage: &str) -> Result<(), CoreError> {
+    fn send_messages_or_fail(
+        &self,
+        outbound_order: &MutexGuard<'_, ()>,
+        messages: Vec<String>,
+        stage: &str,
+    ) -> Result<(), CoreError> {
         if messages.is_empty() {
             return Ok(());
         }
-        if let Err(error) = self.send_messages(messages) {
+        if let Err(error) = self.send_messages(outbound_order, messages) {
             self.fail(
                 "transportFailed",
                 stage,
@@ -2286,7 +2325,11 @@ impl RuntimeSession {
         Ok(())
     }
 
-    fn send_messages(&self, messages: Vec<String>) -> Result<(), CoreError> {
+    fn send_messages(
+        &self,
+        _outbound_order: &MutexGuard<'_, ()>,
+        messages: Vec<String>,
+    ) -> Result<(), CoreError> {
         for message in messages {
             let frame = frame_message(FrameMessageRequest { message })?.frame;
             self.process.write_input(frame.as_bytes())?;
@@ -2296,6 +2339,15 @@ impl RuntimeSession {
 
     fn kill_process(&self) {
         self.process.terminate();
+    }
+
+    fn lock_outbound_order(&self) -> Result<MutexGuard<'_, ()>, CoreError> {
+        self.outbound_order.lock().map_err(|_| {
+            CoreError::new(
+                ErrorCode::Unknown,
+                "Language-server outbound ordering lock was poisoned.",
+            )
+        })
     }
 
     fn lock_state(&self) -> Result<MutexGuard<'_, SessionState>, CoreError> {
@@ -3536,6 +3588,118 @@ mod tests {
             "class Main { int value; }"
         );
         assert_eq!(harness.snapshot().open_documents[uri].version, 1);
+    }
+
+    #[test]
+    fn java_ready_flush_precedes_concurrent_edits_and_closes() {
+        let mut harness = Harness::start(|request| {
+            request.provider_id = "java".to_string();
+        });
+        let first_uri = "file:///workspace/First.java";
+        let second_uri = "file:///workspace/Second.java";
+        harness.sync(first_uri, "class First {}");
+        harness.sync(second_uri, "class Second {}");
+        harness.server.complete_initialize(ready_capabilities());
+        assert!(harness
+            .server
+            .await_notification("workspace/didChangeConfiguration"));
+
+        // Hold the first restored didOpen before it reaches the server. The
+        // complete ready flush must retain outbound ownership and keep Ready
+        // private until every restored document has been written.
+        harness.server.pause_input();
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "language/status",
+            "params": { "type": "ServiceReady" }
+        }));
+        assert!(
+            harness.server.await_input_pause(),
+            "the restored document flush should reach the write barrier"
+        );
+        assert_eq!(
+            harness.snapshot().state,
+            LspLifecycleState::Initializing,
+            "Ready must not be published before queued didOpen messages are written"
+        );
+
+        let start = Arc::new(std::sync::Barrier::new(3));
+        let edit_session = harness.session();
+        let edit_session_id = harness.session_id.clone();
+        let edit_start = start.clone();
+        let edit = thread::spawn(move || {
+            edit_start.wait();
+            edit_session.sync_document(SyncDocumentRequest {
+                session_id: edit_session_id,
+                uri: second_uri.to_string(),
+                language_id: "java".to_string(),
+                text: "class Second { int value; }".to_string(),
+                content_changes: Vec::new(),
+            })
+        });
+        let close_session = harness.session();
+        let close_start = start.clone();
+        let close = thread::spawn(move || {
+            close_start.wait();
+            close_session.close_document(first_uri)
+        });
+        start.wait();
+
+        assert!(
+            harness.session().outbound_order.try_lock().is_err(),
+            "the ready flush should exclude concurrent protocol state commits"
+        );
+        harness.server.resume_input();
+        edit.join()
+            .expect("the concurrent edit thread should finish")
+            .expect("the concurrent edit should succeed after Ready");
+        close
+            .join()
+            .expect("the concurrent close thread should finish")
+            .expect("the concurrent close should succeed after Ready");
+        harness.await_state(LspLifecycleState::Ready);
+
+        let document_messages: Vec<_> = harness
+            .server
+            .messages()
+            .into_iter()
+            .filter(|message| {
+                matches!(
+                    message["method"].as_str(),
+                    Some(
+                        "textDocument/didOpen" | "textDocument/didChange" | "textDocument/didClose"
+                    )
+                )
+            })
+            .collect();
+        assert_eq!(document_messages.len(), 4);
+        assert_eq!(document_messages[0]["method"], "textDocument/didOpen");
+        assert_eq!(
+            document_messages[0]["params"]["textDocument"]["uri"],
+            first_uri
+        );
+        assert_eq!(document_messages[1]["method"], "textDocument/didOpen");
+        assert_eq!(
+            document_messages[1]["params"]["textDocument"]["uri"],
+            second_uri
+        );
+        assert!(document_messages[2..].iter().any(|message| {
+            message["method"] == "textDocument/didChange"
+                && message["params"]["textDocument"]["uri"] == second_uri
+                && message["params"]["textDocument"]["version"] == 2
+        }));
+        assert!(document_messages[2..].iter().any(|message| {
+            message["method"] == "textDocument/didClose"
+                && message["params"]["textDocument"]["uri"] == first_uri
+        }));
+
+        let snapshot = harness.snapshot();
+        assert!(!snapshot.open_documents.contains_key(first_uri));
+        assert_eq!(snapshot.open_documents[second_uri].version, 2);
+        assert_eq!(
+            snapshot.open_documents[second_uri].text,
+            "class Second { int value; }"
+        );
     }
 
     /// Criterion 3: two syncs emit open version 1 then change version 2.

--- a/rust/lithe-core/src/lsp/interface/scripted.rs
+++ b/rust/lithe-core/src/lsp/interface/scripted.rs
@@ -34,7 +34,17 @@ struct ScriptedShared {
     input_closed: AtomicBool,
     /// Set when the test wants writes to fail, standing in for a broken pipe.
     input_broken: AtomicBool,
+    /// Deterministic write barrier used by concurrency-ordering tests.
+    input_pause: Mutex<ScriptedInputPause>,
+    input_pause_changed: Condvar,
     spec: Mutex<Option<LaunchedSpec>>,
+}
+
+#[derive(Default)]
+struct ScriptedInputPause {
+    requested: bool,
+    blocked: bool,
+    release_requested: bool,
 }
 
 /// What the engine asked the launcher for, so tests can assert provider
@@ -56,6 +66,8 @@ impl ScriptedServer {
                 exit: Mutex::new(None),
                 input_closed: AtomicBool::new(false),
                 input_broken: AtomicBool::new(false),
+                input_pause: Mutex::new(ScriptedInputPause::default()),
+                input_pause_changed: Condvar::new(),
                 spec: Mutex::new(None),
             }),
         }
@@ -214,6 +226,43 @@ impl ScriptedServer {
     pub fn break_input(&self) {
         self.shared.input_broken.store(true, Ordering::Release);
     }
+
+    /// Stops the next engine write before any bytes reach the scripted server.
+    pub fn pause_input(&self) {
+        let mut pause = self.shared.input_pause.lock().unwrap();
+        pause.requested = true;
+        pause.blocked = false;
+        pause.release_requested = false;
+    }
+
+    /// Waits until an engine write is held at the deterministic pause barrier.
+    pub fn await_input_pause(&self) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut pause = self.shared.input_pause.lock().unwrap();
+        while !pause.blocked {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            let (guard, timeout) = self
+                .shared
+                .input_pause_changed
+                .wait_timeout(pause, remaining)
+                .unwrap();
+            pause = guard;
+            if timeout.timed_out() && !pause.blocked {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Releases a paused engine write and disables the pause barrier.
+    pub fn resume_input(&self) {
+        let mut pause = self.shared.input_pause.lock().unwrap();
+        pause.release_requested = true;
+        self.shared.input_pause_changed.notify_all();
+    }
 }
 
 struct ScriptedLauncher {
@@ -245,6 +294,19 @@ struct ScriptedProcess {
 
 impl LspProcessHandle for ScriptedProcess {
     fn write_input(&self, frame: &[u8]) -> Result<(), CoreError> {
+        {
+            let mut pause = self.shared.input_pause.lock().unwrap();
+            if pause.requested {
+                pause.requested = false;
+                pause.blocked = true;
+                self.shared.input_pause_changed.notify_all();
+                while !pause.release_requested {
+                    pause = self.shared.input_pause_changed.wait(pause).unwrap();
+                }
+                pause.blocked = false;
+                pause.release_requested = false;
+            }
+        }
         if self.shared.input_broken.load(Ordering::Acquire)
             || self.shared.input_closed.load(Ordering::Acquire)
         {


### PR DESCRIPTION
## Summary

- delay Java document synchronization until JDTLS reports ServiceReady
- coalesce restored document updates and open the latest text at version 1
- delay Java workspace watcher notifications until Maven project import completes
- add regression coverage for restored documents and watcher events

## Root cause

Lithe restored Java documents immediately after the standard LSP initialize handshake. JDTLS has a second readiness phase while Maven projects are imported. A didOpen sent before ServiceReady could bind the working copy to an incomplete Java project model, leaving valid project types unresolved for the lifetime of that server process.

## Validation

- cargo fmt --manifest-path rust/lithe-core/Cargo.toml -- --check
- ./scripts/verify-rust-core-comments.sh
- focused Java readiness regression tests
- cargo test --manifest-path rust/lithe-core/Cargo.toml: 237 unit tests and 5 integration tests passed
- ./scripts/verify-rust-core.sh
- manual macOS A/B acceptance test with the same project, cache, and restored Java tab: 60 Java diagnostics before the fix, 0 after the fix
- current JDTLS session imports Maven and finishes build jobs before validating the restored file; no new BadLocationException was emitted

The six remaining diagnostics in the acceptance workspace are pre-existing Spring YAML placeholder validation false positives and are unrelated to this Java synchronization race.