### PR TITLE
fix(macos): remove unstable Java inlay hints

### DIFF
--- a/macos/Sources/Lithe/Application/Features/JavaFeatureModel.swift
+++ b/macos/Sources/Lithe/Application/Features/JavaFeatureModel.swift
@@ -66,31 +66,23 @@ enum JavaLanguageServerWorkspaceState {
     }
 }
 
-/// Owns Java-only code vision, fallback inlay hints, Maven integration, and
-/// legacy Java debug behavior. Java LSP navigation and editing are delegated
-/// to the Rust host.
+/// Owns Java-only code vision, Maven integration, and legacy Java debug behavior.
+/// Java LSP navigation and editing are delegated to the Rust host.
 @MainActor
 final class JavaFeatureModel: ObservableObject {
     @Published private(set) var javaCodeVisionHints: [URL: [JavaCodeVisionHint]] = [:]
-    @Published private(set) var javaInlayHints: [URL: [JavaInlayHint]] = [:]
     private(set) var languageServerWorkspaceState: JavaLanguageServerWorkspaceState = .idle
 
     private let operations: any JavaMavenOperations
-    private let workspaceOperations: any WorkspaceOperations
     private var documentProvider: (@MainActor () -> EditorDocument?)?
     private var caretProvider: (@MainActor () -> EditorCaret?)?
     private var notify: (@MainActor (String) -> Void)?
     private var loadBlame: (@MainActor (URL) async -> [GitBlameLine])?
-    private var inlayHintTasks: [UUID: Task<Void, Never>] = [:]
     private var mavenFeature: MavenFeatureModel?
     private var debugFeature: JavaDebugFeatureModel?
 
-    init(
-        operations: any JavaMavenOperations,
-        workspaceOperations: any WorkspaceOperations
-    ) {
+    init(operations: any JavaMavenOperations) {
         self.operations = operations
-        self.workspaceOperations = workspaceOperations
     }
 
     func configure(
@@ -125,10 +117,7 @@ final class JavaFeatureModel: ObservableObject {
 
     func stop() {
         cancelLanguageServerPreparation()
-        inlayHintTasks.values.forEach { $0.cancel() }
-        inlayHintTasks.removeAll()
         javaCodeVisionHints = [:]
-        javaInlayHints = [:]
     }
 
     func beginLanguageServerPreparation(
@@ -280,7 +269,6 @@ final class JavaFeatureModel: ObservableObject {
 
     func close(_ document: EditorDocument) {
         javaCodeVisionHints[document.url.standardizedFileURL] = nil
-        javaInlayHints[document.url.standardizedFileURL] = nil
     }
 
     func refreshCodeVision(
@@ -308,71 +296,6 @@ final class JavaFeatureModel: ObservableObject {
                 authorName: hint.authorName
             )
         }
-    }
-
-    func refreshInlayHints(
-        for document: EditorDocument,
-        projectFiles: [URL],
-        workspaceRoot: URL?
-    ) {
-        guard !document.isReadOnly,
-              document.url.pathExtension.lowercased() == "java" else { return }
-        inlayHintTasks[document.id]?.cancel()
-        inlayHintTasks[document.id] = Task { @MainActor [weak self, weak document] in
-            guard let self, let document else { return }
-            await self.requestInlayHints(
-                for: document,
-                projectFiles: projectFiles,
-                workspaceRoot: workspaceRoot
-            )
-            self.inlayHintTasks[document.id] = nil
-        }
-    }
-
-    private func requestInlayHints(
-        for document: EditorDocument,
-        projectFiles: [URL],
-        workspaceRoot: URL?
-    ) async {
-        guard !Task.isCancelled,
-              documentProvider?()?.id == document.id else { return }
-        await applyInlayFallback(
-            for: document,
-            projectFiles: projectFiles,
-            workspaceRoot: workspaceRoot
-        )
-    }
-
-    private func applyInlayFallback(
-        for document: EditorDocument,
-        projectFiles: [URL],
-        workspaceRoot: URL?
-    ) async {
-        let currentText = document.text
-        let sourcePaths = projectFiles.compactMap { file in
-            workspaceRoot.flatMap { workspaceRelativePath(for: file, root: $0) }
-        }
-        let workspaceOperations = self.workspaceOperations
-        let sources: [String]
-        if let workspaceRoot {
-            sources = await Task.detached(priority: .utility) {
-                sourcePaths.compactMap { path in
-                    workspaceOperations.readFile(at: workspaceRoot, relativePath: path)
-                }
-            }.value
-        } else {
-            sources = []
-        }
-        let fallback = await structure(source: currentText, declarationSources: sources)?.inlayHints ?? []
-        guard documentProvider?()?.id == document.id else { return }
-        javaInlayHints[document.url.standardizedFileURL] = fallback
-    }
-
-    private func workspaceRelativePath(for url: URL, root: URL) -> String? {
-        let rootPath = root.standardizedFileURL.path
-        let path = url.standardizedFileURL.path
-        guard path.hasPrefix(rootPath + "/") else { return nil }
-        return String(path.dropFirst(rootPath.count + 1))
     }
 
     func structure(source: String, declarationSources: [String] = []) async -> JavaStructureResult? {

--- a/macos/Sources/Lithe/Core/Rust/RustCoreBridge.swift
+++ b/macos/Sources/Lithe/Core/Rust/RustCoreBridge.swift
@@ -746,16 +746,6 @@ struct RustCoreBridge: Sendable {
             }
         }
 
-        struct InlayHint: Decodable, Sendable {
-            let line: Int
-            let utf16Column: Int
-            let label: String
-
-            func makeModel() -> JavaInlayHint {
-                JavaInlayHint(line: line, utf16Column: utf16Column, label: label)
-            }
-        }
-
         struct SyntaxHighlight: Decodable, Sendable {
             let utf16Start: Int
             let utf16Length: Int
@@ -771,11 +761,9 @@ struct RustCoreBridge: Sendable {
         }
 
         let foldRegions: [FoldRegion]
-        let inlayHints: [InlayHint]
         let syntaxHighlights: [SyntaxHighlight]
 
         func makeFoldRegions() -> [JavaFoldRegion] { foldRegions.compactMap { $0.makeModel() } }
-        func makeInlayHints() -> [JavaInlayHint] { inlayHints.map { $0.makeModel() } }
         func makeSyntaxHighlights() -> [JavaSyntaxHighlight] {
             syntaxHighlights.compactMap { $0.makeModel() }
         }

--- a/macos/Sources/Lithe/Core/Rust/RustJavaMavenOperations.swift
+++ b/macos/Sources/Lithe/Core/Rust/RustJavaMavenOperations.swift
@@ -72,7 +72,6 @@ struct JavaWorkspacePolicyResult: Sendable {
 
 struct JavaStructureResult: Sendable {
     let foldRegions: [JavaFoldRegion]
-    let inlayHints: [JavaInlayHint]
     let syntaxHighlights: [JavaSyntaxHighlight]
 }
 
@@ -259,7 +258,6 @@ struct RustJavaMavenOperations: JavaMavenOperations, Sendable {
         ) else { return nil }
         return JavaStructureResult(
             foldRegions: payload.makeFoldRegions(),
-            inlayHints: payload.makeInlayHints(),
             syntaxHighlights: payload.makeSyntaxHighlights()
         )
     }

--- a/macos/Sources/Lithe/Models/AppModel/AppModel+EditorIntelligence.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+EditorIntelligence.swift
@@ -38,14 +38,6 @@ extension AppModel {
         )
     }
 
-    func refreshJavaInlayHints(for document: EditorDocument) {
-        javaFeature.refreshInlayHints(
-            for: document,
-            projectFiles: projectFiles,
-            workspaceRoot: workspaceURL
-        )
-    }
-
     func showBlame(for fileURL: URL) {
         let normalizedURL = fileURL.standardizedFileURL
         blameVisibleURL = blameVisibleURL == normalizedURL ? nil : normalizedURL

--- a/macos/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -136,9 +136,6 @@ final class AppModel: ObservableObject, Identifiable {
     var javaCodeVisionHints: [URL: [JavaCodeVisionHint]] {
         javaFeature.javaCodeVisionHints
     }
-    var javaInlayHints: [URL: [JavaInlayHint]] {
-        javaFeature.javaInlayHints
-    }
     @Published var blameVisibleURL: URL?
     @Published var gitLogSearchQuery = ""
     private var shortcutDetector: (any ShortcutDetector)?
@@ -391,10 +388,7 @@ final class AppModel: ObservableObject, Identifiable {
             binaryFileViewerRegistry: services.binaryFileViewerRegistry
         )
         navigationHistoryFeature = NavigationHistoryFeatureModel()
-        javaFeature = JavaFeatureModel(
-            operations: services.javaMavenOperations,
-            workspaceOperations: services.workspaceOperations
-        )
+        javaFeature = JavaFeatureModel(operations: services.javaMavenOperations)
         springFeature = SpringFeatureModel(operations: services.javaMavenOperations)
         recentProjects = services.recentProjectsStore.load()
         languageToolingFeature.configureSessions { [weak self] in
@@ -557,11 +551,6 @@ final class AppModel: ObservableObject, Identifiable {
                 self.activateLanguageServerIfAvailable(for: document)
                 guard self.javaFeature.handles(fileURL: document.url) else { return }
                 Task { await self.refreshCodeVision(for: document.url) }
-                self.javaFeature.refreshInlayHints(
-                    for: document,
-                    projectFiles: self.projectFiles,
-                    workspaceRoot: self.workspaceURL
-                )
             },
             onDocumentChanged: { [weak self] document in
                 self?.handleDocumentChanged(document)
@@ -1297,7 +1286,6 @@ final class AppModel: ObservableObject, Identifiable {
             guard !Task.isCancelled, let self, let document else { return }
             guard self.javaFeature.handles(fileURL: document.url) else { return }
             await self.refreshCodeVision(for: document.url)
-            self.refreshJavaInlayHints(for: document)
         }
     }
 

--- a/macos/Sources/Lithe/Models/Java/JavaNavigationModels.swift
+++ b/macos/Sources/Lithe/Models/Java/JavaNavigationModels.swift
@@ -83,14 +83,6 @@ struct JavaFoldRegion: Identifiable, Hashable {
     var id: String { "\(kind.rawValue):\(startLine):\(endLine)" }
 }
 
-struct JavaInlayHint: Identifiable, Hashable {
-    let line: Int
-    let utf16Column: Int
-    let label: String
-
-    var id: String { "\(line):\(utf16Column):\(label)" }
-}
-
 typealias JavaImplementationDirection = JavaNavigationDirection
 typealias JavaImplementationRelation = JavaNavigationRelation
 

--- a/macos/Sources/Lithe/Views/Editor/CodeEditorView.swift
+++ b/macos/Sources/Lithe/Views/Editor/CodeEditorView.swift
@@ -236,58 +236,6 @@ enum EditorFoldVisibility {
 }
 
 enum EditorOverlayLayout {
-    static let inlayHintVerticalPadding: CGFloat = 4
-
-    static func inlayHintBoxHeight(
-        fontAscender: CGFloat,
-        fontDescender: CGFloat,
-        fontLeading: CGFloat
-    ) -> CGFloat {
-        ceil(fontAscender - fontDescender + fontLeading + inlayHintVerticalPadding)
-    }
-
-    static func centeredBoxOriginY(
-        textContainerOriginY: CGFloat,
-        lineOriginY: CGFloat,
-        lineHeight: CGFloat,
-        boxHeight: CGFloat
-    ) -> CGFloat {
-        textContainerOriginY
-            + lineOriginY
-            + (lineHeight - boxHeight) / 2
-    }
-
-    static func inlayHintOriginY(
-        textView: NSTextView,
-        layoutManager: NSLayoutManager,
-        glyphIndex: Int,
-        boxHeight: CGFloat
-    ) -> CGFloat {
-        let lineRect = layoutManager.lineFragmentRect(
-            forGlyphAt: glyphIndex,
-            effectiveRange: nil
-        )
-        return centeredBoxOriginY(
-            textContainerOriginY: textView.textContainerOrigin.y,
-            lineOriginY: lineRect.minY,
-            lineHeight: lineRect.height,
-            boxHeight: boxHeight
-        )
-    }
-
-    static func boxOriginYAlignedToTextCenter(
-        textContainerOriginY: CGFloat,
-        lineOriginY: CGFloat,
-        baselineOffsetY: CGFloat,
-        textAscender: CGFloat,
-        textDescender: CGFloat,
-        boxHeight: CGFloat
-    ) -> CGFloat {
-        let baselineY = lineOriginY + baselineOffsetY
-        let textCenterY = baselineY - (textAscender + textDescender) / 2
-        return textContainerOriginY + textCenterY - boxHeight / 2
-    }
-
     static func centeredFontOriginY(
         textContainerOriginY: CGFloat,
         lineOriginY: CGFloat,
@@ -315,64 +263,6 @@ enum EditorOverlayLayout {
 
     static func requiresRelayout(previousWidth: CGFloat, newWidth: CGFloat) -> Bool {
         previousWidth != newWidth
-    }
-}
-
-struct EditorOverlayUpdatePlan: Equatable {
-    let updateInlayHints: Bool
-    let updateCodeVision: Bool
-
-    init(codeVisionChanged: Bool, inlayHintsChanged: Bool, layoutChanged: Bool) {
-        // Inlay spacing is part of the attributed document and only changes
-        // when the hints change. Reapplying it for a viewport resize invalidates
-        // the full text layout even though unwrapped glyph positions are stable.
-        updateInlayHints = inlayHintsChanged
-        updateCodeVision = codeVisionChanged || inlayHintsChanged || layoutChanged
-    }
-}
-
-private final class InlayHintLabelView: NSView {
-    let title: String
-    let font: NSFont
-    let textColor: NSColor
-
-    init(title: String) {
-        self.title = title
-        font = .systemFont(ofSize: 10.5, weight: .medium)
-        textColor = NSColor(white: 0.61, alpha: 1)
-        super.init(frame: .zero)
-        wantsLayer = true
-        layer?.backgroundColor = NSColor(white: 0.23, alpha: 0.88).cgColor
-        layer?.cornerRadius = 3
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { nil }
-
-    var intrinsicTitleWidth: CGFloat {
-        ceil((title as NSString).size(withAttributes: [.font: font]).width)
-    }
-
-    var intrinsicContentHeight: CGFloat {
-        EditorOverlayLayout.inlayHintBoxHeight(
-            fontAscender: font.ascender,
-            fontDescender: font.descender,
-            fontLeading: font.leading
-        )
-    }
-
-    override func draw(_ dirtyRect: NSRect) {
-        super.draw(dirtyRect)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: textColor
-        ]
-        let titleSize = (title as NSString).size(withAttributes: attributes)
-        let origin = NSPoint(
-            x: (bounds.width - titleSize.width) / 2,
-            y: (bounds.height - titleSize.height) / 2
-        )
-        (title as NSString).draw(at: origin, withAttributes: attributes)
     }
 }
 
@@ -567,7 +457,6 @@ struct CodeEditorView: NSViewRepresentable {
         }
         context.coordinator.attachMarkdownImagePasteMonitor(to: scrollView)
         context.coordinator.codeVisionOverlay = CodeVisionOverlayController(textView: textView)
-        context.coordinator.inlayHintOverlay = JavaInlayHintOverlayController(textView: textView)
         context.coordinator.isDarkAppearance = palette.isDark
         context.coordinator.colorTheme = settings.colorTheme
         context.coordinator.highlight()
@@ -673,7 +562,6 @@ struct CodeEditorView: NSViewRepresentable {
         weak var gutter: LineNumberGutterView?
         weak var container: EditorContainerView?
         var codeVisionOverlay: CodeVisionOverlayController?
-        var inlayHintOverlay: JavaInlayHintOverlayController?
         var isApplyingEditorChange = false
         var isDarkAppearance = true
         var colorTheme: AppColorTheme = .lithe
@@ -700,7 +588,6 @@ struct CodeEditorView: NSViewRepresentable {
         private var appliedLanguageFeatures: LanguageServerFeatureSet?
         private var appliedReadOnly: Bool?
         private var appliedCodeVisionHints: [JavaCodeVisionHint]?
-        private var appliedInlayHints: [JavaInlayHint]?
         private var editorOverlayLayoutRevision = 0
         private var appliedEditorOverlayLayoutRevision = -1
         private var editorOverlayRelayoutTask: Task<Void, Never>?
@@ -1306,23 +1193,10 @@ struct CodeEditorView: NSViewRepresentable {
                 regions: foldRegions,
                 collapsedIDs: collapsedFoldIDs
             )
-            let inlayHints = model.javaInlayHints[url] ?? []
             let overlayLayoutChanged = appliedEditorOverlayLayoutRevision != editorOverlayLayoutRevision
-            let updatePlan = EditorOverlayUpdatePlan(
-                codeVisionChanged: appliedCodeVisionHints != hints,
-                inlayHintsChanged: appliedInlayHints != inlayHints,
-                layoutChanged: overlayLayoutChanged
-            )
 
-            // Inlay hints reserve horizontal space in the text layout. Apply
-            // that input first, then position Code Vision from the final glyph
-            // geometry so the overlays cannot drift when wrapping changes.
-            if updatePlan.updateInlayHints {
-                appliedInlayHints = inlayHints
-                inlayHintOverlay?.update(hints: inlayHints)
-            }
-            if updatePlan.updateCodeVision {
-                appliedCodeVisionHints = hints
+            if appliedCodeVisionHints != visibleCodeVisionHints || overlayLayoutChanged {
+                appliedCodeVisionHints = visibleCodeVisionHints
                 codeVisionOverlay?.update(
                     hints: visibleCodeVisionHints,
                     onUsages: { [weak model] hint in model?.findUsages(for: hint, in: url) },
@@ -4224,92 +4098,6 @@ final class CodeVisionOverlayController {
     private func buttonWidth(_ button: NSButton) -> CGFloat {
         button.sizeToFit()
         return ceil(button.frame.width)
-    }
-}
-
-@MainActor
-final class JavaInlayHintOverlayController {
-    private weak var textView: NSTextView?
-    private var labels: [InlayHintLabelView] = []
-    private var currentHints: [JavaInlayHint] = []
-
-    init(textView: NSTextView) {
-        self.textView = textView
-    }
-
-    func update(hints: [JavaInlayHint]) {
-        guard let textView,
-              let layoutManager = textView.layoutManager,
-              let textStorage = textView.textStorage,
-              let textContainer = textView.textContainer else { return }
-        currentHints = hints
-        labels.forEach { $0.removeFromSuperview() }
-        labels = []
-        let fullRange = NSRange(location: 0, length: textView.string.utf16.count)
-        let source = textView.string as NSString
-        var placements: [(hint: JavaInlayHint, location: Int, label: InlayHintLabelView, width: CGFloat)] = []
-
-        for hint in hints {
-            let lineStart = characterOffset(forLine: hint.line, in: source)
-            let location = min(source.length, lineStart + hint.utf16Column)
-            guard location > 0, location < source.length else { continue }
-            let label = InlayHintLabelView(title: normalizedLabel(hint.label))
-            let width = label.intrinsicTitleWidth + 9
-            placements.append((hint, location, label, width))
-        }
-
-        textStorage.beginEditing()
-        textStorage.removeAttribute(.kern, range: fullRange)
-        for placement in placements {
-            textStorage.addAttribute(
-                .kern,
-                value: placement.width + 3,
-                range: NSRange(location: placement.location - 1, length: 1)
-            )
-        }
-        textStorage.endEditing()
-        layoutManager.invalidateLayout(forCharacterRange: fullRange, actualCharacterRange: nil)
-        layoutManager.ensureLayout(for: textContainer)
-
-        for placement in placements {
-            let glyph = layoutManager.glyphIndexForCharacter(at: placement.location)
-            let point = layoutManager.location(forGlyphAt: glyph)
-            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyph, effectiveRange: nil)
-            let label = placement.label
-            let labelHeight = min(lineRect.height, label.intrinsicContentHeight)
-            let y = EditorOverlayLayout.inlayHintOriginY(
-                textView: textView,
-                layoutManager: layoutManager,
-                glyphIndex: glyph,
-                boxHeight: labelHeight
-            )
-            label.frame = NSRect(
-                x: textView.textContainerOrigin.x + point.x - placement.width - 3,
-                y: y,
-                width: placement.width,
-                height: labelHeight
-            )
-            label.setAccessibilityLabel("Parameter \(placement.hint.label)")
-            textView.addSubview(label)
-            labels.append(label)
-        }
-    }
-
-    private func normalizedLabel(_ label: String) -> String {
-        label.hasSuffix(":") ? label : "\(label):"
-    }
-
-    private func characterOffset(forLine targetLine: Int, in source: NSString) -> Int {
-        if let codeTextView = textView as? CodeTextView {
-            return codeTextView.characterOffset(forLine: targetLine, in: source)
-        }
-        var line = 0
-        var offset = 0
-        while line < targetLine, offset < source.length {
-            offset = NSMaxRange(source.lineRange(for: NSRange(location: offset, length: 0)))
-            line += 1
-        }
-        return offset
     }
 }
 

--- a/macos/Tests/LitheTests/EditorGutterLayoutTests.swift
+++ b/macos/Tests/LitheTests/EditorGutterLayoutTests.swift
@@ -247,39 +247,6 @@ struct EditorGutterLayoutTests {
     }
 
     @Test
-    func inlayLayoutChangesForceCodeVisionToReposition() {
-        let plan = EditorOverlayUpdatePlan(
-            codeVisionChanged: false,
-            inlayHintsChanged: true,
-            layoutChanged: false
-        )
-        #expect(plan.updateInlayHints)
-        #expect(plan.updateCodeVision)
-    }
-
-    @Test
-    func unchangedOverlaysDoNotRebuild() {
-        let plan = EditorOverlayUpdatePlan(
-            codeVisionChanged: false,
-            inlayHintsChanged: false,
-            layoutChanged: false
-        )
-        #expect(!plan.updateInlayHints)
-        #expect(!plan.updateCodeVision)
-    }
-
-    @Test
-    func viewportResizeDoesNotReapplyInlaySpacing() {
-        let plan = EditorOverlayUpdatePlan(
-            codeVisionChanged: false,
-            inlayHintsChanged: false,
-            layoutChanged: true
-        )
-        #expect(!plan.updateInlayHints)
-        #expect(plan.updateCodeVision)
-    }
-
-    @Test
     func codeVisionUsesTheSymbolAsItsVisualLineAnchor() {
         #expect(EditorOverlayLayout.codeVisionAnchorCharacterOffset(
             lineStart: 100,
@@ -374,62 +341,6 @@ struct EditorGutterLayoutTests {
             overlayAscender: 8,
             overlayDescender: -2
         ) == 23)
-    }
-
-    @Test
-    func inlayHintBoxCenterAlignsWithTheLineCenter() {
-        #expect(EditorOverlayLayout.centeredBoxOriginY(
-            textContainerOriginY: 2,
-            lineOriginY: 20,
-            lineHeight: 18,
-            boxHeight: 16
-        ) == 23)
-        #expect(EditorOverlayLayout.centeredBoxOriginY(
-            textContainerOriginY: 2,
-            lineOriginY: 20,
-            lineHeight: 24,
-            boxHeight: 18
-        ) == 25)
-    }
-
-    @Test
-    func inlayHintBoxHeightDependsOnItsFontInsteadOfEditorLineHeight() {
-        let height = EditorOverlayLayout.inlayHintBoxHeight(
-            fontAscender: 10,
-            fontDescender: -3,
-            fontLeading: 1
-        )
-        #expect(height == 18)
-        #expect(EditorOverlayLayout.centeredBoxOriginY(
-            textContainerOriginY: 2,
-            lineOriginY: 20,
-            lineHeight: 40,
-            boxHeight: height
-        ) == 33)
-    }
-
-    @Test
-    func inlayHintBoxAlignsWithTheActualTextCenter() {
-        #expect(EditorOverlayLayout.boxOriginYAlignedToTextCenter(
-            textContainerOriginY: 2,
-            lineOriginY: 0,
-            baselineOffsetY: 28.6,
-            textAscender: 23.2,
-            textDescender: -5.0,
-            boxHeight: 18
-        ) == 12.5)
-    }
-
-    @Test
-    func inlayHintOnALaterLineIncludesTheLineOrigin() {
-        #expect(EditorOverlayLayout.boxOriginYAlignedToTextCenter(
-            textContainerOriginY: 2,
-            lineOriginY: 638.4,
-            baselineOffsetY: 28.6,
-            textAscender: 23.2,
-            textDescender: -5.0,
-            boxHeight: 18
-        ) == 650.9)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- remove the custom AppKit parameter-name overlay and its kerning-based text spacing
- remove macOS Java inlay-hint state, project-source scanning, refresh tasks, and Swift projection models
- preserve fold-aware Code Vision filtering and collapsed-summary positioning, blame layout, shared Rust Core contracts, and Windows behavior

## Validation

- `./scripts/test-macos.sh` (623 tests across 75 suites)
- `./scripts/verify-service-boundaries.sh`
- `./scripts/verify-rust-core.sh` (238 unit tests, 5 integration tests, Swift bridge verification)
- `git diff --check`

Closes #279