### PR TITLE
fix(macos): disable GitHub Pull Request integration

### DIFF
--- a/macos/Resources/en.lproj/Localizable.strings
+++ b/macos/Resources/en.lproj/Localizable.strings
@@ -109,3 +109,5 @@
 "No notifications" = "No notifications";
 "Log: %@" = "Log: %@";
 "Console" = "Console";
+"Pull Requests integration is under development" = "Pull Requests integration is under development";
+"GitHub sign-in and pull request management are temporarily unavailable." = "GitHub sign-in and pull request management are temporarily unavailable.";

--- a/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -376,6 +376,8 @@
 "Running" = "运行中";
 
 /* GitHub pull requests. */
+"Pull Requests integration is under development" = "拉取请求集成正在开发中";
+"GitHub sign-in and pull request management are temporarily unavailable." = "GitHub 登录和拉取请求管理暂时不可用。";
 "Pull Requests" = "拉取请求";
 "Refresh pull requests" = "刷新拉取请求";
 "Restoring GitHub connection" = "正在恢复 GitHub 连接";

--- a/macos/Sources/Lithe/Models/AppModel/AppModel+GitHub.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+GitHub.swift
@@ -2,6 +2,7 @@ import Foundation
 
 extension AppModel {
     func connectGitHubWithDeviceFlow() async {
+        guard LitheFeatureAvailability.githubPullRequests else { return }
         await githubFeature.beginDeviceAuthorization(
             workspaceURL: workspaceURL,
             onAuthorization: { [weak self] authorization in
@@ -15,6 +16,7 @@ extension AppModel {
     }
 
     func connectGitHub(personalAccessToken: String) async {
+        guard LitheFeatureAvailability.githubPullRequests else { return }
         await githubFeature.connect(
             personalAccessToken: personalAccessToken,
             workspaceURL: workspaceURL
@@ -22,10 +24,12 @@ extension AppModel {
     }
 
     func disconnectGitHub() async {
+        guard LitheFeatureAvailability.githubPullRequests else { return }
         await githubFeature.disconnect()
     }
 
     func checkoutSelectedPullRequest() async {
+        guard LitheFeatureAvailability.githubPullRequests else { return }
         if await githubFeature.checkout(workspaceURL: workspaceURL) {
             await refreshGit()
             showNotification("Pull request branch checked out")
@@ -33,6 +37,7 @@ extension AppModel {
     }
 
     func publishGitHubPullRequestBranch(named name: String) async -> String? {
+        guard LitheFeatureAvailability.githubPullRequests else { return nil }
         let branch = await githubFeature.publishPullRequestBranch(
             named: name,
             workspaceURL: workspaceURL

--- a/macos/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -55,6 +55,7 @@ final class AppModel: ObservableObject, Identifiable {
                 case .changes:
                     await self.refreshGit()
                 case .pullRequests:
+                    guard LitheFeatureAvailability.githubPullRequests else { return }
                     await self.githubFeature.refresh(workspaceURL: self.workspaceURL)
                 default:
                     break
@@ -432,9 +433,11 @@ final class AppModel: ObservableObject, Identifiable {
                 guard documentID != nil else { return }
                 self?.terminalPlacementFeature.activateDocument()
             }
-        Task { [weak self] in
-            guard let self else { return }
-            await self.githubFeature.restore(workspaceURL: self.workspaceURL)
+        if LitheFeatureAvailability.githubPullRequests {
+            Task { [weak self] in
+                guard let self else { return }
+                await self.githubFeature.restore(workspaceURL: self.workspaceURL)
+            }
         }
         workspaceFeature.configureProjection(
             documentsProvider: { [weak self] in
@@ -450,7 +453,8 @@ final class AppModel: ObservableObject, Identifiable {
             restoreSession: { [weak self] session, availableFiles in
                 guard let self else { return }
                 let availablePaths = Set(availableFiles.map { $0.standardizedFileURL.path })
-                self.selectedSidebar = SidebarDestination(rawValue: session.selectedSidebar) ?? .project
+                let restoredSidebar = SidebarDestination(rawValue: session.selectedSidebar) ?? .project
+                self.selectedSidebar = restoredSidebar.isAvailable ? restoredSidebar : .project
                 let paths = session.openPaths.filter { availablePaths.contains($0) }
                 await withTaskGroup(of: Void.self) { group in
                     for path in paths {
@@ -1512,6 +1516,9 @@ final class AppModel: ObservableObject, Identifiable {
         base: String,
         head: String
     ) async throws -> PullRequestDescriptionOutput {
+        guard LitheFeatureAvailability.githubPullRequests else {
+            throw GitHubService.ServiceError.oauthClientNotConfigured
+        }
         refreshAIConfigurations()
         let input = try await githubFeature.pullRequestDescriptionInput(base: base, head: head)
         let value = try await services.moduleRuntime.activateCapability(.aiPullRequestDescription)

--- a/macos/Sources/Lithe/Models/AppModel/AppModelSupportTypes.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModelSupportTypes.swift
@@ -1,6 +1,16 @@
 import Foundation
 import LitheCoreContracts
 
+/// Product-level availability switches for integrations that require external
+/// credentials or services. Keeping these switches in one place lets the UI
+/// and application model disable an integration consistently without removing
+/// its implementation, tests, or shared contracts.
+enum LitheFeatureAvailability {
+    /// Pull request support is temporarily hidden while the macOS credential
+    /// and signing story is being redesigned for preview and contributor builds.
+    static let githubPullRequests = false
+}
+
 struct WorkbenchNotification: Identifiable, Equatable {
     let id: UUID
     let message: String
@@ -53,6 +63,15 @@ enum SidebarDestination: String, CaseIterable, Identifiable {
         case .pullRequests: nil
         case .search: "toolwindows/toolWindowFind.svg"
         case .database: "toolwindows/toolWindowDatabase.svg"
+        }
+    }
+
+    var isAvailable: Bool {
+        switch self {
+        case .pullRequests:
+            LitheFeatureAvailability.githubPullRequests
+        case .project, .changes, .search, .database:
+            true
         }
     }
 }

--- a/macos/Sources/Lithe/Views/GitHub/GitHubPullRequestsView.swift
+++ b/macos/Sources/Lithe/Views/GitHub/GitHubPullRequestsView.swift
@@ -64,21 +64,27 @@ struct GitHubPullRequestsSidebarView: View {
     @State private var searchQuery = ""
 
     var body: some View {
-        VStack(spacing: 0) {
-            LitheToolWindowHeader(title: "Pull Requests") {
-                if case .connected = model.githubFeature.connectionState {
-                    Button {
-                        Task { await model.githubFeature.refresh(workspaceURL: model.workspaceURL) }
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
+        Group {
+            if LitheFeatureAvailability.githubPullRequests {
+                VStack(spacing: 0) {
+                    LitheToolWindowHeader(title: "Pull Requests") {
+                        if case .connected = model.githubFeature.connectionState {
+                            Button {
+                                Task { await model.githubFeature.refresh(workspaceURL: model.workspaceURL) }
+                            } label: {
+                                Image(systemName: "arrow.clockwise")
+                            }
+                            .litheIconButton()
+                            .disabled(isContentLoading)
+                            .help("Refresh pull requests")
+                        }
                     }
-                    .litheIconButton()
-                    .disabled(isContentLoading)
-                    .help("Refresh pull requests")
+                    Rectangle().fill(LitheTheme.divider).frame(height: 1)
+                    content
                 }
+            } else {
+                GitHubFeatureUnavailableView()
             }
-            Rectangle().fill(LitheTheme.divider).frame(height: 1)
-            content
         }
     }
 
@@ -376,7 +382,9 @@ struct GitHubPullRequestDetailView: View {
 
     var body: some View {
         Group {
-            if model.githubFeature.isCreatingPullRequest {
+            if !LitheFeatureAvailability.githubPullRequests {
+                GitHubFeatureUnavailableView()
+            } else if model.githubFeature.isCreatingPullRequest {
                 GitHubCreatePullRequestWorkspaceView()
             } else if let request = model.githubFeature.selectedPullRequest {
                 detail(request)
@@ -782,6 +790,28 @@ struct GitHubPullRequestDetailView: View {
     private var isOperationRunning: Bool {
         if case .running = model.githubFeature.operationState { return true }
         return false
+    }
+}
+
+struct GitHubFeatureUnavailableView: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "arrow.triangle.pull")
+                .font(.system(size: 30, weight: .light))
+                .foregroundStyle(LitheTheme.secondaryText)
+            Text("Pull Requests integration is under development")
+                .font(.system(size: 14, weight: .semibold))
+                .multilineTextAlignment(.center)
+            Text("GitHub sign-in and pull request management are temporarily unavailable.")
+                .font(.system(size: 11.5))
+                .foregroundStyle(LitheTheme.secondaryText)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .litheWorkbenchSurface(LitheTheme.editor)
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
+++ b/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
@@ -583,8 +583,19 @@ struct WorkbenchView: View {
                         }
                         .buttonStyle(.plain)
                         .lithePointer()
+                        .disabled(!destination.isAvailable)
                         .foregroundStyle(model.selectedSidebar == destination ? LitheTheme.primaryText : LitheTheme.secondaryText)
-                        .help(LocalizedStringKey(destination.title))
+                        .help(
+                            destination.isAvailable
+                                ? LocalizedStringKey(destination.title)
+                                : LocalizedStringKey("Pull Requests integration is under development")
+                        )
+                        .accessibilityLabel(LocalizedStringKey(destination.title))
+                        .accessibilityHint(
+                            destination.isAvailable
+                                ? LocalizedStringKey("")
+                                : LocalizedStringKey("Pull Requests integration is under development")
+                        )
                     }
                 }
                 .padding(.top, ActivityBarMetrics.edgeInset)
@@ -893,7 +904,11 @@ struct WorkbenchView: View {
                         PluginManagementView()
                             .environmentObject(model)
                     } else if model.selectedSidebar == .pullRequests {
-                        GitHubPullRequestDetailView()
+                        if LitheFeatureAvailability.githubPullRequests {
+                            GitHubPullRequestDetailView()
+                        } else {
+                            GitHubFeatureUnavailableView()
+                        }
                     } else {
                         EditorAreaView()
                     }
@@ -925,7 +940,11 @@ struct WorkbenchView: View {
             case .changes:
                 ChangesSidebarView()
             case .pullRequests:
-                GitHubPullRequestsSidebarView()
+                if LitheFeatureAvailability.githubPullRequests {
+                    GitHubPullRequestsSidebarView()
+                } else {
+                    GitHubFeatureUnavailableView()
+                }
             case .search:
                 SearchSidebarView()
             case .database:

--- a/macos/Tests/LitheTests/GitHubFeatureAvailabilityTests.swift
+++ b/macos/Tests/LitheTests/GitHubFeatureAvailabilityTests.swift
@@ -1,0 +1,14 @@
+import Testing
+@testable import Lithe
+
+@Suite("GitHub feature availability")
+struct GitHubFeatureAvailabilityTests {
+    @Test("Pull request integration is disabled without changing ordinary Git destinations")
+    func pullRequestIntegrationIsUnavailable() {
+        #expect(!LitheFeatureAvailability.githubPullRequests)
+        #expect(!SidebarDestination.pullRequests.isAvailable)
+        #expect(SidebarDestination.project.isAvailable)
+        #expect(SidebarDestination.changes.isAvailable)
+        #expect(SidebarDestination.search.isAvailable)
+    }
+}


### PR DESCRIPTION
## Summary
- 暂时停用 macOS GitHub Pull Request 集成，避免预览版构建启动时访问 Keychain 凭据。
- 保留 Pull Requests 入口但设为不可点击，并显示“开发中”占位状态。
- 阻止启动恢复、会话恢复和其他 AppModel 入口绕过功能开关。
- 不影响普通 Git 操作和 GitHub Release 更新检查。

## Verification
- `./scripts/test-macos.sh`
- `./scripts/verify-service-boundaries.sh`
- `git diff --check`