### PR TITLE
fix(macos): separate fold summary from code vision

### DIFF
--- a/macos/Sources/Lithe/Views/Editor/CodeEditorView.swift
+++ b/macos/Sources/Lithe/Views/Editor/CodeEditorView.swift
@@ -172,29 +172,65 @@ struct EditorGutterLayout: Equatable {
 }
 
 enum EditorFoldVisibility {
+    static func hiddenLines(
+        in source: NSString,
+        regions: [JavaFoldRegion],
+        collapsedIDs: Set<String>
+    ) -> Set<Int> {
+        var hiddenLines: Set<Int> = []
+        for region in regions where collapsedIDs.contains(region.id) {
+            let hiddenRange = region.hiddenRange
+            guard hiddenRange.location >= 0,
+                  hiddenRange.length > 0,
+                  NSMaxRange(hiddenRange) <= source.length else { continue }
+
+            var line = region.startLine + 1
+            var lineStart = hiddenRange.location
+            // Core ranges are half-open, so a closing line that starts at the
+            // upper bound remains visible even when its number is endLine.
+            while line <= region.endLine,
+                  lineStart < NSMaxRange(hiddenRange) {
+                if NSLocationInRange(lineStart, hiddenRange) {
+                    hiddenLines.insert(line)
+                }
+                let lineRange = source.lineRange(
+                    for: NSRange(location: lineStart, length: 0)
+                )
+                let nextLineStart = NSMaxRange(lineRange)
+                guard nextLineStart > lineStart else { break }
+                lineStart = nextLineStart
+                line += 1
+            }
+        }
+        return hiddenLines
+    }
+
     static func isLineHidden(
         _ line: Int,
+        in source: NSString,
         regions: [JavaFoldRegion],
         collapsedIDs: Set<String>
     ) -> Bool {
-        regions.contains { region in
-            collapsedIDs.contains(region.id)
-                && line > region.startLine
-                && line <= region.endLine
-        }
+        hiddenLines(
+            in: source,
+            regions: regions,
+            collapsedIDs: collapsedIDs
+        ).contains(line)
     }
 
     static func visibleCodeVisionHints(
         _ hints: [JavaCodeVisionHint],
+        in source: NSString,
         regions: [JavaFoldRegion],
         collapsedIDs: Set<String>
     ) -> [JavaCodeVisionHint] {
-        hints.filter { hint in
-            !isLineHidden(
-                hint.line,
-                regions: regions,
-                collapsedIDs: collapsedIDs
-            )
+        let hiddenLines = hiddenLines(
+            in: source,
+            regions: regions,
+            collapsedIDs: collapsedIDs
+        )
+        return hints.filter { hint in
+            !hiddenLines.contains(hint.line)
         }
     }
 }
@@ -1266,6 +1302,7 @@ struct CodeEditorView: NSViewRepresentable {
             let hints = model.settings.showCodeVision ? model.javaCodeVisionHints[url] ?? [] : []
             let visibleCodeVisionHints = EditorFoldVisibility.visibleCodeVisionHints(
                 hints,
+                in: (textView?.string ?? "") as NSString,
                 regions: foldRegions,
                 collapsedIDs: collapsedFoldIDs
             )
@@ -2221,12 +2258,13 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
 
         var indentations: [Int: Int] = [:]
         var blankLines: Set<Int> = []
+        let hiddenLines = EditorFoldVisibility.hiddenLines(
+            in: source,
+            regions: foldRegions,
+            collapsedIDs: collapsedFoldIDs
+        )
         for line in firstLine...lastLine {
-            guard !EditorFoldVisibility.isLineHidden(
-                line,
-                regions: foldRegions,
-                collapsedIDs: collapsedFoldIDs
-            ) else { continue }
+            guard !hiddenLines.contains(line) else { continue }
             let indentation = leadingIndentationColumns(forLine: line, in: source)
             indentations[line] = indentation
             if lineIsBlank(line, in: source) {
@@ -3374,14 +3412,15 @@ final class LineNumberGutterView: NSView {
             return
         }
         let firstVisibleLine = visibleLines.lowerBound
+        let hiddenLines = EditorFoldVisibility.hiddenLines(
+            in: source,
+            regions: foldRegions,
+            collapsedIDs: collapsedFoldIDs
+        )
         var newlyVisibleLines: Set<Int> = []
         var accessibilityButtons: [NSButton] = []
         for line in visibleLines {
-            guard !EditorFoldVisibility.isLineHidden(
-                line,
-                regions: foldRegions,
-                collapsedIDs: collapsedFoldIDs
-            ),
+            guard !hiddenLines.contains(line),
                   let button = blameButtons[line],
                   showsBlameMetadata(line: line, firstVisibleLine: firstVisibleLine) else { continue }
             let characterIndex = characterOffset(forLine: line, in: source)
@@ -3519,6 +3558,11 @@ final class LineNumberGutterView: NSView {
                 .reduce(0) { $1 == "\n" ? $0 + 1 : $0 }
         var lineNumber = firstLine + 1
         let maxGlyph = min(NSMaxRange(glyphRange), layoutManager.numberOfGlyphs)
+        let hiddenLines = EditorFoldVisibility.hiddenLines(
+            in: text,
+            regions: foldRegions,
+            collapsedIDs: collapsedFoldIDs
+        )
 
         while glyphIndex < maxGlyph {
             let characterIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
@@ -3527,11 +3571,7 @@ final class LineNumberGutterView: NSView {
             let lineGlyphRange = layoutManager.glyphRange(forCharacterRange: lineRange, actualCharacterRange: nil)
             let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
             let y = lineRect.minY + textView.textContainerOrigin.y - visibleRect.minY
-            let isCollapsedHiddenLine = EditorFoldVisibility.isLineHidden(
-                lineNumber - 1,
-                regions: foldRegions,
-                collapsedIDs: collapsedFoldIDs
-            )
+            let isCollapsedHiddenLine = hiddenLines.contains(lineNumber - 1)
             if isCollapsedHiddenLine {
                 let nextGlyph = NSMaxRange(lineGlyphRange)
                 glyphIndex = nextGlyph > glyphIndex ? nextGlyph : glyphIndex + 1

--- a/macos/Sources/Lithe/Views/Editor/CodeEditorView.swift
+++ b/macos/Sources/Lithe/Views/Editor/CodeEditorView.swift
@@ -171,6 +171,34 @@ struct EditorGutterLayout: Equatable {
     }
 }
 
+enum EditorFoldVisibility {
+    static func isLineHidden(
+        _ line: Int,
+        regions: [JavaFoldRegion],
+        collapsedIDs: Set<String>
+    ) -> Bool {
+        regions.contains { region in
+            collapsedIDs.contains(region.id)
+                && line > region.startLine
+                && line <= region.endLine
+        }
+    }
+
+    static func visibleCodeVisionHints(
+        _ hints: [JavaCodeVisionHint],
+        regions: [JavaFoldRegion],
+        collapsedIDs: Set<String>
+    ) -> [JavaCodeVisionHint] {
+        hints.filter { hint in
+            !isLineHidden(
+                hint.line,
+                regions: regions,
+                collapsedIDs: collapsedIDs
+            )
+        }
+    }
+}
+
 enum EditorOverlayLayout {
     static let inlayHintVerticalPadding: CGFloat = 4
 
@@ -1236,6 +1264,11 @@ struct CodeEditorView: NSViewRepresentable {
             guard let document, let model else { return }
             let url = document.url.standardizedFileURL
             let hints = model.settings.showCodeVision ? model.javaCodeVisionHints[url] ?? [] : []
+            let visibleCodeVisionHints = EditorFoldVisibility.visibleCodeVisionHints(
+                hints,
+                regions: foldRegions,
+                collapsedIDs: collapsedFoldIDs
+            )
             let inlayHints = model.javaInlayHints[url] ?? []
             let overlayLayoutChanged = appliedEditorOverlayLayoutRevision != editorOverlayLayoutRevision
             let updatePlan = EditorOverlayUpdatePlan(
@@ -1254,7 +1287,7 @@ struct CodeEditorView: NSViewRepresentable {
             if updatePlan.updateCodeVision {
                 appliedCodeVisionHints = hints
                 codeVisionOverlay?.update(
-                    hints: hints,
+                    hints: visibleCodeVisionHints,
                     onUsages: { [weak model] hint in model?.findUsages(for: hint, in: url) },
                     onImplementations: { [weak model] hint in
                         model?.findJavaImplementations(
@@ -2189,7 +2222,11 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
         var indentations: [Int: Int] = [:]
         var blankLines: Set<Int> = []
         for line in firstLine...lastLine {
-            guard !isLineHiddenByCollapsedFold(line) else { continue }
+            guard !EditorFoldVisibility.isLineHidden(
+                line,
+                regions: foldRegions,
+                collapsedIDs: collapsedFoldIDs
+            ) else { continue }
             let indentation = leadingIndentationColumns(forLine: line, in: source)
             indentations[line] = indentation
             if lineIsBlank(line, in: source) {
@@ -2257,14 +2294,6 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
                     segmentStart = nil
                 }
             }
-        }
-    }
-
-    private func isLineHiddenByCollapsedFold(_ line: Int) -> Bool {
-        foldRegions.contains { region in
-            collapsedFoldIDs.contains(region.id) &&
-                line > region.startLine &&
-                line <= region.endLine
         }
     }
 
@@ -2376,6 +2405,14 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
             width: 28,
             height: lineRect.height
         )
+    }
+
+    func collapsedFoldSummaryMaxX(forLine line: Int) -> CGFloat? {
+        foldRegions.compactMap { region -> CGFloat? in
+            guard collapsedFoldIDs.contains(region.id),
+                  region.startLine == line else { return nil }
+            return foldSummaryRect(for: region)?.maxX
+        }.max()
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -3278,6 +3315,7 @@ final class LineNumberGutterView: NSView {
             self.hoveredFoldID = nil
         }
         animateFoldIndicators()
+        layoutBlameButtons()
         needsDisplay = true
     }
 
@@ -3339,7 +3377,12 @@ final class LineNumberGutterView: NSView {
         var newlyVisibleLines: Set<Int> = []
         var accessibilityButtons: [NSButton] = []
         for line in visibleLines {
-            guard let button = blameButtons[line],
+            guard !EditorFoldVisibility.isLineHidden(
+                line,
+                regions: foldRegions,
+                collapsedIDs: collapsedFoldIDs
+            ),
+                  let button = blameButtons[line],
                   showsBlameMetadata(line: line, firstVisibleLine: firstVisibleLine) else { continue }
             let characterIndex = characterOffset(forLine: line, in: source)
             guard characterIndex < source.length else {
@@ -3484,10 +3527,11 @@ final class LineNumberGutterView: NSView {
             let lineGlyphRange = layoutManager.glyphRange(forCharacterRange: lineRange, actualCharacterRange: nil)
             let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
             let y = lineRect.minY + textView.textContainerOrigin.y - visibleRect.minY
-            let isCollapsedHiddenLine = foldRegions.contains { region in
-                collapsedFoldIDs.contains(region.id) &&
-                    lineNumber - 1 > region.startLine && lineNumber - 1 <= region.endLine
-            }
+            let isCollapsedHiddenLine = EditorFoldVisibility.isLineHidden(
+                lineNumber - 1,
+                regions: foldRegions,
+                collapsedIDs: collapsedFoldIDs
+            )
             if isCollapsedHiddenLine {
                 let nextGlyph = NSMaxRange(lineGlyphRange)
                 glyphIndex = nextGlyph > glyphIndex ? nextGlyph : glyphIndex + 1
@@ -4027,7 +4071,11 @@ final class CodeVisionOverlayController {
                 forGlyphRange: anchorContentGlyphRange,
                 in: textContainer
             )
-            let x = textView.textContainerOrigin.x + contentRect.maxX + 8
+            var x = textView.textContainerOrigin.x + contentRect.maxX + 8
+            if let foldSummaryMaxX = (textView as? CodeTextView)?
+                .collapsedFoldSummaryMaxX(forLine: hint.line) {
+                x = max(x, foldSummaryMaxX + Self.itemSpacing)
+            }
 
             var items: [NSButton] = []
             if hint.usageCount > 0 {

--- a/macos/Tests/LitheTests/EditorGutterLayoutTests.swift
+++ b/macos/Tests/LitheTests/EditorGutterLayoutTests.swift
@@ -37,6 +37,147 @@ struct EditorGutterLayoutTests {
     }
 
     @Test
+    func collapsedFoldKeepsItsStartLineAndHidesItsContents() {
+        let region = JavaFoldRegion(
+            kind: .method,
+            startLine: 4,
+            endLine: 8,
+            hiddenRange: NSRange(location: 0, length: 0)
+        )
+        let collapsedIDs: Set<String> = [region.id]
+
+        #expect(!EditorFoldVisibility.isLineHidden(
+            4,
+            regions: [region],
+            collapsedIDs: collapsedIDs
+        ))
+        #expect(EditorFoldVisibility.isLineHidden(
+            5,
+            regions: [region],
+            collapsedIDs: collapsedIDs
+        ))
+        #expect(EditorFoldVisibility.isLineHidden(
+            8,
+            regions: [region],
+            collapsedIDs: collapsedIDs
+        ))
+        #expect(!EditorFoldVisibility.isLineHidden(
+            9,
+            regions: [region],
+            collapsedIDs: collapsedIDs
+        ))
+    }
+
+    @Test
+    func expandedFoldDoesNotHideAnyLines() {
+        let region = JavaFoldRegion(
+            kind: .type,
+            startLine: 2,
+            endLine: 10,
+            hiddenRange: NSRange(location: 0, length: 0)
+        )
+
+        #expect(!EditorFoldVisibility.isLineHidden(
+            6,
+            regions: [region],
+            collapsedIDs: []
+        ))
+    }
+
+    @Test
+    func codeVisionExcludesHintsInsideCollapsedFolds() {
+        let region = JavaFoldRegion(
+            kind: .type,
+            startLine: 2,
+            endLine: 8,
+            hiddenRange: NSRange(location: 0, length: 0)
+        )
+        let hints = [
+            JavaCodeVisionHint(
+                line: 2,
+                utf16Column: 6,
+                symbol: "Example",
+                usageCount: 1,
+                implementationCount: 0,
+                authorName: "Ada"
+            ),
+            JavaCodeVisionHint(
+                line: 5,
+                utf16Column: 9,
+                symbol: "run",
+                usageCount: 2,
+                implementationCount: 1,
+                authorName: "Grace"
+            ),
+            JavaCodeVisionHint(
+                line: 9,
+                utf16Column: 4,
+                symbol: "After",
+                usageCount: 3,
+                implementationCount: 0,
+                authorName: nil
+            )
+        ]
+
+        let visibleHints = EditorFoldVisibility.visibleCodeVisionHints(
+            hints,
+            regions: [region],
+            collapsedIDs: [region.id]
+        )
+
+        #expect(visibleHints.map(\.symbol) == ["Example", "After"])
+    }
+
+    @MainActor
+    @Test
+    func codeVisionStartsAfterTheCollapsedFoldSummary() throws {
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 480, height: 160))
+        textView.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        textView.string = "class Example {\n    void run() {}\n}"
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        layoutManager.delegate = textView
+        layoutManager.ensureLayout(for: textContainer)
+
+        let source = textView.string as NSString
+        let hiddenRange = source.range(of: "\n    void run() {}\n}")
+        let region = JavaFoldRegion(
+            kind: .type,
+            startLine: 0,
+            endLine: 2,
+            hiddenRange: hiddenRange
+        )
+        textView.updateFolds(
+            regions: [region],
+            collapsedIDs: [region.id],
+            onToggle: { _ in }
+        )
+        let foldSummaryMaxX = try #require(
+            textView.collapsedFoldSummaryMaxX(forLine: 0)
+        )
+
+        let controller = CodeVisionOverlayController(textView: textView)
+        controller.update(
+            hints: [JavaCodeVisionHint(
+                line: 0,
+                utf16Column: 6,
+                symbol: "Example",
+                usageCount: 2,
+                implementationCount: 0,
+                authorName: nil
+            )],
+            onUsages: { _ in },
+            onImplementations: { _ in },
+            onAuthor: {}
+        )
+        let usageButton = try #require(
+            textView.subviews.compactMap { $0 as? NSButton }.first
+        )
+
+        #expect(usageButton.frame.minX >= foldSummaryMaxX + 4)
+    }
+
+    @Test
     func inlayLayoutChangesForceCodeVisionToReposition() {
         let plan = EditorOverlayUpdatePlan(
             codeVisionChanged: false,

--- a/macos/Tests/LitheTests/EditorGutterLayoutTests.swift
+++ b/macos/Tests/LitheTests/EditorGutterLayoutTests.swift
@@ -37,32 +37,43 @@ struct EditorGutterLayoutTests {
     }
 
     @Test
-    func collapsedFoldKeepsItsStartLineAndHidesItsContents() {
+    func collapsedFoldKeepsItsBoundaryLinesAndHidesItsContents() {
+        let source = """
+        void run() {
+            execute();
+            finish();
+        }
+        """ as NSString
+        let hiddenRange = source.range(of: "    execute();\n    finish();\n")
         let region = JavaFoldRegion(
             kind: .method,
-            startLine: 4,
-            endLine: 8,
-            hiddenRange: NSRange(location: 0, length: 0)
+            startLine: 0,
+            endLine: 3,
+            hiddenRange: hiddenRange
         )
         let collapsedIDs: Set<String> = [region.id]
 
         #expect(!EditorFoldVisibility.isLineHidden(
-            4,
+            0,
+            in: source,
             regions: [region],
             collapsedIDs: collapsedIDs
         ))
         #expect(EditorFoldVisibility.isLineHidden(
-            5,
+            1,
+            in: source,
             regions: [region],
             collapsedIDs: collapsedIDs
         ))
         #expect(EditorFoldVisibility.isLineHidden(
-            8,
+            2,
+            in: source,
             regions: [region],
             collapsedIDs: collapsedIDs
         ))
         #expect(!EditorFoldVisibility.isLineHidden(
-            9,
+            3,
+            in: source,
             regions: [region],
             collapsedIDs: collapsedIDs
         ))
@@ -70,15 +81,17 @@ struct EditorGutterLayoutTests {
 
     @Test
     func expandedFoldDoesNotHideAnyLines() {
+        let source = "class Example {\n    void run() {}\n}" as NSString
         let region = JavaFoldRegion(
             kind: .type,
-            startLine: 2,
-            endLine: 10,
-            hiddenRange: NSRange(location: 0, length: 0)
+            startLine: 0,
+            endLine: 2,
+            hiddenRange: source.range(of: "    void run() {}\n")
         )
 
         #expect(!EditorFoldVisibility.isLineHidden(
-            6,
+            1,
+            in: source,
             regions: [region],
             collapsedIDs: []
         ))
@@ -86,15 +99,21 @@ struct EditorGutterLayoutTests {
 
     @Test
     func codeVisionExcludesHintsInsideCollapsedFolds() {
+        let source = """
+        class Example {
+            void run() {}
+        }
+        class After {}
+        """ as NSString
         let region = JavaFoldRegion(
             kind: .type,
-            startLine: 2,
-            endLine: 8,
-            hiddenRange: NSRange(location: 0, length: 0)
+            startLine: 0,
+            endLine: 2,
+            hiddenRange: source.range(of: "    void run() {}\n")
         )
         let hints = [
             JavaCodeVisionHint(
-                line: 2,
+                line: 0,
                 utf16Column: 6,
                 symbol: "Example",
                 usageCount: 1,
@@ -102,7 +121,7 @@ struct EditorGutterLayoutTests {
                 authorName: "Ada"
             ),
             JavaCodeVisionHint(
-                line: 5,
+                line: 1,
                 utf16Column: 9,
                 symbol: "run",
                 usageCount: 2,
@@ -110,7 +129,7 @@ struct EditorGutterLayoutTests {
                 authorName: "Grace"
             ),
             JavaCodeVisionHint(
-                line: 9,
+                line: 3,
                 utf16Column: 4,
                 symbol: "After",
                 usageCount: 3,
@@ -121,11 +140,61 @@ struct EditorGutterLayoutTests {
 
         let visibleHints = EditorFoldVisibility.visibleCodeVisionHints(
             hints,
+            in: source,
             regions: [region],
             collapsedIDs: [region.id]
         )
 
         #expect(visibleHints.map(\.symbol) == ["Example", "After"])
+    }
+
+    @Test
+    func collapsedFoldKeepsCodeVisionOnItsClosingLine() {
+        let source = """
+        void first() {
+            execute();
+        } void next() {
+        }
+        """ as NSString
+        let region = JavaFoldRegion(
+            kind: .method,
+            startLine: 0,
+            endLine: 2,
+            hiddenRange: source.range(of: "    execute();\n")
+        )
+        let hints = [
+            JavaCodeVisionHint(
+                line: 1,
+                utf16Column: 4,
+                symbol: "execute",
+                usageCount: 1,
+                implementationCount: 0,
+                authorName: nil
+            ),
+            JavaCodeVisionHint(
+                line: 2,
+                utf16Column: 7,
+                symbol: "next",
+                usageCount: 2,
+                implementationCount: 0,
+                authorName: "Ada"
+            )
+        ]
+
+        let visibleHints = EditorFoldVisibility.visibleCodeVisionHints(
+            hints,
+            in: source,
+            regions: [region],
+            collapsedIDs: [region.id]
+        )
+
+        #expect(visibleHints.map(\.symbol) == ["next"])
+        #expect(!EditorFoldVisibility.isLineHidden(
+            2,
+            in: source,
+            regions: [region],
+            collapsedIDs: [region.id]
+        ))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- hide Code Vision and blame controls only for lines whose starts fall inside collapsed fold ranges, preserving visible start and closing boundary lines
- position Code Vision after the collapsed fold summary so usages and author labels cannot overlap the ellipsis
- add regression coverage for collapsed-line visibility, same-line declarations after a closing brace, and fold-summary spacing

## Validation

- `./scripts/test-macos.sh --filter EditorGutterLayoutTests` — 25 tests passed
- `./scripts/test-macos.sh` — 627 tests across 74 suites passed
- `./scripts/verify-service-boundaries.sh` — passed
- manually verified folding, expanding, and re-folding a long Java class in the latest macOS preview build