### PR TITLE
fix(macos): 对齐 IDEA 的通知时间与活动栏底部布局

### DIFF
--- a/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
+++ b/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
@@ -1164,7 +1164,7 @@ private struct WorkbenchNotificationCenterView: View {
                                         .foregroundStyle(LitheTheme.primaryText)
                                         .fixedSize(horizontal: false, vertical: true)
 
-                                    Text(notification.createdAt, style: .relative)
+                                    Text(notification.createdAt.formatted(date: .omitted, time: .shortened))
                                         .font(.system(size: 10.5))
                                         .foregroundStyle(LitheTheme.tertiaryText)
                                 }

--- a/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
+++ b/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
@@ -15,6 +15,7 @@ private enum ActivityBarMetrics {
     static let buttonHeight: CGFloat = 30
     static let spacing: CGFloat = 4
     static let edgeInset: CGFloat = 4
+    static let toolViewportHeight: CGFloat = 292
 }
 
 private enum WorkbenchWorkspaceMetrics {
@@ -592,31 +593,37 @@ struct WorkbenchView: View {
 
                 ScrollView(.vertical, showsIndicators: false) {
                     VStack(spacing: ActivityBarMetrics.spacing) {
-                    ForEach(model.activityBarContributions) { contribution in
-                        if let renderer = moduleUIRegistry.renderer(for: contribution),
-                           renderer.isVisible(model) {
-                            activityToolButton(
-                                systemImage: contribution.icon ?? "square.grid.2x2",
-                                ideaAssetPath: renderer.ideaAssetPath,
-                                help: contribution.title,
-                                isSelected: renderer.isSelected(model)
-                            ) {
-                                moduleUIRegistry.perform(contribution, model: model)
+                        ForEach(model.activityBarContributions) { contribution in
+                            if let renderer = moduleUIRegistry.renderer(for: contribution),
+                               renderer.isVisible(model) {
+                                activityToolButton(
+                                    systemImage: contribution.icon ?? "square.grid.2x2",
+                                    ideaAssetPath: renderer.ideaAssetPath,
+                                    help: contribution.title,
+                                    isSelected: renderer.isSelected(model)
+                                ) {
+                                    moduleUIRegistry.perform(contribution, model: model)
+                                }
                             }
                         }
-                    }
 
-                    activityToolButton(
-                        systemImage: "gearshape",
-                        ideaAssetPath: "general/gear.svg",
-                        help: "Settings",
-                        isSelected: model.isSettingsPresented
-                    ) {
-                        model.showSettings()
+                        activityToolButton(
+                            systemImage: "gearshape",
+                            ideaAssetPath: "general/gear.svg",
+                            help: "Settings",
+                            isSelected: model.isSettingsPresented
+                        ) {
+                            model.showSettings()
+                        }
                     }
-                    }
+                    // Keep short tool lists against the status bar while preserving
+                    // vertical scrolling when modules add more activity buttons.
+                    .frame(
+                        minHeight: ActivityBarMetrics.toolViewportHeight,
+                        alignment: .bottom
+                    )
                 }
-                .frame(height: 292)
+                .frame(height: ActivityBarMetrics.toolViewportHeight)
                 .padding(.bottom, ActivityBarMetrics.edgeInset)
             }
             .frame(width: ActivityBarMetrics.width, height: geometry.size.height, alignment: .top)


### PR DESCRIPTION
## 摘要

- 将工作台通知时间显示为遵循当前区域设置的短格式具体时间。
- 替换会随着时间推移持续刷新的相对时间文本，减少不必要的持续渲染。
- 将左侧活动栏底部工具组贴近状态栏排列，使底部间距与 IntelliJ IDEA 保持一致。
- 保留活动栏工具数量增加时的垂直滚动能力。

## 具体调整

- 使用本地化的短时间格式显示通知创建时间。
- 为活动栏底部工具区域提取统一的视口高度指标。
- 对短工具列表使用底部对齐，使设置按钮和插件入口稳定靠近状态栏。
- 当模块注册更多活动栏入口时，继续通过无滚动条的垂直滚动区域访问全部工具。

## 影响范围

本次改动仅影响 macOS 工作台视图中的通知时间文本和左侧活动栏底部工具布局。通知创建、存储、排序和清除行为不变，活动栏按钮行为及模块注册机制也不受影响。

## 验证

- `./scripts/verify-service-boundaries.sh`
- `./scripts/test-macos.sh`
  - 74 个测试套件中的 622 项测试全部通过

## 截图

改动前后的效果截图及补充说明已在 PR 评论中提供。
