### PR TITLE
fix(macos): 对齐 IDEA 项目树布局指标

### DIFF
--- a/macos/Sources/Lithe/Theme/LitheTheme.swift
+++ b/macos/Sources/Lithe/Theme/LitheTheme.swift
@@ -391,6 +391,12 @@ enum LitheTheme {
     enum Metrics {
         static let rowHeight: CGFloat = 24
         static let treeRowHeight: CGFloat = 27
+        // IntelliJ IDEA New UI uses contiguous project-tree rows, 4/12 pt
+        // tree insets, and an 8 pt selection arc (4 pt corner radius).
+        static let projectTreeRowSpacing: CGFloat = 0
+        static let projectTreeContentVerticalInset: CGFloat = 4
+        static let projectTreeContentHorizontalInset: CGFloat = 12
+        static let projectTreeSelectionCornerRadius: CGFloat = 4
         static let treeIconSize: CGFloat = 16
         static let treeFontSize: CGFloat = 13.5
         static let tabHeight: CGFloat = 34

--- a/macos/Sources/Lithe/Views/Workspace/ProjectSidebarView.swift
+++ b/macos/Sources/Lithe/Views/Workspace/ProjectSidebarView.swift
@@ -26,7 +26,10 @@ struct ProjectSidebarView: View {
                         ScrollView([.vertical, .horizontal]) {
                             // The recursive tree is one scroll-content child. An eager stack
                             // must measure its full height so AppKit receives a real scroll range.
-                            VStack(alignment: .leading, spacing: 1) {
+                            VStack(
+                                alignment: .leading,
+                                spacing: LitheTheme.Metrics.projectTreeRowSpacing
+                            ) {
                                 ProjectFileTreeContent(
                                     root: root,
                                     availableWidth: geometry.size.width,
@@ -42,7 +45,7 @@ struct ProjectSidebarView: View {
                                 )
                                 .equatable()
                             }
-                            .padding(.vertical, 5)
+                            .padding(.vertical, LitheTheme.Metrics.projectTreeContentVerticalInset)
                             .frame(
                                 minWidth: geometry.size.width,
                                 minHeight: geometry.size.height,
@@ -308,8 +311,6 @@ private struct ProjectFileTreeContent: View, Equatable {
 }
 
 private struct FileNodeRow: View {
-    private static let horizontalInset: CGFloat = 10
-
     let node: FileNode
     let depth: Int
     let availableWidth: CGFloat
@@ -322,7 +323,7 @@ private struct FileNodeRow: View {
 
     private var rowWidth: CGFloat {
         max(
-            availableWidth - (Self.horizontalInset * 2),
+            availableWidth - (LitheTheme.Metrics.projectTreeContentHorizontalInset * 2),
             CGFloat(depth * 14 + 8 + 180)
         )
     }
@@ -333,20 +334,25 @@ private struct FileNodeRow: View {
 
     var body: some View {
         if node.isDirectory {
-            directoryRow
-            if isExpanded {
-                ForEach(node.children ?? []) { child in
-                    FileNodeRow(
-                        node: child,
-                        depth: depth + 1,
-                        availableWidth: availableWidth,
-                        rowHeight: rowHeight,
-                        activeDocumentURL: activeDocumentURL,
-                        gitStatus: gitStatus,
-                        actions: actions,
-                        expandedDirectoryPaths: $expandedDirectoryPaths
-                    )
-                    .id(child.url.standardizedFileURL.path)
+            VStack(
+                alignment: .leading,
+                spacing: LitheTheme.Metrics.projectTreeRowSpacing
+            ) {
+                directoryRow
+                if isExpanded {
+                    ForEach(node.children ?? []) { child in
+                        FileNodeRow(
+                            node: child,
+                            depth: depth + 1,
+                            availableWidth: availableWidth,
+                            rowHeight: rowHeight,
+                            activeDocumentURL: activeDocumentURL,
+                            gitStatus: gitStatus,
+                            actions: actions,
+                            expandedDirectoryPaths: $expandedDirectoryPaths
+                        )
+                        .id(child.url.standardizedFileURL.path)
+                    }
                 }
             }
         } else {
@@ -386,13 +392,13 @@ private struct FileNodeRow: View {
             .frame(height: rowHeight)
             .contentShape(Rectangle())
             .litheRowHover(
-                cornerRadius: 4,
+                cornerRadius: LitheTheme.Metrics.projectTreeSelectionCornerRadius,
                 animation: nil
             )
         }
         .buttonStyle(LitheTreeRowButtonStyle())
         .lithePointer()
-        .padding(.horizontal, Self.horizontalInset)
+        .padding(.horizontal, LitheTheme.Metrics.projectTreeContentHorizontalInset)
         .contextMenu { directoryContextMenu }
     }
 
@@ -426,14 +432,14 @@ private struct FileNodeRow: View {
             .litheRowHover(
                 isActive: activeDocumentURL?.standardizedFileURL.path
                     == node.url.standardizedFileURL.path,
-                cornerRadius: 4,
+                cornerRadius: LitheTheme.Metrics.projectTreeSelectionCornerRadius,
                 activeBackground: LitheTheme.subtleSelection,
                 animation: nil
             )
         }
         .buttonStyle(LitheTreeRowButtonStyle())
         .lithePointer()
-        .padding(.horizontal, Self.horizontalInset)
+        .padding(.horizontal, LitheTheme.Metrics.projectTreeContentHorizontalInset)
         .contextMenu { fileContextMenu }
         .task(id: node.url.standardizedFileURL.path) {
             guard node.url.pathExtension.lowercased() == "java" else { return }

--- a/macos/Tests/LitheTests/ProjectTreeLayoutMetricsTests.swift
+++ b/macos/Tests/LitheTests/ProjectTreeLayoutMetricsTests.swift
@@ -1,0 +1,13 @@
+import Testing
+@testable import Lithe
+
+struct ProjectTreeLayoutMetricsTests {
+    @Test
+    func treeRowsMatchIntelliJNewUILayoutMetrics() {
+        #expect(LitheTheme.Metrics.projectTreeRowSpacing == 0)
+        #expect(LitheTheme.Metrics.projectTreeContentVerticalInset == 4)
+        #expect(LitheTheme.Metrics.projectTreeContentHorizontalInset == 12)
+        #expect(LitheTheme.Metrics.projectTreeSelectionCornerRadius == 4)
+        #expect(LitheTheme.Metrics.treeIconSize == 16)
+    }
+}


### PR DESCRIPTION
## 摘要

- 对齐 macOS 项目树与 IntelliJ IDEA New UI 的行间距和内容边距。
- 使用连续的项目树行，并统一递归目录节点的布局方式。
- 将项目树间距和选中状态指标集中到 `LitheTheme.Metrics`。
- 增加布局指标回归测试，防止后续修改破坏已对齐的视觉参数。

## 布局调整

- 项目树行间距调整为 `0`。
- 内容垂直边距调整为 `4` 点。
- 内容水平边距调整为 `12` 点。
- 选中区域圆角统一为 `4` 点。
- 对递归渲染的目录子节点应用相同的行间距策略。

## 影响范围

本次改动仅影响 macOS 项目树的视觉布局。文件发现、目录展开、文件选择、Git 状态投影、文件打开以及右键菜单行为均保持不变。

## 验证

- `./scripts/verify-service-boundaries.sh`
- `./scripts/test-macos.sh`
  - 75 个测试套件中的 623 项测试全部通过
- 新增 `ProjectTreeLayoutMetricsTests`，用于保护与 IDEA 对齐的布局常量。

## 截图

本次未附带截图；关键布局指标已由自动化回归测试覆盖。
