### PR TITLE
perf(macos): 集成终端 Metal 渲染

### DIFF
--- a/macos/Sources/Lithe/Platform/MacOS/Terminal/MacTerminalTransport.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/Terminal/MacTerminalTransport.swift
@@ -8,6 +8,45 @@ import LitheTerminalModule
 final class LitheTerminalView: LocalProcessTerminalView {
     var onOpenLink: ((String, [String: String]) -> Void)?
     private var showsWorkbenchBackground = false
+    private weak var metalActivationFailedWindow: NSWindow?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        configureRendererPolicy()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureRendererPolicy()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard let currentWindow = window,
+              !isUsingMetalRenderer,
+              currentWindow !== metalActivationFailedWindow else { return }
+
+        do {
+            try setUseMetal(true)
+            metalActivationFailedWindow = nil
+        } catch {
+            // A different window gets one fresh attempt because SwiftTerm's
+            // CAMetalLayer must be rebound when the persistent terminal moves.
+            metalActivationFailedWindow = currentWindow
+            NSLog(
+                "Lithe terminal Metal renderer could not be enabled; using Core Graphics: %@",
+                String(describing: error)
+            )
+        }
+    }
+
+    private func configureRendererPolicy() {
+        // Ghostty's renderer keeps unchanged terminal content on the GPU and
+        // redraws only invalidated cells. SwiftTerm's persistent row mode gives
+        // Lithe the same workload shape while its paused MTKView remains
+        // event-driven instead of running a continuous display loop.
+        metalBufferingMode = .perRowPersistent
+    }
 
     override func menu(for event: NSEvent) -> NSMenu? {
         let menu = NSMenu()

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -87,15 +87,20 @@ else
     cp "$arch_binary" "$APP_DIR/Contents/MacOS/Lithe"
 fi
 if [[ "$ARCH" == "universal" ]]; then
-    resource_bundle="$ROOT_DIR/.build/$ARM64_TRIPLE/release/Lithe_Lithe.bundle"
+    swiftpm_resource_root="$ROOT_DIR/.build/$ARM64_TRIPLE/release"
 else
-    resource_bundle="$ROOT_DIR/.build/$ARCH-apple-macosx/release/Lithe_Lithe.bundle"
+    swiftpm_resource_root="$ROOT_DIR/.build/$ARCH-apple-macosx/release"
 fi
-if [[ ! -d "$resource_bundle" ]]; then
-    print -u2 -- "Missing SwiftPM resource bundle: $resource_bundle"
-    exit 1
-fi
-cp -R "$resource_bundle" "$APP_DIR/Contents/Resources/Lithe_Lithe.bundle"
+# SwiftTerm compiles its Metal shaders from this SwiftPM bundle at runtime.
+# Without it, setUseMetal(true) falls back to Core Graphics in packaged apps.
+for bundle_name in Lithe_Lithe.bundle SwiftTerm_SwiftTerm.bundle; do
+    resource_bundle="$swiftpm_resource_root/$bundle_name"
+    if [[ ! -d "$resource_bundle" ]]; then
+        print -u2 -- "Missing SwiftPM resource bundle: $resource_bundle"
+        exit 1
+    fi
+    cp -R "$resource_bundle" "$APP_DIR/Contents/Resources/$bundle_name"
+done
 mkdir -p "$APP_DIR/Contents/Resources/LanguageServers"
 cp -R "$JDTLS_ROOT" "$APP_DIR/Contents/Resources/LanguageServers/jdtls"
 cp -R "$JDK_ROOT" "$APP_DIR/Contents/Resources/LanguageServers/jdk"

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -30,6 +30,12 @@ mkdir -p \
     "$APP_DIR/Contents/Resources/OfficialPlugins" \
     "$APP_DIR/Contents/Helpers"
 cp ".build/$TRIPLE/debug/Lithe" "$APP_DIR/Contents/MacOS/Lithe"
+swiftterm_resource_bundle=".build/$TRIPLE/debug/SwiftTerm_SwiftTerm.bundle"
+if [[ ! -d "$swiftterm_resource_bundle" ]]; then
+    print -u2 -- "Missing SwiftTerm Metal resource bundle: $swiftterm_resource_bundle"
+    exit 1
+fi
+cp -R "$swiftterm_resource_bundle" "$APP_DIR/Contents/Resources/SwiftTerm_SwiftTerm.bundle"
 cp -R "$JDTLS_ROOT" "$APP_DIR/Contents/Resources/LanguageServers/jdtls"
 cp -R "$JDK_ROOT" "$APP_DIR/Contents/Resources/LanguageServers/jdk"
 plugin_root=$(scripts/build-official-plugins.sh --configuration debug --triple "$TRIPLE")

--- a/scripts/verify-macos-app-build-safety.sh
+++ b/scripts/verify-macos-app-build-safety.sh
@@ -33,6 +33,10 @@ for packaging_script in scripts/package-app.sh scripts/preview.sh; do
         print -u2 -- "$packaging_script must stamp traceable build metadata"
         exit 1
     fi
+    if ! /usr/bin/grep -Fq -- 'SwiftTerm_SwiftTerm.bundle' "$packaging_script"; then
+        print -u2 -- "$packaging_script must package SwiftTerm's Metal shader resources"
+        exit 1
+    fi
 done
 
 temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/lithe-build-info-verification.XXXXXX")

--- a/scripts/verify-macos-package.sh
+++ b/scripts/verify-macos-package.sh
@@ -78,6 +78,7 @@ done
 required_resources=(
     "$app_path/Contents/Info.plist"
     "$app_path/Contents/Resources/Lithe_Lithe.bundle"
+    "$app_path/Contents/Resources/SwiftTerm_SwiftTerm.bundle/Shaders.metal"
     "$app_path/Contents/Resources/LanguageServers/jdtls/bin/jdtls"
     "$app_path/Contents/Resources/LanguageServers/jdk/bin/java"
     "$app_path/Contents/Resources/LanguageServers/jdk/lib"


### PR DESCRIPTION
## 摘要

- 为 macOS 终端启用 SwiftTerm Metal 渲染。
- 使用按行持久化缓冲模式，减少未变化终端内容的重复绘制。
- 在 Metal 初始化失败时保留 Core Graphics 回退路径。
- 将 SwiftTerm 的 Metal Shader 资源纳入开发预览和正式应用打包流程。
- 增加构建安全检查及最终应用包资源验证。

## 具体调整

- 在 `LitheTerminalView` 初始化时配置 `.perRowPersistent` Metal 缓冲模式。
- 在终端视图关联到窗口后调用 `setUseMetal(true)`，确保 SwiftTerm 的 `CAMetalLayer` 已具备有效窗口环境。
- 持久终端视图移动到其他窗口时允许重新绑定和启用 Metal。
- 当 Metal 激活失败时记录诊断信息并继续使用 Core Graphics。
- 对同一个失败窗口不进行重复激活，避免反复产生失败日志。
- 在 `preview.sh` 中复制 `SwiftTerm_SwiftTerm.bundle`。
- 在正式应用打包时同时复制 Lithe 和 SwiftTerm 的 SwiftPM 资源包。
- 检查最终应用包中是否包含 `SwiftTerm_SwiftTerm.bundle/Shaders.metal`。

## 影响范围

本次改动影响 macOS 终端的渲染后端以及应用资源打包流程。终端会话、PTY 进程、标签页切换和命令执行行为保持不变。

Metal 不可用或初始化失败时，终端会继续通过 Core Graphics 渲染，不会阻止终端使用。

## 测试环境

- 系统：macOS 27.0（Build `26A5421a`）
- 架构：Apple Silicon `arm64`
- Xcode：26.6（Build `17F113`）
- Swift：Apple Swift 6.3.3
- Rust：`rustc 1.96.0`
- SwiftTerm：1.15.0

## 详细验证数据

### 最新 `preview` 基线上的最终验证

最终提交：`45329b43 perf(macos): 集成终端 Metal 渲染`

基线提交：`8694dbf1 Merge pull request #261 from 1lck/codex/fix-folded-code-vision-layout`

#### 服务和构建边界

运行：

```bash
./scripts/verify-service-boundaries.sh
```

结果：

- macOS App build safety verification passed
- Service boundary verification passed
- Core、Services、UI 和 AppModel composition boundaries 均保持完整
- `package-app.sh` 和 `preview.sh` 均通过 SwiftTerm Metal 资源打包规则检查

#### macOS 测试

运行：

```bash
./scripts/test-macos.sh
```

结果：

- Debug 构建完成：18.16 秒
- 测试执行完成：18.837 秒
- 测试套件：74
- 测试数量：627
- 失败：0
- 非预期失败：0

构建日志同时确认 SwiftPM 已处理：

```text
Copying Shaders.metal
Compiling Lithe MacTerminalTransport.swift
```

#### 应用包和 DMG 验证

运行：

```bash
./scripts/verify-macos-package.sh
```

结果：

- macOS App build safety verification passed
- Swift Production 构建完成：72.19 秒
- `lithe-core` Release 构建通过
- `lithe-db-sidecar` Release 构建通过
- `lithe-db-mcp` Release 构建通过
- 2 个官方原生插件包完成构建和签名
- arm64 应用包完成组装和签名
- `codesign --verify --deep --strict` 通过
- `SwiftTerm_SwiftTerm.bundle/Shaders.metal` 存在性检查通过
- JDTLS 和内置 JDK 资源检查通过
- JDK arm64 架构检查通过
- arm64 DMG 创建成功
- DMG 镜像完整性检查通过
- 最终结果：`macOS package and disk image verification passed for arm64`

最终打包身份信息：

```text
revision=45329b4343fd
branch=codex/macos-terminal-metal-rendering
dirty=false
```

### 变基前验证

在基线 `47e511d8` 上也完成过一轮完整验证：

- `./scripts/verify-service-boundaries.sh`：通过
- `./scripts/test-macos.sh`
  - Debug 构建：56.56 秒
  - 测试执行：18.505 秒
  - 74 个测试套件
  - 622 项测试
  - 0 项失败
- `./scripts/verify-macos-package.sh`
  - `lithe-core` Release 构建：38.86 秒
  - Swift Production 构建：107.43 秒
  - `lithe-db-sidecar` Release 构建：1 分 22 秒
  - `lithe-db-mcp` Release 构建：4.94 秒
  - arm64 应用包、签名、Shader 资源和 DMG 验证全部通过

远端 `preview` 更新后，分支已变基至 `8694dbf1`，并重新执行上述最终验证。

## 性能数据说明

本 PR 已验证 Metal 渲染接入、回退行为的编译路径以及 Shader 在最终应用包中的完整性。当前验证不包含 FPS、CPU 占用或 GPU 帧时间的量化基准，因此不在本 PR 中声明具体性能提升比例。

## 已知非阻塞警告

- 打包期间 Rust 编译器报告现有 `lithe-core/src/git/mod.rs` 中一处 `unused_mut` 警告，与本次终端改动无关。
- `hdiutil create` 和 `hdiutil imageinfo` 输出 macOS 工具弃用提示，但 DMG 创建及镜像验证均成功。
