### PR TITLE
fix(release): restore Windows in-app updater artifacts

### DIFF
--- a/.agents/skills/release-lithe/SKILL.md
+++ b/.agents/skills/release-lithe/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: release-lithe
+description: Prepare and validate stable Lithe release notes and publishing workflows. Use when drafting docs/releases files, cutting a stable version, publishing a GitHub Release, or changing stable release automation.
+---
+
+# Release Lithe
+
+Apply this Skill after `develop-lithe` for stable releases. Preview releases
+keep their existing workflow unless the task explicitly includes them.
+
+## Prepare the release notes first
+
+- Create `docs/releases/v<version>.md` and commit it before creating the tag or
+  manually dispatching either stable release workflow.
+- Derive the content from the commits, pull requests, tests, packaging changes,
+  and known limitations between the previous stable tag and the target commit.
+  Do not invent features, compatibility claims, download assets, or fixes.
+- Treat the release notes as a required release artifact. A missing or empty
+  file blocks the release; never fall back to GitHub-generated notes.
+- Keep user-facing language focused on outcomes. Do not publish a raw commit or
+  pull-request list as the release description.
+
+## Use the bilingual structure
+
+Write Simplified Chinese first and English second, separated by `---`. Keep the
+two sections equivalent in meaning. Use these literal required headings and
+this order:
+
+1. `## 中文`, a short release summary, `### 下载`, and `### 重点更新`.
+2. Optional product-area groupings when they make the changes easier to scan.
+3. `### 升级说明` and `### 兼容性与已知问题`.
+4. A comparison link from the previous stable tag to the new tag.
+5. `## English`, a short release summary, `### Downloads`, and `### Highlights`.
+6. English counterparts for any optional product-area groupings.
+7. `### Upgrade instructions` and `### Compatibility and known issues`.
+8. The equivalent English comparison link.
+
+The download sections cover the project page, both macOS architectures,
+Windows x64, and the complete Release Assets page. Use versioned asset URLs
+that match the packaging workflows. Upgrade instructions cover macOS DMG,
+Homebrew, and Windows. Compatibility sections include platform preview or
+signing limitations only when they actually apply to that version.
+
+Use the most recent stable file under `docs/releases/` as the formatting
+reference, but verify every statement and URL for the new version instead of
+copying stale details.
+
+## Validate before publishing
+
+- Confirm the version uses `MAJOR.MINOR.PATCH`, the filename is exactly
+  `docs/releases/v<version>.md`, and the file is non-empty.
+- Check that Chinese and English describe the same release and that download
+  filenames match the artifacts produced by both platform workflows.
+- Check the comparison range, current platform requirements, bundled tools,
+  signing status, updater availability, and known issues against the target
+  commit and release configuration.
+- Run `actionlint` after changing a GitHub Actions workflow. Run any focused
+  packaging or manifest checks required by `develop-lithe` for other release
+  changes.
+
+Creating tags, pushing commits, dispatching workflows, or editing a live GitHub
+Release changes external state. Perform those actions only when the user has
+explicitly requested them. Preparing and validating the local release artifact
+does not authorize publication.

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -29,6 +29,9 @@ jobs:
       build_number: ${{ steps.version.outputs.build_number }}
 
     steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+
       - name: Resolve release version
         id: version
         env:
@@ -52,6 +55,17 @@ jobs:
             echo "tag=v$version"
             echo "build_number=$GITHUB_RUN_NUMBER"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Validate release notes
+        env:
+          LITHE_VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          notes_file="docs/releases/v${LITHE_VERSION}.md"
+          if [[ ! -s "$notes_file" ]]; then
+            echo "::error file=${notes_file}::Stable releases require non-empty bilingual release notes."
+            exit 1
+          fi
 
   build:
     name: Build ${{ matrix.architecture }} release
@@ -209,12 +223,8 @@ jobs:
             "dist/latest-macos.json"
           )
 
-          if [[ -f "$notes_file" ]]; then
-            create_args+=(--notes-file "$notes_file")
-            edit_args+=(--notes-file "$notes_file")
-          else
-            create_args+=(--generate-notes)
-          fi
+          create_args+=(--notes-file "$notes_file")
+          edit_args+=(--notes-file "$notes_file")
 
           if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create "${create_args[@]}" || \

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -62,10 +62,7 @@ jobs:
         shell: bash
         run: |
           notes_file="docs/releases/v${LITHE_VERSION}.md"
-          if [[ ! -s "$notes_file" ]]; then
-            echo "::error file=${notes_file}::Stable releases require non-empty bilingual release notes."
-            exit 1
-          fi
+          node scripts/validate-stable-release-notes.mjs "$notes_file"
 
   build:
     name: Build ${{ matrix.architecture }} release

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -30,6 +30,35 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
 
+      - name: Resolve release version
+        id: version
+        shell: pwsh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_VERSION: ${{ inputs.version }}
+        run: |
+          $version = if ($env:EVENT_NAME -eq "workflow_dispatch") {
+            $env:MANUAL_VERSION
+          } else {
+            $env:GITHUB_REF_NAME.Substring(1)
+          }
+          if ($version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+$') {
+            throw "Release version must use the form MAJOR.MINOR.PATCH: $version"
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "tag=v$version" >> $env:GITHUB_OUTPUT
+
+      - name: Validate release notes
+        shell: pwsh
+        env:
+          LITHE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          $notes = "docs/releases/v$env:LITHE_VERSION.md"
+          if (-not (Test-Path -LiteralPath $notes -PathType Leaf) -or
+              (Get-Item -LiteralPath $notes).Length -eq 0) {
+            throw "Stable releases require non-empty bilingual release notes: $notes"
+          }
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -133,24 +162,6 @@ jobs:
             -JdkOutcome "${{ steps.jdk-download-cache.outcome }}" `
             -IncludeWindowsAssets
 
-      - name: Resolve release version
-        id: version
-        shell: pwsh
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          MANUAL_VERSION: ${{ inputs.version }}
-        run: |
-          $version = if ($env:EVENT_NAME -eq "workflow_dispatch") {
-            $env:MANUAL_VERSION
-          } else {
-            $env:GITHUB_REF_NAME.Substring(1)
-          }
-          if ($version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+$') {
-            throw "Release version must use the form MAJOR.MINOR.PATCH: $version"
-          }
-          "version=$version" >> $env:GITHUB_OUTPUT
-          "tag=v$version" >> $env:GITHUB_OUTPUT
-
       - name: Import Authenticode certificate
         id: signing
         shell: pwsh
@@ -248,14 +259,19 @@ jobs:
           )
           $existing = gh release view $env:RELEASE_TAG --repo $env:GITHUB_REPOSITORY 2>$null
           if ($LASTEXITCODE -ne 0) {
-            if (Test-Path -LiteralPath $notes) { $createArgs += @("--notes-file", $notes) }
-            else { $createArgs += "--generate-notes" }
+            $createArgs += @("--notes-file", $notes)
             gh release create @createArgs
             if ($LASTEXITCODE -ne 0) {
               $existing = gh release view $env:RELEASE_TAG --repo $env:GITHUB_REPOSITORY 2>$null
               if ($LASTEXITCODE -ne 0) { throw "Could not create or find release $env:RELEASE_TAG" }
             }
           }
+          gh release edit $env:RELEASE_TAG `
+            --repo $env:GITHUB_REPOSITORY `
+            --target $env:GITHUB_SHA `
+            --title "Lithe $env:RELEASE_TAG" `
+            --notes-file $notes
+          if ($LASTEXITCODE -ne 0) { throw "Could not update release notes for $env:RELEASE_TAG" }
 
           $assets = @(
             "dist/Lithe-$env:LITHE_VERSION-windows-x64.exe",

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -54,10 +54,7 @@ jobs:
           LITHE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           $notes = "docs/releases/v$env:LITHE_VERSION.md"
-          if (-not (Test-Path -LiteralPath $notes -PathType Leaf) -or
-              (Get-Item -LiteralPath $notes).Length -eq 0) {
-            throw "Stable releases require non-empty bilingual release notes: $notes"
-          }
+          node scripts/validate-stable-release-notes.mjs $notes
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -185,19 +185,22 @@ jobs:
           "LITHE_WINDOWS_CERTIFICATE_THUMBPRINT=$($certificate.Thumbprint)" >> $env:GITHUB_ENV
           "signed=true" >> $env:GITHUB_OUTPUT
 
-      - name: Resolve updater signing
-        id: updater-signing
+      - name: Validate updater signing
         shell: pwsh
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           LITHE_UPDATER_PUBLIC_KEY: ${{ vars.TAURI_UPDATER_PUBLIC_KEY }}
         run: |
-          $configured = -not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY) -and
-            -not [string]::IsNullOrWhiteSpace($env:LITHE_UPDATER_PUBLIC_KEY)
-          if (-not $configured) {
-            Write-Output "Tauri updater signing is not configured; publishing the installer without updater artifacts."
+          $missing = @()
+          if ([string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY)) {
+            $missing += "TAURI_SIGNING_PRIVATE_KEY secret"
           }
-          "configured=$($configured.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+          if ([string]::IsNullOrWhiteSpace($env:LITHE_UPDATER_PUBLIC_KEY)) {
+            $missing += "TAURI_UPDATER_PUBLIC_KEY variable"
+          }
+          if ($missing.Count -gt 0) {
+            throw "Stable Windows releases require Tauri updater signing. Missing: $($missing -join ', ')."
+          }
 
       - name: Package Windows installer
         shell: pwsh
@@ -212,10 +215,8 @@ jobs:
           $packageArgs = @{
             Configuration = "Release"
             Version = $env:LITHE_VERSION
-          }
-          if ("${{ steps.updater-signing.outputs.configured }}" -eq "true") {
-            $packageArgs.UpdaterEndpoint = "https://github.com/$env:GITHUB_REPOSITORY/releases/latest/download/latest.json"
-            $packageArgs.RequireUpdaterArtifacts = $true
+            UpdaterEndpoint = "https://github.com/$env:GITHUB_REPOSITORY/releases/latest/download/latest.json"
+            RequireUpdaterArtifacts = $true
           }
           if ($env:WINDOWS_RELEASE_SIGNED -eq "true") {
             $packageArgs.RequireAuthenticodeSignature = $true
@@ -225,7 +226,6 @@ jobs:
           ./scripts/package-windows.ps1 @packageArgs
 
       - name: Create updater manifest
-        if: steps.updater-signing.outputs.configured == 'true'
         shell: pwsh
         run: |
           ./scripts/create-windows-updater-manifest.ps1 `
@@ -247,7 +247,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.version.outputs.tag }}
           LITHE_VERSION: ${{ steps.version.outputs.version }}
-          WINDOWS_UPDATER_CONFIGURED: ${{ steps.updater-signing.outputs.configured }}
         shell: pwsh
         run: |
           $notes = "docs/releases/v$env:LITHE_VERSION.md"
@@ -275,14 +274,10 @@ jobs:
 
           $assets = @(
             "dist/Lithe-$env:LITHE_VERSION-windows-x64.exe",
-            "dist/Lithe-$env:LITHE_VERSION-windows-x64.exe.sha256"
+            "dist/Lithe-$env:LITHE_VERSION-windows-x64.exe.sha256",
+            "dist/Lithe-$env:LITHE_VERSION-windows-x64-updater.exe",
+            "dist/Lithe-$env:LITHE_VERSION-windows-x64-updater.exe.sig",
+            "dist/latest.json"
           )
-          if ($env:WINDOWS_UPDATER_CONFIGURED -eq "true") {
-            $assets += @(
-              "dist/Lithe-$env:LITHE_VERSION-windows-x64-updater.exe",
-              "dist/Lithe-$env:LITHE_VERSION-windows-x64-updater.exe.sig",
-              "dist/latest.json"
-            )
-          }
           gh release upload $env:RELEASE_TAG @assets `
             --repo $env:GITHUB_REPOSITORY --clobber

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ additionally load `.agents/skills/write-stable-tests/SKILL.md` before
 proceeding. That Skill defines the mandatory bounded-wait, deterministic-time,
 cleanup, and per-test timing rules for both macOS and Windows.
 
+If a task prepares, validates, or publishes a stable Lithe release,
+additionally load `.agents/skills/release-lithe/SKILL.md` before changing
+release notes, version metadata, tags, or release workflows.
+
 If the task involves building, running, diagnosing, or transferring files to the
 Windows product through a Parallels guest VM, additionally load
 `.agents/skills/debug-windows-on-parallels/SKILL.md` before proceeding.

--- a/docs/releases/windows-updater.md
+++ b/docs/releases/windows-updater.md
@@ -11,14 +11,18 @@ An owner of the release repository must generate the updater signing keypair:
 
 ```powershell
 cd windows/tauri
-bunx tauri signer generate
+bun run tauri signer generate -w <secure-backup-directory>/lithe-updater.key
 ```
+
+The command writes the password-protected private key to the requested path and
+the shareable public key alongside it. Back up the private key and its password
+before configuring GitHub; GitHub Actions secrets cannot be read back later.
 
 Store the generated values in the release repository settings:
 
 | Kind | Name | Value |
 | --- | --- | --- |
-| Actions secret | `TAURI_SIGNING_PRIVATE_KEY` | Complete generated private key |
+| Actions secret | `TAURI_SIGNING_PRIVATE_KEY` | Complete generated private key file contents |
 | Actions secret | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Private-key password; omit this secret when the key has no password |
 | Actions variable | `TAURI_UPDATER_PUBLIC_KEY` | Complete generated public key |
 

--- a/scripts/test-validate-stable-release-notes.mjs
+++ b/scripts/test-validate-stable-release-notes.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateStableReleaseNotes } from "./validate-stable-release-notes.mjs";
+
+const validNotes = `## 中文
+
+本版本改进了发布可靠性。
+
+### 下载
+
+- [Windows x64](https://example.com/windows)
+
+### 重点更新
+
+- Windows 更新包现在包含签名。
+
+### 升级说明
+
+请安装对应平台的软件包。
+
+### 兼容性与已知问题
+
+Windows 旧版本需要先手动升级。
+
+[完整变更](https://example.com/compare)
+
+---
+
+## English
+
+This release improves publishing reliability.
+
+### Downloads
+
+- [Windows x64](https://example.com/windows)
+
+### Highlights
+
+- Windows updater bundles now include signatures.
+
+### Upgrade instructions
+
+Install the package for your platform.
+
+### Compatibility and known issues
+
+Older Windows versions require one manual upgrade.
+
+[Full changelog](https://example.com/compare)
+`;
+
+test("accepts complete bilingual stable release notes", () => {
+  assert.doesNotThrow(() => validateStableReleaseNotes(validNotes, "valid.md"));
+});
+
+test("rejects whitespace-only release notes", () => {
+  assert.throws(
+    () => validateStableReleaseNotes(" \n\t\n", "whitespace.md"),
+    /file must contain non-whitespace content/,
+  );
+});
+
+test("rejects a missing language section", () => {
+  const chineseOnly = validNotes.slice(0, validNotes.indexOf("## English"));
+  assert.throws(
+    () => validateStableReleaseNotes(chineseOnly, "missing-english.md"),
+    /required heading "## English" must appear exactly once/,
+  );
+});
+
+test("rejects required headings in the wrong order", () => {
+  const outOfOrder = validNotes
+    .replace("### 下载", "### TEMP")
+    .replace("### 重点更新", "### 下载")
+    .replace("### TEMP", "### 重点更新");
+  assert.throws(
+    () => validateStableReleaseNotes(outOfOrder, "out-of-order.md"),
+    /required heading "### 重点更新" is out of order/,
+  );
+});
+
+test("rejects an empty required section", () => {
+  const emptyDownloads = validNotes.replace(
+    "### 下载\n\n- [Windows x64](https://example.com/windows)\n\n### 重点更新",
+    "### 下载\n\n### 重点更新",
+  );
+  assert.throws(
+    () => validateStableReleaseNotes(emptyDownloads, "empty-downloads.md"),
+    /section "### 下载" must contain content before the next heading/,
+  );
+});
+
+test("ignores required-looking headings inside fenced code blocks", () => {
+  const missingEnglish = validNotes.slice(0, validNotes.indexOf("## English"));
+  const fencedHeadings = `${missingEnglish}\n\`\`\`markdown\n## English\n### Downloads\n### Highlights\n### Upgrade instructions\n### Compatibility and known issues\n\`\`\`\n`;
+  assert.throws(
+    () => validateStableReleaseNotes(fencedHeadings, "fenced.md"),
+    /required heading "## English" must appear exactly once; found 0/,
+  );
+});

--- a/scripts/validate-stable-release-notes.mjs
+++ b/scripts/validate-stable-release-notes.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REQUIRED_HEADINGS = [
+  "## 中文",
+  "### 下载",
+  "### 重点更新",
+  "### 升级说明",
+  "### 兼容性与已知问题",
+  "## English",
+  "### Downloads",
+  "### Highlights",
+  "### Upgrade instructions",
+  "### Compatibility and known issues",
+];
+
+function markdownHeadings(lines) {
+  const headings = [];
+  let fence = null;
+
+  for (const [index, line] of lines.entries()) {
+    const trimmed = line.trim();
+    const fenceMatch = trimmed.match(/^(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0];
+      if (fence === null) fence = marker;
+      else if (fence === marker) fence = null;
+      continue;
+    }
+    if (fence !== null) continue;
+
+    const headingMatch = trimmed.match(/^(#{1,6})\s+(.+?)\s*#*$/);
+    if (headingMatch) {
+      headings.push({
+        line: index,
+        level: headingMatch[1].length,
+        text: `${headingMatch[1]} ${headingMatch[2].trim()}`,
+      });
+    }
+  }
+
+  return headings;
+}
+
+function hasSectionContent(lines, start, end) {
+  return lines.slice(start, end).some((line) => {
+    const trimmed = line.trim();
+    return trimmed.length > 0
+      && !/^#{1,6}\s+/.test(trimmed)
+      && !/^([-*_])(?:\s*\1){2,}$/.test(trimmed)
+      && !/^<!--.*-->$/.test(trimmed);
+  });
+}
+
+export function validateStableReleaseNotes(contents, source = "release notes") {
+  const errors = [];
+  if (contents.trim().length === 0) {
+    errors.push("file must contain non-whitespace content");
+  }
+
+  const lines = contents.replaceAll("\r\n", "\n").split("\n");
+  const headings = markdownHeadings(lines);
+  const required = [];
+
+  for (const expected of REQUIRED_HEADINGS) {
+    const matches = headings.filter((heading) => heading.text === expected);
+    if (matches.length !== 1) {
+      errors.push(`required heading "${expected}" must appear exactly once; found ${matches.length}`);
+      continue;
+    }
+    required.push(matches[0]);
+  }
+
+  if (required.length === REQUIRED_HEADINGS.length) {
+    for (let index = 1; index < required.length; index += 1) {
+      if (required[index - 1].line >= required[index].line) {
+        errors.push(`required heading "${REQUIRED_HEADINGS[index]}" is out of order`);
+        break;
+      }
+    }
+
+    for (const heading of required) {
+      const headingIndex = headings.indexOf(heading);
+      const nextHeadingLine = headings[headingIndex + 1]?.line ?? lines.length;
+      if (!hasSectionContent(lines, heading.line + 1, nextHeadingLine)) {
+        errors.push(`section "${heading.text}" must contain content before the next heading`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`${source} is not a valid stable release note:\n- ${errors.join("\n- ")}`);
+  }
+}
+
+function main() {
+  const notesPath = process.argv[2];
+  if (!notesPath || process.argv.length !== 3) {
+    throw new Error("Usage: validate-stable-release-notes.mjs <release-notes.md>");
+  }
+  const resolvedPath = path.resolve(notesPath);
+  validateStableReleaseNotes(readFileSync(resolvedPath, "utf8"), notesPath);
+  console.log(`Stable release notes validated: ${notesPath}`);
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- require curated bilingual release notes for stable macOS and Windows releases
- validate required Chinese and English headings, order, and section content through one shared script
- fail stable Windows releases when Tauri updater signing is not configured
- always package and upload the signed updater installer, signature, and `latest.json`
- document updater key generation, backup, and repository configuration

## Root cause and rollout

Windows v0.3.6 was packaged without the updater endpoint and public key because updater signing was optional. Its release therefore also omitted `latest.json` and signed updater artifacts. Existing v0.3.6 installations must manually install the first fixed release; in-app updates work from that release onward.

## Validation

- `node --test scripts/test-validate-stable-release-notes.mjs`
- `node scripts/validate-stable-release-notes.mjs docs/releases/v0.3.5.md`
- `actionlint .github/workflows/release-macos.yml .github/workflows/release-windows.yml`
- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh --platform all`
- `node scripts/test-verify-download-cache.mjs`
- `pwsh -NoProfile -File scripts/test-windows-updater-manifest.ps1`
- `./scripts/verify-windows-boundaries.sh`
- `git diff --check origin/preview...HEAD`

Fixes #294