### PR TITLE
fix(macos): 修正插件 LSP 能力声明与激活条件

### DIFF
--- a/macos/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -1325,8 +1325,14 @@ final class AppModel: ObservableObject, Identifiable {
             }
         }
         if let ownership = services.pluginCatalog.languageSupport(for: document.url),
-           ownership.declaration.languageServerModuleID != nil {
+           let moduleID = ownership.declaration.languageServerModuleID {
             let support = ownership.declaration
+            // Static plugin metadata may exist before a native plugin is loaded.
+            // Only a registered and enabled module may enter LSP activation.
+            guard let snapshot = try? services.moduleRuntime.snapshot(for: moduleID),
+                  snapshot.state != .disabled else {
+                return false
+            }
             let capabilityID = ModuleCapabilityID.languageServerExtension(support.id)
             if services.moduleRuntime.capability(capabilityID) == nil {
                 Task { [weak self, weak document] in

--- a/macos/Sources/Lithe/Platform/MacOS/MacServiceContainer.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/MacServiceContainer.swift
@@ -183,7 +183,7 @@ final class MacServiceContainer {
         // manifests below contribute factories; keeping static ownership here
         // prevents the host from silently restoring its legacy process path.
         let installedPluginManifests = pluginStartup.installedManifests
-        let installedLanguageSupports = bundledLanguageManifests.flatMap { $0.languageSupports ?? [] }
+        let installedLanguageSupports = BundledLanguagePluginCatalog.languageSupports
             + pluginStartup.installedLanguageSupports
         let languageProviderCatalogSource = PluginLanguageProviderCatalogSource(
             base: rustLanguageProviderCatalogSource,
@@ -420,10 +420,12 @@ final class MacServiceContainer {
                 }
             }
             for specification in BundledLanguagePluginCatalog.specifications {
-                let languageServerModule = BundledLanguageServerModule(specification: specification)
-                try moduleRegistry.register(ModuleFactory(manifest: languageServerModule.manifest) {
-                    BundledLanguageServerModule(specification: specification)
-                })
+                if specification.supportsLanguageServer {
+                    let languageServerModule = BundledLanguageServerModule(specification: specification)
+                    try moduleRegistry.register(ModuleFactory(manifest: languageServerModule.manifest) {
+                        BundledLanguageServerModule(specification: specification)
+                    })
+                }
                 if specification.supportsExecution {
                     let executionModule = BundledLanguageExecutionModule(
                         languageID: specification.id,

--- a/macos/Sources/LitheModuleAPI/Catalog/BundledLanguagePluginCatalog.swift
+++ b/macos/Sources/LitheModuleAPI/Catalog/BundledLanguagePluginCatalog.swift
@@ -11,6 +11,12 @@ public struct BundledLanguagePluginSpecification: Sendable {
     public let languageIdentifier: String
     public let supportsExecution: Bool
 
+    /// A language-server module is only real when the host has at least one
+    /// executable candidate it can launch through the generic LSP runtime.
+    public var supportsLanguageServer: Bool {
+        !executableNames.isEmpty
+    }
+
     public init(
         id: String,
         displayName: String,
@@ -34,8 +40,9 @@ public struct BundledLanguagePluginSpecification: Sendable {
     }
 }
 
-/// Non-Java language providers are independently manageable bundled plugins.
-/// Go remains an official native package and is therefore not duplicated here.
+/// Describes bundled non-Java language recognition and the process-backed
+/// features that are independently manageable as plugins. Go remains an
+/// official native package and is therefore not duplicated here.
 public enum BundledLanguagePluginCatalog {
     public static let specifications: [BundledLanguagePluginSpecification] = [
         .init(id: "python", displayName: "Python", fileExtensions: ["py", "pyw"], executableNames: ["basedpyright-langserver", "pyright-langserver"], arguments: ["--stdio"], supportsExecution: true),
@@ -84,14 +91,24 @@ public enum BundledLanguagePluginCatalog {
         .init(id: "solidity", displayName: "Solidity", fileExtensions: ["sol"])
     ]
 
-    public static let manifests: [PluginManifest] = specifications.map(makeManifest).sorted { $0.id < $1.id }
+    public static let languageSupports: [LanguageSupportDeclaration] = specifications
+        .map(makeLanguageSupport)
+        .sorted { $0.id < $1.id }
+
+    public static let manifests: [PluginManifest] = specifications
+        .filter { $0.supportsLanguageServer || $0.supportsExecution }
+        .map(makeManifest)
+        .sorted { $0.id < $1.id }
 
     public static func specification(languageID: String) -> BundledLanguagePluginSpecification? {
         specifications.first { $0.id == languageID }
     }
 
     private static func makeManifest(_ specification: BundledLanguagePluginSpecification) -> PluginManifest {
-        var modules = [PluginModuleDeclaration(manifest: languageServerManifest(specification))]
+        var modules: [PluginModuleDeclaration] = []
+        if specification.supportsLanguageServer {
+            modules.append(PluginModuleDeclaration(manifest: languageServerManifest(specification)))
+        }
         if specification.supportsExecution {
             modules.append(PluginModuleDeclaration(manifest: executionManifest(specification)))
         }
@@ -106,15 +123,27 @@ public enum BundledLanguagePluginCatalog {
             vendor: BuiltInPluginCatalog.vendor,
             entrypoint: .builtIn(targetName: "LitheLanguageSupportModules"),
             modules: modules,
-            languageSupports: [LanguageSupportDeclaration(
-                id: specification.id,
-                displayName: specification.displayName,
-                fileExtensions: specification.fileExtensions,
-                fileNames: specification.fileNames,
-                languageServerModuleID: .languageServerExtension(specification.id),
-                executionModuleID: specification.supportsExecution ? .languageExecutionExtension(specification.id) : nil,
-                testingModuleID: specification.supportsExecution ? .languageExecutionExtension(specification.id) : nil
-            )]
+            languageSupports: [makeLanguageSupport(specification)]
+        )
+    }
+
+    private static func makeLanguageSupport(
+        _ specification: BundledLanguagePluginSpecification
+    ) -> LanguageSupportDeclaration {
+        LanguageSupportDeclaration(
+            id: specification.id,
+            displayName: specification.displayName,
+            fileExtensions: specification.fileExtensions,
+            fileNames: specification.fileNames,
+            languageServerModuleID: specification.supportsLanguageServer
+                ? .languageServerExtension(specification.id)
+                : nil,
+            executionModuleID: specification.supportsExecution
+                ? .languageExecutionExtension(specification.id)
+                : nil,
+            testingModuleID: specification.supportsExecution
+                ? .languageExecutionExtension(specification.id)
+                : nil
         )
     }
 

--- a/macos/Tests/LitheTests/LanguageProviderCatalogSourceTests.swift
+++ b/macos/Tests/LitheTests/LanguageProviderCatalogSourceTests.swift
@@ -149,6 +149,29 @@ struct LanguageProviderCatalogSourceTests {
         #expect(provider.languageServerLaunch == nil)
     }
 
+    @Test
+    func syntaxOnlyBundledLanguagesDoNotAdvertiseAnUnimplementedServer() throws {
+        let source = PluginLanguageProviderCatalogSource(
+            base: RustLanguageProviderCatalogSource(loader: CatalogPayloadLoader(
+                isAvailable: false,
+                data: nil
+            )),
+            languageSupports: BundledLanguagePluginCatalog.languageSupports
+        )
+        let catalog = source.load().catalog
+        let markdown = try #require(catalog.provider(
+            for: URL(fileURLWithPath: "/tmp/README.md")
+        ))
+        let yaml = try #require(catalog.provider(
+            for: URL(fileURLWithPath: "/tmp/config.yaml")
+        ))
+
+        #expect(!markdown.capabilities.contains(.languageServer))
+        #expect(yaml.capabilities.contains(.languageServer))
+        #expect(markdown.languageServerLaunch == nil)
+        #expect(yaml.languageServerLaunch == nil)
+    }
+
     private func catalogPayload(origin: String, diagnostics: String = "[]") -> Data {
         Data("""
         {

--- a/macos/Tests/LitheTests/PluginManagerTests.swift
+++ b/macos/Tests/LitheTests/PluginManagerTests.swift
@@ -7,7 +7,7 @@ import Testing
 @MainActor
 struct PluginManagerTests {
     @Test
-    func bundledLanguagePluginsCoverEveryNonJavaNonGoProvider() throws {
+    func bundledLanguageCatalogOnlyCreatesPluginsForImplementedProcessFeatures() throws {
         let expectedIDs: Set<String> = [
             "python", "node", "rust", "clangd", "csharp", "fsharp", "swift", "kotlin", "scala", "groovy",
             "ruby", "php", "dart", "lua", "shell", "powershell", "html", "css", "vue", "svelte", "astro",
@@ -16,10 +16,28 @@ struct PluginManagerTests {
             "r", "perl", "zig", "solidity"
         ]
         #expect(Set(BundledLanguagePluginCatalog.specifications.map(\.id)) == expectedIDs)
-        #expect(BundledLanguagePluginCatalog.manifests.count == expectedIDs.count)
+        #expect(Set(BundledLanguagePluginCatalog.languageSupports.map(\.id)) == expectedIDs)
+
+        let expectedPluginIDs = Set(
+            BundledLanguagePluginCatalog.specifications
+                .filter { $0.supportsLanguageServer || $0.supportsExecution }
+                .map(\.id)
+        )
+        #expect(Set(BundledLanguagePluginCatalog.manifests.compactMap {
+            $0.languageSupports?.first?.id
+        }) == expectedPluginIDs)
         #expect(BundledLanguagePluginCatalog.manifests.flatMap(\.modules).allSatisfy {
             $0.manifest.defaultState == .disabled
         })
+
+        let markdown = try #require(BundledLanguagePluginCatalog.languageSupports.first {
+            $0.id == "markdown"
+        })
+        let yaml = try #require(BundledLanguagePluginCatalog.languageSupports.first {
+            $0.id == "yaml"
+        })
+        #expect(markdown.languageServerModuleID == nil)
+        #expect(yaml.languageServerModuleID == .languageServerExtension("yaml"))
         let officialLanguagePlugins = OfficialPluginCatalog.manifests.filter {
             !($0.languageSupports ?? []).isEmpty
         }

--- a/macos/Tests/LitheTests/WorkbenchNotificationTests.swift
+++ b/macos/Tests/LitheTests/WorkbenchNotificationTests.swift
@@ -32,6 +32,43 @@ struct WorkbenchNotificationTests {
         #expect(model.notifications.isEmpty)
         #expect(model.notificationMessage == nil)
     }
+
+    @Test
+    func disabledYAMLLanguageServerDoesNotShowAStartupError() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lithe-disabled-yaml-lsp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = WorkbenchNotificationTestStore()
+        let settings = AppSettings(store: store)
+        let services = MacServiceContainer(
+            store: store,
+            settings: settings,
+            moduleLaunchMode: .safeMode
+        ).services
+        let model = AppModel(settings: settings, services: services)
+        model.openProjectDirectly(root)
+        model.clearNotifications()
+
+        let document = EditorDocument(
+            url: root.appendingPathComponent("config.yaml"),
+            text: "enabled: true\n",
+            modificationDate: nil
+        )
+
+        #expect(!model.activateLanguageServerIfAvailable(for: document))
+
+        // A regression used to enqueue activation and report moduleDisabled on
+        // the next task turn, so yield before checking the notification queue.
+        for _ in 0..<5 {
+            await Task.yield()
+        }
+        #expect(!model.notifications.contains {
+            $0.message.contains("Could not start YAML language server")
+        })
+    }
+
 }
 
 private final class WorkbenchNotificationTestStore: KeyValueStore, @unchecked Sendable {


### PR DESCRIPTION
## 摘要

- 区分内置语言识别能力与真正实现的进程型语言服务器能力。
- 仅为存在可执行程序候选的语言声明并注册 LSP 模块。
- 在发起 LSP 激活前确认对应模块已注册且未被禁用。
- 避免禁用的内置语言服务器产生误导性的启动失败通知。
- 增加语言目录、插件清单和通知行为的回归测试。

## 具体调整

- 根据 `executableNames` 判断内置语言是否真正支持语言服务器。
- 保留所有内置语言的文件识别声明，但只为实现了 LSP 或执行能力的语言生成插件 Manifest。
- 只为真正支持 LSP 的语言注册 `BundledLanguageServerModule`。
- Markdown 等仅提供语法识别的语言不再声明未实现的语言服务器能力。
- YAML 继续声明可用的 LSP 能力，但默认禁用时不会进入激活流程。
- 当静态插件元数据存在、但模块未注册或已禁用时，直接跳过 LSP 激活。

## 影响范围

本次改动影响 macOS 内置语言插件目录、模块注册和 LSP 激活判断。语言文件识别仍然保留；Java 和 Go 的独立语言支持路径不受影响。

## 回归测试

- 验证纯语法语言不会声明未实现的语言服务器。
- 验证只有实现进程型能力的内置语言才生成插件 Manifest。
- 验证 Markdown 不包含 LSP 能力，而 YAML 仍包含 LSP 能力。
- 验证禁用的 YAML 语言服务器不会产生启动错误通知。

## 验证

- `./scripts/verify-service-boundaries.sh`
- `./scripts/verify-official-plugins.sh`
  - 2 个官方原生插件包验证通过
- `./scripts/test-macos.sh`
  - 74 个测试套件中的 624 项测试全部通过
