### PR TITLE
docs: trim README hero actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@
     <img src="https://img.shields.io/badge/Debugger-Breakpoints-D32F2F?style=flat" alt="Breakpoint debugging">
     <img src="https://img.shields.io/badge/Git-Diff%20Review-F05032?style=flat&logo=git&logoColor=white" alt="Git diff review">
     <img src="https://img.shields.io/badge/Database-SQL%20Workspace-336791?style=flat" alt="Database SQL workspace">
-    <img src="https://img.shields.io/badge/AI-Commit%20Messages-8B5CF6?style=flat" alt="AI commit messages">
-  </p>
-
-  <p>
-    <a href="https://github.com/1lck/Lithe-IDEA/releases/latest"><strong>Download the latest release</strong></a> ·
-    <a href="https://github.com/1lck/Lithe-IDEA">View the repository</a>
   </p>
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,12 +35,6 @@
     <img src="https://img.shields.io/badge/Debugger-Breakpoints-D32F2F?style=flat" alt="断点调试">
     <img src="https://img.shields.io/badge/Git-Diff%20Review-F05032?style=flat&logo=git&logoColor=white" alt="Git Diff 审查">
     <img src="https://img.shields.io/badge/Database-SQL%20Workspace-336791?style=flat" alt="数据库 SQL 工作台">
-    <img src="https://img.shields.io/badge/AI-Commit%20Messages-8B5CF6?style=flat" alt="AI Commit Message">
-  </p>
-
-  <p>
-    <a href="https://github.com/1lck/Lithe-IDEA/releases/latest"><strong>下载最新版本</strong></a> ·
-    <a href="https://github.com/1lck/Lithe-IDEA">查看 GitHub 仓库</a>
   </p>
 </div>
 


### PR DESCRIPTION
## Summary

- remove the AI Commit Messages badge from the compact capability row
- remove the redundant download and repository text links below the hero badges
- keep the English and Chinese READMEs aligned

## Verification

- `git diff --check`
- confirmed both READMEs retain the same 13 compact badges