### PR TITLE
chore(release): prepare v0.3.5

### DIFF
--- a/docs/releases/v0.3.5.md
+++ b/docs/releases/v0.3.5.md
@@ -1,0 +1,97 @@
+## 中文
+
+Lithe 0.3.5 是一次性能与稳定性更新，重点改善 macOS 终端渲染、Java 项目就绪流程、语言服务激活和工作台细节。
+
+### 下载
+
+- **项目主页：** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.5/Lithe-0.3.5-arm64.dmg)
+- **macOS Intel：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.5/Lithe-0.3.5-x86_64.dmg)
+- **Windows x64（预览版）：** [下载安装程序](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.5/Lithe-0.3.5-windows-x64.exe)
+- **全部下载：** [查看 Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.5)
+
+> Windows 版本目前仍处于预览阶段。安装程序在未配置 Authenticode 证书时可能没有数字签名，Windows 可能会显示安全提示。
+
+### 重点更新
+
+- macOS 终端现在使用 Metal 和按行持久化缓冲区渲染，减少大量日志输出时对未变化内容的重复绘制；Metal 不可用时会自动回退到 Core Graphics。
+- Java 文档同步现在会等待 JDTLS 完成 ServiceReady 阶段和 Maven 项目导入，避免恢复的文件过早绑定到不完整的项目模型并持续报告错误诊断。
+- 内置语言目录只为真正实现了进程型语言服务器的语言声明 LSP 能力，并在激活前检查模块是否已注册和启用，避免 Markdown、已禁用的 YAML 等语言产生误导性的启动失败通知。
+- 折叠代码时，Code Vision 和 blame 控件会保留可见的起始行与闭合边界行，并避开折叠摘要，减少标签重叠和边界行内容消失。
+
+### 工作台改进
+
+- 项目树使用连续行和统一的内容边距、行高及选中圆角，使目录层级更接近 IntelliJ IDEA New UI。
+- 通知时间改为遵循当前区域设置的具体创建时间，不再持续刷新相对时间文本。
+- 左侧活动栏底部工具组贴近状态栏排列，同时保留工具数量增加后的滚动访问能力。
+- 终端正式包和预览包现在都会验证并包含 SwiftTerm Metal Shader 资源。
+
+### 其他改进
+
+- 改进了 PR 自动审查流程的可靠性、超时处理和失败反馈。
+- 增加 Java 就绪时序、折叠边界、项目树布局、语言能力目录、插件注册和工作台通知的回归测试。
+
+### 升级说明
+
+- **macOS DMG：** 退出正在运行的 Lithe，打开对应架构的 DMG，然后将 Lithe 拖入“应用程序”并替换旧版本。
+- **Homebrew：** 运行 `brew update && brew upgrade --cask lithe`。
+- **Windows：** 退出正在运行的 Lithe，然后运行 Windows x64 安装程序并按提示完成安装。
+
+### 兼容性与已知问题
+
+- macOS 需要 macOS 13 或更高版本。
+- Java 项目功能需要 JDK 17 或更高版本，推荐使用 JDK 17 或 JDK 21。
+- macOS 和 Windows 正式安装包均包含 JDTLS，无需单独安装。
+- Windows 版本仍处于预览阶段，部分平台能力和界面细节可能与 macOS 不完全一致。
+
+查看 [v0.3.4 到 v0.3.5 的完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.3.4...v0.3.5)。
+
+---
+
+## English
+
+Lithe 0.3.5 is a performance and reliability update focused on macOS terminal rendering, Java project readiness, language server activation, and workbench details.
+
+### Downloads
+
+- **Project homepage:** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.5/Lithe-0.3.5-arm64.dmg)
+- **macOS Intel:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.5/Lithe-0.3.5-x86_64.dmg)
+- **Windows x64 preview:** [Download installer](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.5/Lithe-0.3.5-windows-x64.exe)
+- **All downloads:** [View Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.5)
+
+> The Windows build remains a preview. If an Authenticode certificate is not configured, the installer may be unsigned and Windows may show a security warning.
+
+### Highlights
+
+- The macOS terminal now renders with Metal and per-row persistent buffers, reducing redraws of unchanged content during heavy log output. It automatically falls back to Core Graphics when Metal is unavailable.
+- Java document synchronization now waits for JDTLS to finish its ServiceReady phase and Maven project import, preventing restored files from binding to an incomplete project model and retaining incorrect diagnostics.
+- The bundled language catalog only declares LSP capabilities for languages with an implemented process-backed server. Activation also checks that the module is registered and enabled, preventing misleading startup failures for languages such as Markdown and disabled YAML support.
+- Code Vision and blame controls now preserve visible fold start and closing boundary lines and stay clear of the fold summary, reducing label overlap and missing boundary content.
+
+### Workbench improvements
+
+- The project tree now uses continuous rows with consistent content padding, row height, and selection corners that better match IntelliJ IDEA New UI.
+- Notifications show a locale-aware creation time instead of continuously refreshing relative time text.
+- Bottom activity bar tools sit closer to the status bar while remaining scrollable when more tools are registered.
+- Preview and release packages now include and verify the SwiftTerm Metal shader resources.
+
+### Other improvements
+
+- Improved the reliability, timeout handling, and failure feedback of automated PR reviews.
+- Added regression coverage for Java readiness ordering, fold boundaries, project tree layout, language capabilities, plugin registration, and workbench notifications.
+
+### Upgrade instructions
+
+- **macOS DMG:** Quit Lithe, open the DMG for your Mac architecture, and replace the existing application in the Applications folder.
+- **Homebrew:** Run `brew update && brew upgrade --cask lithe`.
+- **Windows:** Quit Lithe, run the Windows x64 installer, and follow the installation prompts.
+
+### Compatibility and known issues
+
+- macOS requires macOS 13 or later.
+- Java project features require JDK 17 or newer. JDK 17 or JDK 21 is recommended.
+- Release packages for macOS and Windows include JDTLS, so it does not need to be installed separately.
+- The Windows build remains a preview, and some platform capabilities and interface details may differ from macOS.
+
+Review the [full changes from v0.3.4 to v0.3.5](https://github.com/1lck/Lithe-IDEA/compare/v0.3.4...v0.3.5).


### PR DESCRIPTION
## Summary

- add Chinese and English release notes for Lithe v0.3.5
- document macOS and Windows downloads, highlights, upgrade steps, and compatibility
- provide the release notes required by the Windows updater manifest

## Validation

- `git diff --check`
- release asset links and comparison links use `v0.3.5` consistently