### PR TITLE
fix(lsp): keep JDTLS alive during active project import

### DIFF
--- a/docs/architecture/language-tooling.md
+++ b/docs/architecture/language-tooling.md
@@ -161,6 +161,24 @@ timeout。Core、service 和 adapter 只返回稳定原因，面向用户的提�
 4. manager 只在真实 `ready` 后发布 capability；打开文档发送 `didOpen`，后续编辑优先按服务器协商结果发送增量 `didChange`；
 5. Rust 以 LSP request ID 关联 deadline，并用不透明 operation ID 把 terminal result 投影给 Swift。
 
+`initializeTimeoutMilliseconds` 只约束标准 LSP 握手。JDTLS 返回 initialize
+结果后，Core 立即切换到独立的 `ServiceReady` 等待：连续 45 秒没有变化的
+`$/progress` 才判定 idle timeout，同时保留 10 分钟绝对上限。百分比增长、阶段或
+模块变化、下载字节增长都属于有效进展；完全重复的消息不续期。平台 adapter 不得再
+添加自己的固定 readiness deadline。最终 ready 仍只认
+`language/status: ServiceReady`，进度文本解析只服务于日志和超时快照。
+
+Java import 日志以节流后的结构化 JSON detail 发布，至少保留 phase、百分比、当前
+模块、观察到的模块数、artifact、仓库 host、已下载/总字节、估算吞吐、elapsed、idle
+和 `cacheDisposition`。超时使用 `serviceReadyTimeout`/`serviceReady`，并以
+`networkDownloadStalled`、`networkTransferActive`、`noProgressStall` 或
+`projectImportActive` 标明最后状态。JDTLS workspace 已存在 `.metadata` 时记为
+`reused`，否则记为 `new`。
+
+JDTLS 初始化配置不主动下载 Maven/Eclipse source attachment；依赖 POM/JAR 仍按
+项目模型需要正常解析。外部依赖没有源码包时，跳转使用已有的 class-file/decompile
+能力，从而把非必要源码下载移出首次 `ServiceReady` 关键路径。
+
 服务端 capability 可以来自 initialize 响应，也可以通过 `client/registerCapability` 和
 `client/unregisterCapability` 动态变化。客户端处理有文档/version 归属的 diagnostics、workspace configuration/folders、work-done progress 和 apply-edit 协议；未知的服务端 request 返回 JSON-RPC `Method not found`，未知 notification 作为 typed log/event 保留。
 

--- a/macos/Sources/Lithe/Core/Rust/RustCoreBridge.swift
+++ b/macos/Sources/Lithe/Core/Rust/RustCoreBridge.swift
@@ -2952,7 +2952,7 @@ struct RustCoreBridge: Sendable {
         jdtlsLaunchResources: JDTLSLaunchResources? = nil,
         cacheDirectoryURL: URL? = nil,
         workspaceFingerprint: String? = nil,
-        initializeTimeout: TimeInterval = 60,
+        initializeTimeout: TimeInterval = 30,
         requestTimeout: TimeInterval = 30,
         shutdownTimeout: TimeInterval = 2
     ) -> Result<LspStartServerPayload, CoreCallError> {

--- a/macos/Sources/LitheCoreContracts/Language/LanguageToolingContracts.swift
+++ b/macos/Sources/LitheCoreContracts/Language/LanguageToolingContracts.swift
@@ -414,7 +414,9 @@ package struct LanguageServerSessionFailure: Equatable, Sendable {
         self.message = message
     }
 
-    package var isTimedOut: Bool { code == "timed_out" }
+    package var isTimedOut: Bool {
+        code == "timed_out" || code == "initializeTimeout" || code == "serviceReadyTimeout"
+    }
 }
 
 package struct LanguageServerSessionStartError: LocalizedError, Sendable {

--- a/macos/Sources/LitheLanguageIntelligenceModule/Runtime/LanguageServerSession.swift
+++ b/macos/Sources/LitheLanguageIntelligenceModule/Runtime/LanguageServerSession.swift
@@ -55,7 +55,7 @@ package final class LanguageServerRuntimeSession: LanguageServerSession {
         runtimeExecutableURL: URL? = nil,
         jdtlsLaunchResources: JDTLSLaunchResources? = nil,
         cacheDirectoryURL: URL? = nil,
-        initializeTimeout: TimeInterval = 60,
+        initializeTimeout: TimeInterval = 30,
         requestTimeout: TimeInterval = 30,
         shutdownTimeout: TimeInterval = 2,
         core: any LanguageServerRuntimeCore,

--- a/macos/Tests/LitheTests/JavaLanguageServerRuntimeTests.swift
+++ b/macos/Tests/LitheTests/JavaLanguageServerRuntimeTests.swift
@@ -5,6 +5,14 @@ import Testing
 @Suite("Java language server runtime")
 struct JavaLanguageServerRuntimeTests {
     @Test
+    func coreInitializationTimeoutCodesRemainUserVisibleTimeouts() {
+        #expect(LanguageServerSessionFailure(code: "timed_out").isTimedOut)
+        #expect(LanguageServerSessionFailure(code: "initializeTimeout").isTimedOut)
+        #expect(LanguageServerSessionFailure(code: "serviceReadyTimeout").isTimedOut)
+        #expect(!LanguageServerSessionFailure(code: "serverExited").isTimedOut)
+    }
+
+    @Test
     func macRuntimeLocatorSelectsJdkForRequestedProcessArchitecture() throws {
         let fileManager = FileManager.default
         let resources = fileManager.temporaryDirectory

--- a/rust/lithe-core/src/lsp/interface/engine.rs
+++ b/rust/lithe-core/src/lsp/interface/engine.rs
@@ -1983,6 +1983,9 @@ impl RuntimeSession {
                 None => {}
             }
 
+            let suppress_structured_java_preparation_notification = state.lifecycle
+                == LspLifecycleState::Initializing
+                && (java_import_progress.is_some() || readiness.is_some());
             if state.lifecycle == LspLifecycleState::Initializing {
                 if let Some(progress) = java_import_progress {
                     let detail = state.java_preparation.as_mut().and_then(|diagnostics| {
@@ -2024,10 +2027,11 @@ impl RuntimeSession {
                         );
                     }
                 } else if event.kind == "notification"
-                    && !is_structured_import_notification(
-                        &self.provider_id,
-                        event.method.as_deref(),
-                    )
+                    && !(suppress_structured_java_preparation_notification
+                        && is_structured_import_notification(
+                            &self.provider_id,
+                            event.method.as_deref(),
+                        ))
                 {
                     push_log_event(
                         self,
@@ -3707,13 +3711,12 @@ mod tests {
         let mut harness = Harness::start(|request| {
             request.provider_id = "java".to_string();
             request.initialize_timeout_milliseconds = 1_000;
-            request.service_ready_idle_timeout_milliseconds = 200;
-            request.service_ready_absolute_timeout_milliseconds = 1_000;
+            request.service_ready_idle_timeout_milliseconds = 500;
+            request.service_ready_absolute_timeout_milliseconds = 2_000;
         });
         harness.server.complete_initialize(ready_capabilities());
         assert!(harness.server.await_notification("initialized"));
 
-        thread::sleep(Duration::from_millis(130));
         harness.server.send(json!({
             "jsonrpc": "2.0",
             "method": "$/progress",
@@ -3726,7 +3729,14 @@ mod tests {
                 }
             }
         }));
-        thread::sleep(Duration::from_millis(130));
+        harness.await_event(|event| {
+            event.message.as_deref() == Some("Java workspace import progress")
+                && event
+                    .detail
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains("\"progressPercent\":20"))
+        });
+        thread::sleep(Duration::from_millis(300));
         harness.server.send(json!({
             "jsonrpc": "2.0",
             "method": "$/progress",
@@ -3739,6 +3749,14 @@ mod tests {
                 }
             }
         }));
+        harness.await_event(|event| {
+            event.message.as_deref() == Some("Java workspace import progress")
+                && event
+                    .detail
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains("\"progressPercent\":25"))
+        });
+        thread::sleep(Duration::from_millis(300));
         harness.server.send(json!({
             "jsonrpc": "2.0",
             "method": "language/status",
@@ -3755,6 +3773,55 @@ mod tests {
         let detail: Value = serde_json::from_str(progress.detail.as_deref().unwrap()).unwrap();
         assert_eq!(detail["progressPercent"], 25);
         assert_eq!(detail["currentProject"], "module-a");
+    }
+
+    #[test]
+    fn java_import_notifications_are_logged_after_service_ready() {
+        let mut harness = Harness::start(|request| {
+            request.provider_id = "java".to_string();
+        });
+        harness.server.complete_initialize(ready_capabilities());
+        assert!(harness.server.await_notification("initialized"));
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "language/status",
+            "params": { "type": "ServiceReady" }
+        }));
+        harness.await_state(LspLifecycleState::Ready);
+        assert!(
+            !harness.events.iter().any(|event| {
+                matches!(
+                    event.message.as_deref(),
+                    Some("$/progress" | "language/status")
+                )
+            }),
+            "structured preparation notifications should not be logged twice"
+        );
+
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {
+                "token": "java-build",
+                "value": {
+                    "kind": "report",
+                    "message": "Building workspace - Project 'module-a'",
+                    "percentage": 50
+                }
+            }
+        }));
+        harness.await_event(|event| event.message.as_deref() == Some("$/progress"));
+
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "language/status",
+            "params": {
+                "type": "Error",
+                "message": "Background build failed"
+            }
+        }));
+        harness.await_event(|event| event.message.as_deref() == Some("language/status"));
+        assert_eq!(harness.snapshot().state, LspLifecycleState::Ready);
     }
 
     #[test]

--- a/rust/lithe-core/src/lsp/interface/engine.rs
+++ b/rust/lithe-core/src/lsp/interface/engine.rs
@@ -12,12 +12,14 @@ use super::{
     ParseServerMessagesRequest,
 };
 use crate::lsp::languages::jdt::{
-    adapt_initialization_options, adapt_start, initialized_notification, is_virtual_source_uri,
-    normalize_location, readiness_signal, virtual_source_content, virtual_source_resolve_params,
-    waits_for_service_ready, workspace_configuration, JdtDirectLaunchResources, JdtReadinessSignal,
-    JdtStartContext, ProviderLocation, WorkspaceConfigurationItem,
+    adapt_initialization_options, adapt_start, import_progress, initialized_notification,
+    is_structured_import_notification, is_virtual_source_uri, normalize_location, readiness_signal,
+    virtual_source_content, virtual_source_resolve_params, waits_for_service_ready,
+    workspace_configuration, JdtDirectLaunchResources, JdtReadinessSignal, JdtStartContext,
+    ProviderLocation, WorkspaceConfigurationItem,
 };
 use crate::lsp::languages::jdt_navigation::{JavaNavigationMarkerBatch, MAX_JAVA_NAVIGATION_TASKS};
+use crate::lsp::languages::jdt_progress::JavaPreparationDiagnostics;
 use crate::protocol::{CoreError, ErrorCode};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -30,6 +32,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 const DEFAULT_INITIALIZE_TIMEOUT_MS: u64 = 10_000;
+const DEFAULT_SERVICE_READY_IDLE_TIMEOUT_MS: u64 = 45_000;
+const DEFAULT_SERVICE_READY_ABSOLUTE_TIMEOUT_MS: u64 = 10 * 60_000;
 const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS: u64 = 2_000;
 const MONITOR_INTERVAL_MS: u64 = 10;
@@ -85,6 +89,12 @@ pub struct StartServerRequest {
     pub workspace_fingerprint: Option<String>,
     #[serde(default = "default_initialize_timeout")]
     pub initialize_timeout_milliseconds: u64,
+    /// Maximum silence while waiting for a provider-specific readiness signal.
+    #[serde(default = "default_service_ready_idle_timeout")]
+    pub service_ready_idle_timeout_milliseconds: u64,
+    /// Absolute safety cap for provider-specific preparation even while active.
+    #[serde(default = "default_service_ready_absolute_timeout")]
+    pub service_ready_absolute_timeout_milliseconds: u64,
     #[serde(default = "default_request_timeout")]
     pub request_timeout_milliseconds: u64,
     #[serde(default = "default_shutdown_timeout")]
@@ -448,6 +458,9 @@ struct SessionState {
     events: VecDeque<LspRuntimeEvent>,
     next_sequence: u64,
     initialize_deadline: Option<Instant>,
+    service_ready_idle_timeout: Duration,
+    service_ready_absolute_timeout: Duration,
+    java_preparation: Option<JavaPreparationDiagnostics>,
     shutdown_deadline: Option<Instant>,
     request_timeout: Duration,
     shutdown_timeout: Duration,
@@ -481,6 +494,14 @@ pub(super) struct LspEngine {
 
 fn default_initialize_timeout() -> u64 {
     DEFAULT_INITIALIZE_TIMEOUT_MS
+}
+
+fn default_service_ready_idle_timeout() -> u64 {
+    DEFAULT_SERVICE_READY_IDLE_TIMEOUT_MS
+}
+
+fn default_service_ready_absolute_timeout() -> u64 {
+    DEFAULT_SERVICE_READY_ABSOLUTE_TIMEOUT_MS
 }
 
 fn default_request_timeout() -> u64 {
@@ -678,6 +699,7 @@ impl LspEngine {
 
     fn start_server(&self, request: StartServerRequest) -> Result<StartServerResponse, CoreError> {
         validate_start_request(&request)?;
+        let startup_started_at = Instant::now();
         let session_id = format!(
             "lsp-session-{}",
             self.next_session_id.fetch_add(1, Ordering::Relaxed)
@@ -708,6 +730,13 @@ impl LspEngine {
             arguments: request.arguments.clone(),
             workspace_fingerprint: request.workspace_fingerprint.clone(),
         });
+        let java_cache_disposition = adaptation.data_directory.as_ref().map(|directory| {
+            if directory.join(".metadata").is_dir() {
+                "reused"
+            } else {
+                "new"
+            }
+        });
         if let Some(directory) = &adaptation.data_directory {
             std::fs::create_dir_all(directory).map_err(|error| {
                 CoreError::new(
@@ -726,8 +755,13 @@ impl LspEngine {
             working_directory: workspace_root,
             environment: request.environment,
         })?;
+        let process_start_elapsed = startup_started_at.elapsed();
 
         let initialize_timeout = Duration::from_millis(request.initialize_timeout_milliseconds);
+        let service_ready_idle_timeout =
+            Duration::from_millis(request.service_ready_idle_timeout_milliseconds);
+        let service_ready_absolute_timeout =
+            Duration::from_millis(request.service_ready_absolute_timeout_milliseconds);
         let request_timeout = Duration::from_millis(request.request_timeout_milliseconds);
         let shutdown_timeout = Duration::from_millis(request.shutdown_timeout_milliseconds);
         let initialize = client_initialize(ClientInitializeRequest {
@@ -742,6 +776,17 @@ impl LspEngine {
         let request_id = (initialize.state.next_request_id - 1).to_string();
         let now = Instant::now();
         let process_id = process.handle.process_id();
+        let java_preparation = java_cache_disposition.map(|cache_disposition| {
+            JavaPreparationDiagnostics::new(
+                startup_started_at,
+                process_start_elapsed,
+                cache_disposition,
+                request.workspace_fingerprint.is_some(),
+            )
+        });
+        let java_startup_detail = java_preparation
+            .as_ref()
+            .map(JavaPreparationDiagnostics::startup_detail);
         let session = Arc::new(RuntimeSession {
             id: session_id.clone(),
             provider_id: request.provider_id,
@@ -770,6 +815,9 @@ impl LspEngine {
                 events: VecDeque::new(),
                 next_sequence: 1,
                 initialize_deadline: Some(now + initialize_timeout),
+                service_ready_idle_timeout,
+                service_ready_absolute_timeout,
+                java_preparation,
                 shutdown_deadline: None,
                 request_timeout,
                 shutdown_timeout,
@@ -782,6 +830,13 @@ impl LspEngine {
         session.transition(LspLifecycleState::Created, None)?;
         session.transition(LspLifecycleState::ProcessStarting, None)?;
         session.transition(LspLifecycleState::Initializing, None)?;
+        if let Some(detail) = java_startup_detail {
+            session.log(
+                "info",
+                "Java language service process started",
+                Some(detail),
+            );
+        }
 
         self.lock_sessions()?
             .insert(session_id.clone(), session.clone());
@@ -1562,11 +1617,9 @@ impl RuntimeSession {
             CoreError::new(ErrorCode::ParseFailed, "Invalid LSP server JSON message.")
                 .with_details(error.to_string())
         })?;
-        let readiness = readiness_signal(
-            &self.provider_id,
-            value.get("method").and_then(Value::as_str),
-            value.get("params"),
-        );
+        let method = value.get("method").and_then(Value::as_str);
+        let readiness = readiness_signal(&self.provider_id, method, value.get("params"));
+        let java_import_progress = import_progress(&self.provider_id, method, value.get("params"));
         let outbound_order = self.lock_outbound_order()?;
 
         if value.get("method").and_then(Value::as_str) == Some("workspace/configuration") {
@@ -1647,8 +1700,30 @@ impl RuntimeSession {
                             server_error,
                         ));
                     } else {
-                        if !waits_for_service_ready(&self.provider_id) {
-                            state.initialize_deadline = None;
+                        state.initialize_deadline = None;
+                        if waits_for_service_ready(&self.provider_id) {
+                            let now = Instant::now();
+                            let idle_timeout = state.service_ready_idle_timeout;
+                            let absolute_timeout = state.service_ready_absolute_timeout;
+                            let initialize_elapsed = pending_before
+                                .as_ref()
+                                .map(|pending| now.saturating_duration_since(pending.created_at))
+                                .unwrap_or_default();
+                            if let Some(diagnostics) = state.java_preparation.as_mut() {
+                                let detail = diagnostics.begin_readiness(
+                                    now,
+                                    initialize_elapsed,
+                                    idle_timeout,
+                                    absolute_timeout,
+                                );
+                                push_log_event(
+                                    self,
+                                    &mut state,
+                                    "info",
+                                    "Java language service protocol initialized",
+                                    Some(detail),
+                                );
+                            }
                         }
                         ready_server_info = parse_server_info(&value);
                         flush_documents = true;
@@ -1909,6 +1984,23 @@ impl RuntimeSession {
             }
 
             if state.lifecycle == LspLifecycleState::Initializing {
+                if let Some(progress) = java_import_progress {
+                    let detail = state.java_preparation.as_mut().and_then(|diagnostics| {
+                        diagnostics.record_progress(progress, Instant::now())
+                    });
+                    if let Some(detail) = detail {
+                        push_log_event(
+                            self,
+                            &mut state,
+                            "info",
+                            "Java workspace import progress",
+                            Some(detail),
+                        );
+                    }
+                }
+            }
+
+            if state.lifecycle == LspLifecycleState::Initializing {
                 match readiness.as_ref() {
                     Some(JdtReadinessSignal::Ready) if state.client.initialized => {
                         service_ready = true;
@@ -1931,7 +2023,12 @@ impl RuntimeSession {
                             event.diagnostics.unwrap_or_default(),
                         );
                     }
-                } else if event.kind == "notification" {
+                } else if event.kind == "notification"
+                    && !is_structured_import_notification(
+                        &self.provider_id,
+                        event.method.as_deref(),
+                    )
+                {
                     push_log_event(
                         self,
                         &mut state,
@@ -2018,6 +2115,10 @@ impl RuntimeSession {
             self.send_messages_or_fail(&outbound_order, queued_messages, "serviceReady")?;
             {
                 let mut state = self.lock_state()?;
+                let ready_detail = state
+                    .java_preparation
+                    .as_mut()
+                    .map(|diagnostics| diagnostics.ready_detail(Instant::now()));
                 transition_locked(self, &mut state, LspLifecycleState::Ready, None);
                 let capabilities = state.client.server_capabilities.clone();
                 push_features_event(self, &mut state, capabilities);
@@ -2026,7 +2127,7 @@ impl RuntimeSession {
                     &mut state,
                     "info",
                     "Java language service finished project import",
-                    None,
+                    ready_detail,
                 );
             }
         }
@@ -2085,6 +2186,7 @@ impl RuntimeSession {
         let now = Instant::now();
         let mut cancellations = Vec::new();
         let mut initialize_timeout = false;
+        let mut service_ready_timeout = None;
         let mut shutdown_timeout = false;
         if let Ok(mut state) = self.lock_state() {
             if state.lifecycle == LspLifecycleState::Initializing
@@ -2094,6 +2196,12 @@ impl RuntimeSession {
             {
                 state.initialize_deadline = None;
                 initialize_timeout = true;
+            }
+            if state.lifecycle == LspLifecycleState::Initializing && !initialize_timeout {
+                service_ready_timeout = state
+                    .java_preparation
+                    .as_mut()
+                    .and_then(|diagnostics| diagnostics.take_timeout(now));
             }
 
             let expired: Vec<_> = state
@@ -2165,6 +2273,15 @@ impl RuntimeSession {
                 "initialize",
                 "Language-server initialization timed out.",
                 None,
+                None,
+            );
+            self.kill_process();
+        } else if let Some(detail) = service_ready_timeout {
+            self.fail(
+                "serviceReadyTimeout",
+                "serviceReady",
+                "Java language service project import timed out.",
+                Some(detail),
                 None,
             );
             self.kill_process();
@@ -3167,6 +3284,8 @@ mod tests {
             cache_directory: None,
             workspace_fingerprint: None,
             initialize_timeout_milliseconds: 10_000,
+            service_ready_idle_timeout_milliseconds: 45_000,
+            service_ready_absolute_timeout_milliseconds: 600_000,
             request_timeout_milliseconds: 10_000,
             shutdown_timeout_milliseconds: 10_000,
         }
@@ -3562,7 +3681,9 @@ mod tests {
     fn java_preparation_timeout_covers_project_import() {
         let mut harness = Harness::start(|request| {
             request.provider_id = "java".to_string();
-            request.initialize_timeout_milliseconds = 40;
+            request.initialize_timeout_milliseconds = 1_000;
+            request.service_ready_idle_timeout_milliseconds = 40;
+            request.service_ready_absolute_timeout_milliseconds = 5_000;
         });
         harness.server.complete_initialize(ready_capabilities());
         assert!(harness.server.await_notification("initialized"));
@@ -3573,8 +3694,67 @@ mod tests {
             .iter()
             .find_map(|event| event.error.as_ref())
             .expect("project import timeout should be reported");
-        assert_eq!(failure.code, "initializeTimeout");
-        assert_eq!(failure.stage, "initialize");
+        assert_eq!(failure.code, "serviceReadyTimeout");
+        assert_eq!(failure.stage, "serviceReady");
+        assert!(failure
+            .underlying_message
+            .as_deref()
+            .is_some_and(|detail| detail.contains("\"classification\":\"noProgressStall\"")));
+    }
+
+    #[test]
+    fn java_meaningful_progress_refreshes_the_service_ready_idle_timeout() {
+        let mut harness = Harness::start(|request| {
+            request.provider_id = "java".to_string();
+            request.initialize_timeout_milliseconds = 1_000;
+            request.service_ready_idle_timeout_milliseconds = 200;
+            request.service_ready_absolute_timeout_milliseconds = 1_000;
+        });
+        harness.server.complete_initialize(ready_capabilities());
+        assert!(harness.server.await_notification("initialized"));
+
+        thread::sleep(Duration::from_millis(130));
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {
+                "token": "java-import",
+                "value": {
+                    "kind": "report",
+                    "message": "Importing Maven project(s) - Importing project module-a",
+                    "percentage": 20
+                }
+            }
+        }));
+        thread::sleep(Duration::from_millis(130));
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {
+                "token": "java-import",
+                "value": {
+                    "kind": "report",
+                    "message": "Setting classpath containers - 25% Project 'module-a'",
+                    "percentage": 25
+                }
+            }
+        }));
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "language/status",
+            "params": { "type": "ServiceReady" }
+        }));
+        harness.await_state(LspLifecycleState::Ready);
+
+        let progress = harness
+            .events
+            .iter()
+            .rev()
+            .find(|event| event.message.as_deref() == Some("Java workspace import progress"))
+            .expect("structured Java import progress should be logged");
+        let detail: Value = serde_json::from_str(progress.detail.as_deref().unwrap()).unwrap();
+        assert_eq!(detail["progressPercent"], 25);
+        assert_eq!(detail["currentProject"], "module-a");
     }
 
     #[test]
@@ -5090,6 +5270,8 @@ public class Main {
                 cache_directory: Some(root.join("cache").to_string_lossy().into_owned()),
                 workspace_fingerprint: None,
                 initialize_timeout_milliseconds: 90_000,
+                service_ready_idle_timeout_milliseconds: 45_000,
+                service_ready_absolute_timeout_milliseconds: 600_000,
                 request_timeout_milliseconds: 30_000,
                 shutdown_timeout_milliseconds: 10_000,
             })
@@ -5814,6 +5996,8 @@ public class Main {
             cache_directory: None,
             workspace_fingerprint: None,
             initialize_timeout_milliseconds: 1,
+            service_ready_idle_timeout_milliseconds: 1,
+            service_ready_absolute_timeout_milliseconds: 1,
             request_timeout_milliseconds: 1,
             shutdown_timeout_milliseconds: 1,
         };
@@ -5859,5 +6043,8 @@ public class Main {
             resources.configuration_directory,
             "/opt/lithe/jdtls/config_mac"
         );
+        assert_eq!(request.initialize_timeout_milliseconds, 30_000);
+        assert_eq!(request.service_ready_idle_timeout_milliseconds, 45_000);
+        assert_eq!(request.service_ready_absolute_timeout_milliseconds, 600_000);
     }
 }

--- a/rust/lithe-core/src/lsp/interface/engine.rs
+++ b/rust/lithe-core/src/lsp/interface/engine.rs
@@ -3707,16 +3707,12 @@ mod tests {
     }
 
     #[test]
-    fn java_meaningful_progress_refreshes_the_service_ready_idle_timeout() {
+    fn java_import_notifications_are_logged_after_service_ready() {
         let mut harness = Harness::start(|request| {
             request.provider_id = "java".to_string();
-            request.initialize_timeout_milliseconds = 1_000;
-            request.service_ready_idle_timeout_milliseconds = 500;
-            request.service_ready_absolute_timeout_milliseconds = 2_000;
         });
         harness.server.complete_initialize(ready_capabilities());
         assert!(harness.server.await_notification("initialized"));
-
         harness.server.send(json!({
             "jsonrpc": "2.0",
             "method": "$/progress",
@@ -3731,57 +3727,7 @@ mod tests {
         }));
         harness.await_event(|event| {
             event.message.as_deref() == Some("Java workspace import progress")
-                && event
-                    .detail
-                    .as_deref()
-                    .is_some_and(|detail| detail.contains("\"progressPercent\":20"))
         });
-        thread::sleep(Duration::from_millis(300));
-        harness.server.send(json!({
-            "jsonrpc": "2.0",
-            "method": "$/progress",
-            "params": {
-                "token": "java-import",
-                "value": {
-                    "kind": "report",
-                    "message": "Setting classpath containers - 25% Project 'module-a'",
-                    "percentage": 25
-                }
-            }
-        }));
-        harness.await_event(|event| {
-            event.message.as_deref() == Some("Java workspace import progress")
-                && event
-                    .detail
-                    .as_deref()
-                    .is_some_and(|detail| detail.contains("\"progressPercent\":25"))
-        });
-        thread::sleep(Duration::from_millis(300));
-        harness.server.send(json!({
-            "jsonrpc": "2.0",
-            "method": "language/status",
-            "params": { "type": "ServiceReady" }
-        }));
-        harness.await_state(LspLifecycleState::Ready);
-
-        let progress = harness
-            .events
-            .iter()
-            .rev()
-            .find(|event| event.message.as_deref() == Some("Java workspace import progress"))
-            .expect("structured Java import progress should be logged");
-        let detail: Value = serde_json::from_str(progress.detail.as_deref().unwrap()).unwrap();
-        assert_eq!(detail["progressPercent"], 25);
-        assert_eq!(detail["currentProject"], "module-a");
-    }
-
-    #[test]
-    fn java_import_notifications_are_logged_after_service_ready() {
-        let mut harness = Harness::start(|request| {
-            request.provider_id = "java".to_string();
-        });
-        harness.server.complete_initialize(ready_capabilities());
-        assert!(harness.server.await_notification("initialized"));
         harness.server.send(json!({
             "jsonrpc": "2.0",
             "method": "language/status",

--- a/rust/lithe-core/src/lsp/languages/jdt.rs
+++ b/rust/lithe-core/src/lsp/languages/jdt.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
+use url::Url;
 
 const JAVA_PROVIDER_ID: &str = "java";
 const JDT_URI_SCHEME: &str = "jdt";
@@ -18,6 +19,7 @@ const JDTLS_DATA_DIRECTORY: &str = "jdtls";
 const JAVA_DECOMPILE_COMMAND: &str = "java.decompile";
 const DID_CHANGE_CONFIGURATION_METHOD: &str = "workspace/didChangeConfiguration";
 const LANGUAGE_STATUS_METHOD: &str = "language/status";
+const WORK_DONE_PROGRESS_METHOD: &str = "$/progress";
 const SERVICE_READY_STATUS: &str = "ServiceReady";
 const ERROR_STATUS: &str = "Error";
 
@@ -29,6 +31,34 @@ pub(crate) enum JdtReadinessSignal {
     Ready,
     /// JDT LS reported that its Java service could not become usable.
     Failed(String),
+}
+
+/// Maven artifact transfer details extracted from JDT LS work-done progress.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct JdtDownloadProgress {
+    /// File name only; repository URLs can contain credentials or private hosts.
+    pub artifact: String,
+    /// Repository host without path, query, or credentials.
+    pub repository_host: Option<String>,
+    /// Bytes transferred according to JDT LS, when its progress includes a size pair.
+    pub downloaded_bytes: Option<u64>,
+    /// Expected artifact size according to JDT LS, when the server reports it.
+    pub total_bytes: Option<u64>,
+}
+
+/// Observable Java workspace-import activity derived from standard progress events.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct JdtImportProgress {
+    /// Stable signature used to ignore duplicate progress notifications.
+    pub activity_signature: String,
+    /// JDT LS work phase such as Maven import or classpath setup.
+    pub phase: Option<String>,
+    /// Outer workspace-import percentage, which can stay fixed during downloads.
+    pub percentage: Option<u64>,
+    /// Current Maven project when JDT LS includes it in the progress message.
+    pub current_project: Option<String>,
+    /// Current artifact transfer, if the progress message contains a repository URL.
+    pub download: Option<JdtDownloadProgress>,
 }
 
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq, Serialize)]
@@ -265,6 +295,116 @@ pub(crate) fn readiness_signal(
         )),
         _ => None,
     }
+}
+
+/// Extracts observability-only Maven import details from JDT LS `$/progress`.
+///
+/// Lifecycle correctness must never depend on this parser because progress text
+/// is owned by JDT LS and can change between releases. Readiness continues to
+/// depend exclusively on `language/status: ServiceReady`.
+pub(crate) fn import_progress(
+    provider_id: &str,
+    method: Option<&str>,
+    params: Option<&Value>,
+) -> Option<JdtImportProgress> {
+    if !is_java_provider(provider_id) || method != Some(WORK_DONE_PROGRESS_METHOD) {
+        return None;
+    }
+    let value = params?.get("value")?;
+    let kind = value
+        .get("kind")
+        .and_then(Value::as_str)
+        .unwrap_or("report");
+    let message = value
+        .get("message")
+        .and_then(Value::as_str)
+        .or_else(|| value.get("title").and_then(Value::as_str))
+        .unwrap_or("")
+        .trim();
+    let percentage = value.get("percentage").and_then(Value::as_u64);
+    if message.is_empty() && percentage.is_none() {
+        return None;
+    }
+
+    Some(JdtImportProgress {
+        activity_signature: format!("{kind}|{}|{message}", percentage.unwrap_or(u64::MAX)),
+        phase: progress_phase(message),
+        percentage,
+        current_project: progress_project(message),
+        download: progress_download(message),
+    })
+}
+
+/// Returns whether a Java notification is replaced by structured import logs.
+pub(crate) fn is_structured_import_notification(provider_id: &str, method: Option<&str>) -> bool {
+    is_java_provider(provider_id)
+        && matches!(
+            method,
+            Some(WORK_DONE_PROGRESS_METHOD | LANGUAGE_STATUS_METHOD)
+        )
+}
+
+fn progress_phase(message: &str) -> Option<String> {
+    let phase = message
+        .split_once(" - ")
+        .map_or(message, |(phase, _)| phase)
+        .trim();
+    (!phase.is_empty()).then(|| phase.to_string())
+}
+
+fn progress_project(message: &str) -> Option<String> {
+    if let Some((_, project)) = message.split_once("Importing project ") {
+        let project = project.trim().trim_matches('\'');
+        return (!project.is_empty()).then(|| project.to_string());
+    }
+    let (_, quoted) = message.split_once("Project '")?;
+    let (project, _) = quoted.split_once('\'')?;
+    let project = project.trim();
+    (!project.is_empty()).then(|| project.to_string())
+}
+
+fn progress_download(message: &str) -> Option<JdtDownloadProgress> {
+    let url_text = message
+        .split_whitespace()
+        .find(|part| part.starts_with("https://") || part.starts_with("http://"))?
+        .trim_end_matches(|character: char| matches!(character, ',' | ';' | ')' | ']'));
+    let url = Url::parse(url_text).ok()?;
+    let artifact = url
+        .path_segments()
+        .and_then(|mut segments| segments.next_back())
+        .filter(|segment| !segment.is_empty())?
+        .to_string();
+    let sizes = message.split_whitespace().find_map(parse_size_pair);
+    Some(JdtDownloadProgress {
+        artifact,
+        repository_host: url.host_str().map(ToString::to_string),
+        downloaded_bytes: sizes.map(|(downloaded, _)| downloaded),
+        total_bytes: sizes.map(|(_, total)| total),
+    })
+}
+
+fn parse_size_pair(value: &str) -> Option<(u64, u64)> {
+    if value.starts_with("http://") || value.starts_with("https://") {
+        return None;
+    }
+    let value = value.trim_matches(|character: char| matches!(character, '(' | ')' | ',' | ';'));
+    let (downloaded, total) = value.split_once('/')?;
+    Some((parse_byte_count(downloaded)?, parse_byte_count(total)?))
+}
+
+fn parse_byte_count(value: &str) -> Option<u64> {
+    let number_end = value
+        .find(|character: char| !character.is_ascii_digit() && character != '.')
+        .unwrap_or(value.len());
+    let number = value[..number_end].parse::<f64>().ok()?;
+    let multiplier = match value[number_end..].to_ascii_uppercase().as_str() {
+        "B" => 1_f64,
+        "KB" | "KIB" => 1024_f64,
+        "MB" | "MIB" => 1024_f64 * 1024_f64,
+        "GB" | "GIB" => 1024_f64 * 1024_f64 * 1024_f64,
+        _ => return None,
+    };
+    Some((number * multiplier).round() as u64)
 }
 
 /// Marks JDT virtual locations as read-only and gives them a source-like path.
@@ -509,10 +649,10 @@ fn java_settings() -> Value {
     json!({
         "java": {
             "eclipse": {
-                "downloadSources": true
+                "downloadSources": false
             },
             "maven": {
-                "downloadSources": true
+                "downloadSources": false
             },
             "configuration": {
                 "updateBuildConfiguration": "automatic"
@@ -538,10 +678,10 @@ fn java_configuration_for_section(section: Option<&str>) -> Value {
     match section {
         Some("java") => json!({
             "eclipse": {
-                "downloadSources": true
+                "downloadSources": false
             },
             "maven": {
-                "downloadSources": true
+                "downloadSources": false
             },
             "configuration": {
                 "updateBuildConfiguration": "automatic"
@@ -565,10 +705,10 @@ fn java_configuration_for_section(section: Option<&str>) -> Value {
         }),
         Some("java.inlayHints.parameterNames") => json!({ "enabled": "all" }),
         Some("java.inlayHints.parameterNames.enabled") => json!("all"),
-        Some("java.eclipse") => json!({ "downloadSources": true }),
-        Some("java.eclipse.downloadSources") => json!(true),
-        Some("java.maven") => json!({ "downloadSources": true }),
-        Some("java.maven.downloadSources") => json!(true),
+        Some("java.eclipse") => json!({ "downloadSources": false }),
+        Some("java.eclipse.downloadSources") => json!(false),
+        Some("java.maven") => json!({ "downloadSources": false }),
+        Some("java.maven.downloadSources") => json!(false),
         Some("java.configuration") => json!({ "updateBuildConfiguration": "automatic" }),
         Some("java.configuration.updateBuildConfiguration") => json!("automatic"),
         Some("java.implementationsCodeLens") => json!({ "enabled": true }),
@@ -738,6 +878,59 @@ mod tests {
             arguments: vec!["--stdio".to_string()],
             workspace_fingerprint: None,
         }
+    }
+
+    #[test]
+    fn import_progress_extracts_module_and_download_diagnostics() {
+        let module = import_progress(
+            "java",
+            Some("$/progress"),
+            Some(&json!({
+                "value": {
+                    "kind": "report",
+                    "message": "Importing Maven project(s) - Importing project module-a",
+                    "percentage": 24
+                }
+            })),
+        )
+        .expect("Java work-done progress should be observed");
+        assert_eq!(module.phase.as_deref(), Some("Importing Maven project(s)"));
+        assert_eq!(module.current_project.as_deref(), Some("module-a"));
+        assert_eq!(module.percentage, Some(24));
+
+        let download = import_progress(
+            "java",
+            Some("$/progress"),
+            Some(&json!({
+                "value": {
+                    "kind": "report",
+                    "message": "Importing Maven project(s) - 117KB/7MB (1%) https://repo.maven.apache.org/maven2/org/apache/poi/poi.jar",
+                    "percentage": 49
+                }
+            })),
+        )
+        .and_then(|progress| progress.download)
+        .expect("artifact transfer details should be parsed");
+        assert_eq!(download.artifact, "poi.jar");
+        assert_eq!(
+            download.repository_host.as_deref(),
+            Some("repo.maven.apache.org")
+        );
+        assert_eq!(download.downloaded_bytes, Some(117 * 1024));
+        assert_eq!(download.total_bytes, Some(7 * 1024 * 1024));
+    }
+
+    #[test]
+    fn import_progress_ignores_other_providers_and_status_text() {
+        let params = json!({
+            "value": {
+                "kind": "report",
+                "message": "Importing Maven project(s) - 50%",
+                "percentage": 50
+            }
+        });
+        assert!(import_progress("gopls", Some("$/progress"), Some(&params)).is_none());
+        assert!(import_progress("java", Some("language/status"), Some(&params)).is_none());
     }
 
     #[test]
@@ -972,12 +1165,12 @@ mod tests {
         let values = workspace_configuration("java", &items).unwrap();
 
         assert_eq!(values[0]["inlayHints"]["parameterNames"]["enabled"], "all");
-        assert_eq!(values[0]["eclipse"]["downloadSources"], true);
-        assert_eq!(values[0]["maven"]["downloadSources"], true);
+        assert_eq!(values[0]["eclipse"]["downloadSources"], false);
+        assert_eq!(values[0]["maven"]["downloadSources"], false);
         assert_eq!(values[0]["implementationsCodeLens"]["enabled"], true);
         assert_eq!(values[0]["referencesCodeLens"]["enabled"], true);
-        assert_eq!(values[1], true); // java.eclipse.downloadSources
-        assert_eq!(values[2], true); // java.maven.downloadSources
+        assert_eq!(values[1], false); // java.eclipse.downloadSources
+        assert_eq!(values[2], false); // java.maven.downloadSources
         assert_eq!(values[3]["parameterNames"]["enabled"], "all"); // java.inlayHints
         assert_eq!(values[4]["enabled"], "all"); // java.inlayHints.parameterNames
         assert_eq!(values[5], "all"); // java.inlayHints.parameterNames.enabled
@@ -999,11 +1192,11 @@ mod tests {
         );
         assert_eq!(
             notification.params["settings"]["java"]["eclipse"]["downloadSources"],
-            true
+            false
         );
         assert_eq!(
             notification.params["settings"]["java"]["maven"]["downloadSources"],
-            true
+            false
         );
         assert_eq!(
             notification.params["settings"]["java"]["implementationsCodeLens"]["enabled"],

--- a/rust/lithe-core/src/lsp/languages/jdt_progress.rs
+++ b/rust/lithe-core/src/lsp/languages/jdt_progress.rs
@@ -1,0 +1,374 @@
+//! Stateful, throttled diagnostics for JDT LS workspace-import progress.
+
+use super::jdt::JdtImportProgress;
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::{Duration, Instant};
+
+const JAVA_PROGRESS_LOG_INTERVAL_MS: u64 = 2_000;
+const JAVA_PROGRESS_PERCENTAGE_STEP: u64 = 5;
+
+struct JavaDownloadDiagnostics {
+    artifact: String,
+    repository_host: Option<String>,
+    started_at: Instant,
+    downloaded_bytes: Option<u64>,
+    total_bytes: Option<u64>,
+}
+
+/// Java-only preparation observations retained until `ServiceReady` or timeout.
+pub(crate) struct JavaPreparationDiagnostics {
+    startup_started_at: Instant,
+    process_start_elapsed: Duration,
+    cache_disposition: &'static str,
+    workspace_fingerprint_present: bool,
+    readiness_started_at: Option<Instant>,
+    last_progress_at: Option<Instant>,
+    absolute_deadline: Option<Instant>,
+    idle_timeout: Duration,
+    last_activity_signature: Option<String>,
+    phase: Option<String>,
+    progress_percentage: Option<u64>,
+    current_project: Option<String>,
+    observed_projects: BTreeSet<String>,
+    observed_downloads: BTreeMap<String, u64>,
+    active_download: Option<JavaDownloadDiagnostics>,
+    last_log_at: Option<Instant>,
+    last_logged_phase: Option<String>,
+    last_logged_project: Option<String>,
+    last_logged_percentage: Option<u64>,
+    last_logged_download_bytes: Option<u64>,
+    initialize_elapsed: Option<Duration>,
+}
+
+impl JavaPreparationDiagnostics {
+    /// Starts diagnostics with the process-launch and durable-cache observations.
+    pub(crate) fn new(
+        startup_started_at: Instant,
+        process_start_elapsed: Duration,
+        cache_disposition: &'static str,
+        workspace_fingerprint_present: bool,
+    ) -> Self {
+        Self {
+            startup_started_at,
+            process_start_elapsed,
+            cache_disposition,
+            workspace_fingerprint_present,
+            readiness_started_at: None,
+            last_progress_at: None,
+            absolute_deadline: None,
+            idle_timeout: Duration::ZERO,
+            last_activity_signature: None,
+            phase: None,
+            progress_percentage: None,
+            current_project: None,
+            observed_projects: BTreeSet::new(),
+            observed_downloads: BTreeMap::new(),
+            active_download: None,
+            last_log_at: None,
+            last_logged_phase: None,
+            last_logged_project: None,
+            last_logged_percentage: None,
+            last_logged_download_bytes: None,
+            initialize_elapsed: None,
+        }
+    }
+
+    /// Serializes the process-start observation for platform log adapters.
+    pub(crate) fn startup_detail(&self) -> String {
+        json!({
+            "stage": "processStart",
+            "processStartMilliseconds": self.process_start_elapsed.as_millis(),
+            "cacheDisposition": self.cache_disposition,
+            "workspaceFingerprintPresent": self.workspace_fingerprint_present,
+        })
+        .to_string()
+    }
+
+    /// Switches from the standard initialize handshake to post-initialize readiness.
+    pub(crate) fn begin_readiness(
+        &mut self,
+        now: Instant,
+        initialize_elapsed: Duration,
+        idle_timeout: Duration,
+        absolute_timeout: Duration,
+    ) -> String {
+        self.initialize_elapsed = Some(initialize_elapsed);
+        self.readiness_started_at = Some(now);
+        self.last_progress_at = Some(now);
+        self.absolute_deadline = Some(now + absolute_timeout);
+        self.idle_timeout = idle_timeout;
+        json!({
+            "stage": "serviceReady",
+            "initializeMilliseconds": initialize_elapsed.as_millis(),
+            "idleTimeoutMilliseconds": idle_timeout.as_millis(),
+            "absoluteTimeoutMilliseconds": absolute_timeout.as_millis(),
+            "cacheDisposition": self.cache_disposition,
+        })
+        .to_string()
+    }
+
+    /// Records changed work-done progress and returns a throttled JSON log detail.
+    pub(crate) fn record_progress(
+        &mut self,
+        progress: JdtImportProgress,
+        now: Instant,
+    ) -> Option<String> {
+        self.readiness_started_at?;
+        if self.last_activity_signature.as_deref() == Some(&progress.activity_signature) {
+            return None;
+        }
+        self.last_activity_signature = Some(progress.activity_signature);
+        self.last_progress_at = Some(now);
+
+        let phase_changed = progress
+            .phase
+            .as_ref()
+            .is_some_and(|phase| self.last_logged_phase.as_deref() != Some(phase.as_str()));
+        let project_changed = progress
+            .current_project
+            .as_ref()
+            .is_some_and(|project| self.last_logged_project.as_deref() != Some(project.as_str()));
+        let percentage_advanced = progress.percentage.is_some_and(|percentage| {
+            self.last_logged_percentage.is_none_or(|logged| {
+                percentage >= logged.saturating_add(JAVA_PROGRESS_PERCENTAGE_STEP)
+            })
+        });
+        let download_finished = progress.download.is_none() && self.active_download.is_some();
+
+        if let Some(phase) = progress.phase {
+            self.phase = Some(phase);
+        }
+        if let Some(percentage) = progress.percentage {
+            self.progress_percentage = Some(percentage);
+        }
+        if let Some(project) = progress.current_project {
+            self.observed_projects.insert(project.clone());
+            self.current_project = Some(project);
+        }
+
+        let mut download_advanced = false;
+        if let Some(download) = progress.download {
+            let download_key = format!(
+                "{}/{}",
+                download.repository_host.as_deref().unwrap_or("unknown"),
+                download.artifact
+            );
+            let observed = self.observed_downloads.entry(download_key).or_default();
+            if let Some(downloaded_bytes) = download.downloaded_bytes {
+                *observed = (*observed).max(downloaded_bytes);
+                download_advanced = self
+                    .last_logged_download_bytes
+                    .is_none_or(|logged| downloaded_bytes > logged);
+            }
+            let same_download = self.active_download.as_ref().is_some_and(|active| {
+                active.artifact == download.artifact
+                    && active.repository_host == download.repository_host
+            });
+            if same_download {
+                if let Some(active) = self.active_download.as_mut() {
+                    active.downloaded_bytes = download.downloaded_bytes;
+                    active.total_bytes = download.total_bytes;
+                }
+            } else {
+                self.active_download = Some(JavaDownloadDiagnostics {
+                    artifact: download.artifact,
+                    repository_host: download.repository_host,
+                    started_at: now,
+                    downloaded_bytes: download.downloaded_bytes,
+                    total_bytes: download.total_bytes,
+                });
+                self.last_logged_download_bytes = None;
+                download_advanced = true;
+            }
+        } else {
+            self.active_download = None;
+            self.last_logged_download_bytes = None;
+        }
+
+        let log_interval_elapsed = self.last_log_at.is_none_or(|logged_at| {
+            now.saturating_duration_since(logged_at)
+                >= Duration::from_millis(JAVA_PROGRESS_LOG_INTERVAL_MS)
+        });
+        let should_log = phase_changed
+            || project_changed
+            || percentage_advanced
+            || download_finished
+            || (download_advanced && log_interval_elapsed);
+        if !should_log {
+            return None;
+        }
+
+        self.last_log_at = Some(now);
+        self.last_logged_phase = self.phase.clone();
+        self.last_logged_project = self.current_project.clone();
+        self.last_logged_percentage = self.progress_percentage;
+        self.last_logged_download_bytes = self
+            .active_download
+            .as_ref()
+            .and_then(|download| download.downloaded_bytes);
+        Some(self.progress_detail(now))
+    }
+
+    fn progress_detail(&self, now: Instant) -> String {
+        let (artifact, repository_host, downloaded_bytes, total_bytes, bytes_per_second) = self
+            .active_download
+            .as_ref()
+            .map(|download| {
+                let elapsed = now.saturating_duration_since(download.started_at);
+                let throughput = download.downloaded_bytes.and_then(|bytes| {
+                    (elapsed > Duration::ZERO)
+                        .then(|| (bytes as f64 / elapsed.as_secs_f64()).round() as u64)
+                });
+                (
+                    Some(download.artifact.clone()),
+                    download.repository_host.clone(),
+                    download.downloaded_bytes,
+                    download.total_bytes,
+                    throughput,
+                )
+            })
+            .unwrap_or((None, None, None, None, None));
+        json!({
+            "stage": "serviceReady",
+            "phase": self.phase,
+            "progressPercent": self.progress_percentage,
+            "currentProject": self.current_project,
+            "observedProjectCount": self.observed_projects.len(),
+            "downloadArtifact": artifact,
+            "repositoryHost": repository_host,
+            "downloadedBytes": downloaded_bytes,
+            "totalBytes": total_bytes,
+            "bytesPerSecond": bytes_per_second,
+            "elapsedMilliseconds": self.readiness_started_at
+                .map(|started| now.saturating_duration_since(started).as_millis()),
+            "idleMilliseconds": self.last_progress_at
+                .map(|progress| now.saturating_duration_since(progress).as_millis()),
+            "cacheDisposition": self.cache_disposition,
+        })
+        .to_string()
+    }
+
+    /// Finishes preparation and serializes one aggregate startup summary.
+    pub(crate) fn ready_detail(&mut self, now: Instant) -> String {
+        let import_elapsed = self
+            .readiness_started_at
+            .map(|started| now.saturating_duration_since(started));
+        self.readiness_started_at = None;
+        self.absolute_deadline = None;
+        let downloaded_bytes: u64 = self.observed_downloads.values().copied().sum();
+        json!({
+            "stage": "serviceReady",
+            "outcome": "ready",
+            "totalMilliseconds": now.saturating_duration_since(self.startup_started_at).as_millis(),
+            "processStartMilliseconds": self.process_start_elapsed.as_millis(),
+            "initializeMilliseconds": self.initialize_elapsed.map(|elapsed| elapsed.as_millis()),
+            "importMilliseconds": import_elapsed.map(|elapsed| elapsed.as_millis()),
+            "progressPercent": self.progress_percentage,
+            "observedProjectCount": self.observed_projects.len(),
+            "downloadedArtifactCount": self.observed_downloads.len(),
+            "downloadedBytes": downloaded_bytes,
+            "cacheDisposition": self.cache_disposition,
+        })
+        .to_string()
+    }
+
+    /// Takes an idle or absolute timeout once and returns its diagnostic snapshot.
+    pub(crate) fn take_timeout(&mut self, now: Instant) -> Option<String> {
+        let started_at = self.readiness_started_at?;
+        let last_progress_at = self.last_progress_at.unwrap_or(started_at);
+        let idle = now.saturating_duration_since(last_progress_at);
+        let timeout_kind = if self
+            .absolute_deadline
+            .is_some_and(|deadline| now >= deadline)
+        {
+            "absolute"
+        } else if idle >= self.idle_timeout {
+            "idle"
+        } else {
+            return None;
+        };
+        let classification = match (timeout_kind, self.active_download.is_some()) {
+            ("idle", true) => "networkDownloadStalled",
+            ("idle", false) => "noProgressStall",
+            ("absolute", true) => "networkTransferActive",
+            _ => "projectImportActive",
+        };
+        self.readiness_started_at = None;
+        self.absolute_deadline = None;
+        Some(
+            json!({
+                "stage": "serviceReady",
+                "timeoutKind": timeout_kind,
+                "classification": classification,
+                "elapsedMilliseconds": now.saturating_duration_since(started_at).as_millis(),
+                "idleMilliseconds": idle.as_millis(),
+                "progressPercent": self.progress_percentage,
+                "phase": self.phase,
+                "currentProject": self.current_project,
+                "observedProjectCount": self.observed_projects.len(),
+                "downloadArtifact": self.active_download.as_ref().map(|download| &download.artifact),
+                "downloadedBytes": self.active_download.as_ref().and_then(|download| download.downloaded_bytes),
+                "totalBytes": self.active_download.as_ref().and_then(|download| download.total_bytes),
+                "cacheDisposition": self.cache_disposition,
+            })
+            .to_string(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn progress(signature: &str, percentage: u64) -> JdtImportProgress {
+        JdtImportProgress {
+            activity_signature: signature.to_string(),
+            phase: Some("Importing Maven project(s)".to_string()),
+            percentage: Some(percentage),
+            current_project: Some("module-a".to_string()),
+            download: None,
+        }
+    }
+
+    #[test]
+    fn duplicate_progress_does_not_refresh_the_idle_deadline() {
+        let started = Instant::now();
+        let mut diagnostics =
+            JavaPreparationDiagnostics::new(started, Duration::from_millis(5), "new", true);
+        diagnostics.begin_readiness(
+            started,
+            Duration::from_millis(10),
+            Duration::from_millis(45),
+            Duration::from_secs(10),
+        );
+        diagnostics.record_progress(progress("same", 20), started + Duration::from_millis(10));
+        diagnostics.record_progress(progress("same", 20), started + Duration::from_millis(30));
+
+        let timeout = diagnostics
+            .take_timeout(started + Duration::from_millis(56))
+            .expect("unchanged progress must not keep preparation alive");
+        assert!(timeout.contains("\"timeoutKind\":\"idle\""));
+    }
+
+    #[test]
+    fn absolute_deadline_still_caps_continuously_active_imports() {
+        let started = Instant::now();
+        let mut diagnostics =
+            JavaPreparationDiagnostics::new(started, Duration::from_millis(5), "reused", true);
+        diagnostics.begin_readiness(
+            started,
+            Duration::from_millis(10),
+            Duration::from_secs(1),
+            Duration::from_millis(100),
+        );
+        diagnostics.record_progress(progress("first", 20), started + Duration::from_millis(40));
+        diagnostics.record_progress(progress("second", 25), started + Duration::from_millis(90));
+
+        let timeout = diagnostics
+            .take_timeout(started + Duration::from_millis(100))
+            .expect("the absolute deadline must remain a final safety cap");
+        assert!(timeout.contains("\"timeoutKind\":\"absolute\""));
+        assert!(timeout.contains("\"classification\":\"projectImportActive\""));
+    }
+}

--- a/rust/lithe-core/src/lsp/languages/jdt_progress.rs
+++ b/rust/lithe-core/src/lsp/languages/jdt_progress.rs
@@ -332,6 +332,39 @@ mod tests {
     }
 
     #[test]
+    fn meaningful_progress_refreshes_the_idle_deadline() {
+        let started = Instant::now();
+        let mut diagnostics =
+            JavaPreparationDiagnostics::new(started, Duration::from_millis(5), "new", true);
+        diagnostics.begin_readiness(
+            started,
+            Duration::from_millis(10),
+            Duration::from_millis(100),
+            Duration::from_secs(1),
+        );
+        diagnostics.record_progress(progress("first", 20), started + Duration::from_millis(80));
+
+        assert!(
+            diagnostics
+                .take_timeout(started + Duration::from_millis(150))
+                .is_none(),
+            "changed progress should extend the original idle deadline"
+        );
+        diagnostics.record_progress(progress("second", 25), started + Duration::from_millis(160));
+        assert!(
+            diagnostics
+                .take_timeout(started + Duration::from_millis(240))
+                .is_none(),
+            "each changed progress event should refresh the idle deadline"
+        );
+
+        let timeout = diagnostics
+            .take_timeout(started + Duration::from_millis(261))
+            .expect("silence after the refreshed deadline should still time out");
+        assert!(timeout.contains("\"timeoutKind\":\"idle\""));
+    }
+
+    #[test]
     fn duplicate_progress_does_not_refresh_the_idle_deadline() {
         let started = Instant::now();
         let mut diagnostics =

--- a/rust/lithe-core/src/lsp/languages/mod.rs
+++ b/rust/lithe-core/src/lsp/languages/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod java_navigation_syntax;
 mod java_workspace;
 pub(crate) mod jdt;
 pub(crate) mod jdt_navigation;
+pub(crate) mod jdt_progress;
 #[cfg(test)]
 pub(crate) mod swift;
 

--- a/shared/contracts/application-boundary.md
+++ b/shared/contracts/application-boundary.md
@@ -179,6 +179,13 @@ code, and diagnostic detail across the Rust, Swift, and TypeScript boundaries.
 Domain and adapter layers return stable reasons rather than user-facing prose;
 each product's presentation layer owns localized notification text.
 
+For JDT LS, the standard initialize handshake and project-import readiness use
+separate Core-owned deadlines. Project import fails only after 45 seconds
+without changed progress or the 10-minute absolute safety cap; platform clients
+must not impose a shorter readiness deadline. The terminal timeout code is
+`serviceReadyTimeout`, and its details preserve the last import, download, and
+cache snapshot for both products.
+
 ## Error Codes
 
 Use stable categories rather than platform error strings:

--- a/shared/contracts/rust-core-api.md
+++ b/shared/contracts/rust-core-api.md
@@ -369,7 +369,13 @@ commands are the semantic LSP runtime boundary. `lsp.startServer` accepts the
 provider ID, selected executable/arguments/environment, root URI, working
 directory, initialization options, optional runtime executable,
 `jdtlsLaunchResources`, cache directory, and `workspaceFingerprint`, plus
-initialize/request/shutdown deadlines. `jdtlsLaunchResources`, when present,
+initialize, post-initialize readiness, request, and shutdown deadlines.
+`initializeTimeoutMilliseconds` bounds only the standard LSP handshake. For a
+provider such as JDT LS that has a later readiness signal,
+`serviceReadyIdleTimeoutMilliseconds` bounds time without changed work-done
+progress and `serviceReadyAbsoluteTimeoutMilliseconds` is the final safety cap.
+The defaults are 45 seconds idle and 10 minutes absolute; duplicate progress
+does not refresh the idle deadline. `jdtlsLaunchResources`, when present,
 contains `launcherJarPath`, `configurationDirectory`, and `lombokAgentPath`; it
 is valid only for the Java provider and requires `runtimeExecutablePath`. Rust
 then uses `runtimeExecutablePath` as the process executable and constructs the
@@ -379,6 +385,15 @@ compatibility path. Rust owns the returned
 session's child process, stdin/stdout/stderr, framing buffer, JSON-RPC request
 IDs, document versions, pending deadlines, capabilities, diagnostics, and
 graceful/forced termination.
+
+JDT LS remains `initializing` until `language/status: ServiceReady`. During this
+phase Rust reduces changed `$/progress` notifications into throttled JSON log
+details containing the current phase, percentage, project, observed project
+count, artifact name, repository host, downloaded/total bytes, calculated
+throughput, elapsed/idle durations, and cache disposition. Progress parsing is
+observability-only and never substitutes for `ServiceReady`. Idle and absolute
+failures use `serviceReadyTimeout` at stage `serviceReady` and retain the final
+diagnostic snapshot in `underlyingMessage`.
 
 Platform adapters own filesystem discovery and validate that packaged JDT LS
 contains the Equinox launcher, platform configuration directory, Lombok agent,

--- a/shared/fixtures/lsp/jdt-direct-launch-v1.json
+++ b/shared/fixtures/lsp/jdt-direct-launch-v1.json
@@ -20,7 +20,9 @@
     },
     "cacheDirectory": "/var/cache/lithe/language-servers",
     "workspaceFingerprint": "build=|modules=|jdtls=1.55.0",
-    "initializeTimeoutMilliseconds": 60000,
+    "initializeTimeoutMilliseconds": 30000,
+    "serviceReadyIdleTimeoutMilliseconds": 45000,
+    "serviceReadyAbsoluteTimeoutMilliseconds": 600000,
     "requestTimeoutMilliseconds": 30000,
     "shutdownTimeoutMilliseconds": 2000
   }

--- a/windows/tauri/src/features/editor/lsp/java-workspace-language-server.test.ts
+++ b/windows/tauri/src/features/editor/lsp/java-workspace-language-server.test.ts
@@ -95,7 +95,7 @@ test("closing a workspace cancels an in-flight prewarm and stops its server", as
 
 test("records a timeout without converting it to a generic failure", async () => {
   const timeout = Object.assign(new Error("JDTLS initialize timed out"), {
-    code: "timed_out",
+    code: "serviceReadyTimeout",
   });
   const operations = operationRecorder();
   const notifyFailure = mock(() => undefined);

--- a/windows/tauri/src/features/editor/lsp/java-workspace-language-server.ts
+++ b/windows/tauri/src/features/editor/lsp/java-workspace-language-server.ts
@@ -60,7 +60,8 @@ function workspaceKey(workspacePath: string): string {
 }
 
 function isTimeout(error: unknown): boolean {
-  return (error as { code?: unknown } | null)?.code === "timed_out";
+  const code = (error as { code?: unknown } | null)?.code;
+  return code === "timed_out" || code === "initializeTimeout" || code === "serviceReadyTimeout";
 }
 
 export class JavaWorkspaceLanguageServerOwner {

--- a/windows/tauri/src/platform/lsp-core-adapter.test.ts
+++ b/windows/tauri/src/platform/lsp-core-adapter.test.ts
@@ -32,6 +32,7 @@ let scenario:
   | "multi-session"
   | "runtime-ready-transition"
   | "semantic-request"
+  | "structured-log"
   | "virtual-document" = "failure";
 let startPayload: Record<string, unknown> | undefined;
 let requestPayload: Record<string, unknown> | undefined;
@@ -125,6 +126,32 @@ const executeCore = mock(
           id: request.id,
           ok: true as const,
           data: { events: sessionPollCount === 1 ? readyEvents(sessionId) : [] },
+        };
+      }
+      if (scenario === "structured-log") {
+        return {
+          id: request.id,
+          ok: true as const,
+          data: {
+            events:
+              sessionPollCount === 1
+                ? [
+                    {
+                      type: "log",
+                      level: "info",
+                      message: "Java workspace import progress",
+                      detail: JSON.stringify({
+                        stage: "serviceReady",
+                        currentProject: "module-a",
+                        downloadedBytes: 1024,
+                      }),
+                      providerId: "java",
+                      sessionId,
+                    },
+                    ...readyEvents(sessionId),
+                  ]
+                : [],
+          },
         };
       }
       if (scenario === "runtime-ready-transition") {
@@ -457,6 +484,28 @@ describe("Rust Core LSP adapter failures", () => {
     } finally {
       testStorage.restore();
     }
+  });
+
+  test("projects structured Java import diagnostics as searchable log fields", async () => {
+    scenario = "structured-log";
+    await invokeLsp("lsp_start_for_file", {
+      workspacePath: "C:/work",
+      filePath: "C:/work/Main.java",
+      languageId: "java",
+      providerId: "java",
+      serverPath: "C:/Lithe/jdtls.bat",
+    });
+
+    expect(frontendTrace).toHaveBeenCalledWith(
+      "info",
+      "lsp.runtime",
+      "Java workspace import progress",
+      expect.objectContaining({
+        stage: "serviceReady",
+        currentProject: "module-a",
+        downloadedBytes: 1024,
+      }),
+    );
   });
 
   test("starts and exposes a workspace-owned Java session before a file attaches", async () => {

--- a/windows/tauri/src/platform/lsp-core-adapter.ts
+++ b/windows/tauri/src/platform/lsp-core-adapter.ts
@@ -334,8 +334,9 @@ function normalizeCoreValue(value: unknown): unknown {
 async function dispatchRuntimeEvent(event: RuntimeEvent): Promise<void> {
   if (event.type === "log") {
     const level = event.level === "error" ? "error" : event.level === "warning" ? "warn" : "info";
+    const structuredDetail = parseStructuredRuntimeDetail(event.detail);
     frontendTrace(level, "lsp.runtime", event.message ?? "Language-server log", {
-      detail: event.detail ?? null,
+      ...(structuredDetail ?? { detail: event.detail ?? null }),
       providerId: event.providerId,
       sessionId: event.sessionId,
     });
@@ -350,6 +351,23 @@ async function dispatchRuntimeEvent(event: RuntimeEvent): Promise<void> {
   if (event.type === "stateChanged" && event.state === "failed") {
     await emit("lsp://server-crashed", {});
   }
+}
+
+function parseStructuredRuntimeDetail(detail: string | undefined): JsonRecord | null {
+  if (!detail?.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(detail);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as JsonRecord)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isInitializationTimeout(reason: unknown): boolean {
+  const code = (reason as Error & { code?: string } | null)?.code;
+  return code === "timed_out" || code === "initializeTimeout" || code === "serviceReadyTimeout";
 }
 
 async function dispatchSessionEvent(session: Session, event: RuntimeEvent): Promise<void> {
@@ -490,8 +508,7 @@ async function runEventPump(session: Session, owner: EventPumpOwner): Promise<vo
 }
 
 async function waitUntilReady(session: Session): Promise<void> {
-  const deadline = Date.now() + INITIALIZE_TIMEOUT_MS;
-  while (Date.now() < deadline) {
+  while (true) {
     const events = await poll(session, 200);
     if (isSessionReady(session.lifecycle)) return;
     const state = [...events].reverse().find((event) => event.type === "stateChanged")?.state;
@@ -515,9 +532,6 @@ async function waitUntilReady(session: Session): Promise<void> {
       throw error;
     }
   }
-  const error = new Error("Language server initialization timed out") as Error & { code?: string };
-  error.code = "timed_out";
-  throw error;
 }
 
 async function stopAndDestroySession(
@@ -700,8 +714,12 @@ async function createSession(args: JsonRecord, key: string): Promise<Session> {
   try {
     await waitUntilReady(session);
   } catch (reason) {
-    if ((reason as Error & { code?: string })?.code === "timed_out") {
-      operation.timedOut({ stage: "initialize", sessionId: session.id });
+    if (isInitializationTimeout(reason)) {
+      const code = (reason as Error & { code?: string }).code;
+      operation.timedOut({
+        stage: code === "serviceReadyTimeout" ? "serviceReady" : "initialize",
+        sessionId: session.id,
+      });
     } else {
       operation.failed(reason, { stage: "initialize", sessionId: session.id });
     }
@@ -717,14 +735,13 @@ async function createSession(args: JsonRecord, key: string): Promise<Session> {
 
 async function waitForProjectedReadiness(
   session: Session,
-): Promise<"ready" | "terminal" | "timedOut"> {
+): Promise<"ready" | "terminal"> {
   const operation = new LspOperationLog("sessionReadinessWait", crypto.randomUUID(), {
     sessionId: session.id,
     workspacePath: session.workspacePath,
     languageId: session.languageId,
   });
-  const deadline = Date.now() + INITIALIZE_TIMEOUT_MS;
-  while (Date.now() < deadline) {
+  while (true) {
     if (isSessionReady(session.lifecycle)) {
       operation.succeeded();
       return "ready";
@@ -735,8 +752,6 @@ async function waitForProjectedReadiness(
     }
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
-  operation.timedOut({ sessionState: session.lifecycle.phase });
-  return "timedOut";
 }
 
 async function resolveSession(args: JsonRecord, key: string): Promise<Session> {


### PR DESCRIPTION
## Summary

- split the standard LSP initialize deadline from JDTLS ServiceReady project-import readiness in shared Rust Core
- use a 45-second no-progress timeout plus a 10-minute absolute cap, while meaningful module and download progress keeps the session alive
- emit structured module, download, throughput, cache, elapsed-time, and stall diagnostics for Windows and macOS
- remove Windows frontend-owned readiness deadlines and keep both platforms dependent on Core lifecycle events
- disable nonessential Maven and Eclipse source attachment downloads during initial import while retaining required POM and JAR resolution

## Validation

- ./scripts/verify-rust-core.sh
- ./scripts/verify-shared-contracts.sh
- ./scripts/verify-windows-boundaries.sh
- ./scripts/verify-service-boundaries.sh
- ./scripts/test-macos.sh
- bun test src/platform/lsp-core-adapter.test.ts src/features/editor/lsp/java-workspace-language-server.test.ts
- bun run typecheck

Rust Core: 262 tests passed. macOS: 659 tests in 77 suites passed. Windows targeted tests: 20 passed.