### PR TITLE
fix(core): ignore custom Spring mapping annotations that share a prefix

### DIFF
--- a/rust/lithe-core/src/languages/spring.rs
+++ b/rust/lithe-core/src/languages/spring.rs
@@ -1574,21 +1574,33 @@ fn find_mapping_annotation(text: &str) -> Option<(SpringMappingAnnotation, &str)
     Some((annotation, isolate_annotation_at(text, start)))
 }
 
-/// Slices one annotation starting at `start` (`@Name` … optional argument list)
-/// so route extraction cannot read string literals from a neighboring decoy.
+/// Slices one annotation starting at `start` (`@Name` followed by an optional
+/// argument list) so route extraction cannot read string literals from a
+/// neighboring decoy.
+///
+/// A later annotation's `(` is not this annotation's argument list. After the
+/// name, only whitespace may appear before `(`.
 fn isolate_annotation_at(text: &str, start: usize) -> &str {
     let rest = &text[start..];
-    let Some(open_index) = rest.find('(') else {
-        let end = rest
-            .char_indices()
-            .skip(1)
-            .find(|(_, character)| {
-                !(character.is_ascii_alphanumeric() || *character == '_' || *character == '$')
-            })
-            .map(|(index, _)| index)
-            .unwrap_or(rest.len());
-        return &rest[..end];
-    };
+    let name_end = rest
+        .char_indices()
+        .skip(1)
+        .find(|(_, character)| {
+            !(character.is_ascii_alphanumeric() || *character == '_' || *character == '$')
+        })
+        .map(|(index, _)| index)
+        .unwrap_or(rest.len());
+    let after_name = rest.get(name_end..).unwrap_or("");
+    let whitespace_len = after_name
+        .chars()
+        .take_while(|character| character.is_whitespace())
+        .map(char::len_utf8)
+        .sum::<usize>();
+    let after_whitespace = after_name.get(whitespace_len..).unwrap_or("");
+    if !after_whitespace.starts_with('(') {
+        return &rest[..name_end];
+    }
+    let open_index = name_end + whitespace_len;
     let mut depth = 0isize;
     for (index, character) in rest[open_index..].char_indices() {
         match character {
@@ -1877,5 +1889,18 @@ mod tests {
             .expect("leftmost Mapping should win");
         assert_eq!(leftmost.0, SpringMappingAnnotation::PutMapping);
         assert_eq!(leftmost.2, vec!["/first".to_string()]);
+    }
+
+    #[test]
+    fn mapping_does_not_take_routes_from_a_following_unrelated_annotation() {
+        let bare = mapping("@GetMapping @Custom(\"/decoy\")")
+            .expect("bare GetMapping should still match");
+        assert_eq!(bare.0, SpringMappingAnnotation::GetMapping);
+        assert_eq!(bare.1, vec!["GET".to_string()]);
+        assert_eq!(bare.2, vec![String::new()]);
+
+        let spaced = mapping("@GetMapping (\"/x\") @Custom(\"/decoy\")")
+            .expect("GetMapping with its own argument list should keep that route");
+        assert_eq!(spaced.2, vec!["/x".to_string()]);
     }
 }

--- a/rust/lithe-core/src/languages/spring.rs
+++ b/rust/lithe-core/src/languages/spring.rs
@@ -1219,6 +1219,64 @@ spring_annotations! {
     Service => "Service",
 }
 
+/// Declares the Spring web mapping annotations exactly once, and derives the
+/// type, spelling, boundary pattern, fixed HTTP method, and test list from that
+/// one declaration. `RequestMapping` carries `None` so methods come from its
+/// `RequestMethod.*` arguments instead.
+macro_rules! spring_mapping_annotations {
+    ($($variant:ident => $name:literal, $method:expr),+ $(,)?) => {
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        enum SpringMappingAnnotation {
+            $($variant),+
+        }
+
+        impl SpringMappingAnnotation {
+            /// Every recognized mapping annotation. Production selection walks
+            /// this list and keeps the earliest source match, not declaration
+            /// order by itself.
+            const ALL: &'static [Self] = &[$(Self::$variant),+];
+
+            #[cfg(test)]
+            fn name(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $name),+
+                }
+            }
+
+            fn pattern(self) -> &'static Regex {
+                match self {
+                    $(Self::$variant => {
+                        static PATTERN: LazyLock<Regex> =
+                            LazyLock::new(|| annotation_boundary_pattern($name));
+                        &PATTERN
+                    })+
+                }
+            }
+
+            /// Fixed verb for method mappings; `None` for [`Self::RequestMapping`].
+            fn fixed_http_method(self) -> Option<&'static str> {
+                match self {
+                    $(Self::$variant => $method),+
+                }
+            }
+
+            #[cfg(test)]
+            fn is_present(self, context: &str) -> bool {
+                self.pattern().is_match(context)
+            }
+        }
+    };
+}
+
+spring_mapping_annotations! {
+    GetMapping => "GetMapping", Some("GET"),
+    PostMapping => "PostMapping", Some("POST"),
+    PutMapping => "PutMapping", Some("PUT"),
+    DeleteMapping => "DeleteMapping", Some("DELETE"),
+    PatchMapping => "PatchMapping", Some("PATCH"),
+    RequestMapping => "RequestMapping", None,
+}
+
 impl SpringAnnotation {
     /// Annotations that declare a Spring component on a type declaration. The
     /// order also drives the alternation in [`component_name`], so changing it
@@ -1433,7 +1491,7 @@ fn endpoint_index(sources: &[(String, String)]) -> Vec<SpringEndpointResponse> {
                 continue;
             }
             let (annotation, annotation_end) = annotation_block(&lines, index);
-            let Some((methods, routes)) = mapping(&annotation) else {
+            let Some((mapping_annotation, methods, routes)) = mapping(&annotation) else {
                 index = annotation_end + 1;
                 continue;
             };
@@ -1441,7 +1499,11 @@ fn endpoint_index(sources: &[(String, String)]) -> Vec<SpringEndpointResponse> {
             let declaration = declaration_index
                 .and_then(|value| lines.get(value).copied())
                 .unwrap_or_default();
-            if annotation.contains("@RequestMapping") && CLASS.is_match(declaration) {
+            // Class-level base routes come only from an exact @RequestMapping, not
+            // a longer custom name that merely starts with that spelling.
+            if mapping_annotation == SpringMappingAnnotation::RequestMapping
+                && CLASS.is_match(declaration)
+            {
                 base_routes = routes;
                 index = annotation_end + 1;
                 continue;
@@ -1477,35 +1539,87 @@ fn endpoint_index(sources: &[(String, String)]) -> Vec<SpringEndpointResponse> {
     endpoints
 }
 
-fn mapping(annotation_text: &str) -> Option<(Vec<String>, Vec<String>)> {
-    for (annotation, method) in [
-        ("@GetMapping", "GET"),
-        ("@PostMapping", "POST"),
-        ("@PutMapping", "PUT"),
-        ("@DeleteMapping", "DELETE"),
-        ("@PatchMapping", "PATCH"),
-    ] {
-        if annotation_text.contains(annotation) {
-            return Some((vec![method.to_string()], annotation_routes(annotation_text)));
+/// Finds the earliest exact Mapping annotation in `annotation_text` and returns
+/// its HTTP methods and routes. Custom names that only share a standard prefix
+/// (for example `@GetMappingCustom`) do not match.
+///
+/// When several Mapping annotations appear in one context, the leftmost source
+/// span wins so selection does not depend on declaration order in
+/// [`SpringMappingAnnotation::ALL`].
+fn mapping(
+    annotation_text: &str,
+) -> Option<(SpringMappingAnnotation, Vec<String>, Vec<String>)> {
+    let (annotation, isolated) = find_mapping_annotation(annotation_text)?;
+    let methods = match annotation.fixed_http_method() {
+        Some(method) => vec![method.to_string()],
+        None => request_mapping_methods(isolated),
+    };
+    Some((annotation, methods, annotation_routes(isolated)))
+}
+
+/// Returns the earliest exact Mapping annotation and the isolated annotation
+/// text used for route and `RequestMethod` parsing.
+fn find_mapping_annotation(text: &str) -> Option<(SpringMappingAnnotation, &str)> {
+    let mut best: Option<(usize, SpringMappingAnnotation)> = None;
+    for &annotation in SpringMappingAnnotation::ALL {
+        if let Some(found) = annotation.pattern().find(text) {
+            let start = found.start();
+            match best {
+                Some((best_start, _)) if start >= best_start => {}
+                _ => best = Some((start, annotation)),
+            }
         }
     }
-    if annotation_text.contains("@RequestMapping") {
-        static METHOD_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r"RequestMethod\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE)")
-                .expect("literal pattern is valid")
-        });
-        let mut methods = METHOD_PATTERN
-            .captures_iter(annotation_text)
-            .filter_map(|capture| capture.get(1).map(|value| value.as_str().to_string()))
-            .collect::<Vec<_>>();
-        if methods.is_empty() {
-            methods.push("ANY".to_string());
+    let (start, annotation) = best?;
+    Some((annotation, isolate_annotation_at(text, start)))
+}
+
+/// Slices one annotation starting at `start` (`@Name` … optional argument list)
+/// so route extraction cannot read string literals from a neighboring decoy.
+fn isolate_annotation_at(text: &str, start: usize) -> &str {
+    let rest = &text[start..];
+    let Some(open_index) = rest.find('(') else {
+        let end = rest
+            .char_indices()
+            .skip(1)
+            .find(|(_, character)| {
+                !(character.is_ascii_alphanumeric() || *character == '_' || *character == '$')
+            })
+            .map(|(index, _)| index)
+            .unwrap_or(rest.len());
+        return &rest[..end];
+    };
+    let mut depth = 0isize;
+    for (index, character) in rest[open_index..].char_indices() {
+        match character {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &rest[..open_index + index + 1];
+                }
+            }
+            _ => {}
         }
-        methods.sort();
-        methods.dedup();
-        return Some((methods, annotation_routes(annotation_text)));
     }
-    None
+    rest
+}
+
+fn request_mapping_methods(annotation: &str) -> Vec<String> {
+    static METHOD_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"RequestMethod\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE)")
+            .expect("literal pattern is valid")
+    });
+    let mut methods = METHOD_PATTERN
+        .captures_iter(annotation)
+        .filter_map(|capture| capture.get(1).map(|value| value.as_str().to_string()))
+        .collect::<Vec<_>>();
+    if methods.is_empty() {
+        methods.push("ANY".to_string());
+    }
+    methods.sort();
+    methods.dedup();
+    methods
 }
 
 fn annotation_routes(annotation: &str) -> Vec<String> {
@@ -1675,5 +1789,93 @@ mod tests {
         assert_eq!(fields[0].name, "payments");
         assert_eq!(fields[0].type_name, "PaymentService");
         assert_eq!(injections[0].type_name, "PaymentService");
+    }
+
+    /// Mapping detection must use the same closed set for spelling, boundary
+    /// matching, and HTTP methods so a prefix decoy cannot become an endpoint.
+    #[test]
+    fn every_mapping_annotation_has_a_compiled_boundary_pattern() {
+        for annotation in SpringMappingAnnotation::ALL.iter().copied() {
+            let name = annotation.name();
+            assert!(
+                annotation.is_present(&format!("@{name}(\"/x\")")),
+                "{name} should match its own annotation"
+            );
+            assert!(
+                annotation.is_present(&format!("@{name}")),
+                "{name} should match at the end of a context"
+            );
+            assert!(
+                !annotation.is_present(&format!("@{name}Custom(\"/x\")")),
+                "{name} must not match a longer annotation sharing its prefix"
+            );
+        }
+
+        let names = SpringMappingAnnotation::ALL
+            .iter()
+            .map(|annotation| annotation.name())
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            names.len(),
+            SpringMappingAnnotation::ALL.len(),
+            "every mapping case needs a distinct annotation name"
+        );
+    }
+
+    #[test]
+    fn mapping_rejects_custom_annotations_that_only_share_a_standard_prefix() {
+        assert!(mapping("@GetMappingCustom(\"/x\")").is_none());
+        assert!(mapping("@PostMappingCustom(\"/x\")").is_none());
+        assert!(mapping("@PutMappingCustom(\"/x\")").is_none());
+        assert!(mapping("@DeleteMappingCustom(\"/x\")").is_none());
+        assert!(mapping("@PatchMappingCustom(\"/x\")").is_none());
+        assert!(mapping("@RequestMappingFoo(\"/base\")").is_none());
+    }
+
+    #[test]
+    fn mapping_keeps_standard_annotations_and_request_method_arrays() {
+        let get = mapping("@GetMapping(\"/x\")").expect("GetMapping should match");
+        assert_eq!(get.0, SpringMappingAnnotation::GetMapping);
+        assert_eq!(get.1, vec!["GET".to_string()]);
+        assert_eq!(get.2, vec!["/x".to_string()]);
+
+        let post = mapping("@PostMapping(path = \"/y\")").expect("PostMapping should match");
+        assert_eq!(post.1, vec!["POST".to_string()]);
+        assert_eq!(post.2, vec!["/y".to_string()]);
+
+        let put = mapping("@PutMapping(\"/z\")").expect("PutMapping should match");
+        assert_eq!(put.1, vec!["PUT".to_string()]);
+
+        let delete = mapping("@DeleteMapping(\"/d\")").expect("DeleteMapping should match");
+        assert_eq!(delete.1, vec!["DELETE".to_string()]);
+
+        let patch = mapping("@PatchMapping(\"/p\")").expect("PatchMapping should match");
+        assert_eq!(patch.1, vec!["PATCH".to_string()]);
+
+        let any = mapping("@RequestMapping(\"/base\")").expect("RequestMapping should match");
+        assert_eq!(any.0, SpringMappingAnnotation::RequestMapping);
+        assert_eq!(any.1, vec!["ANY".to_string()]);
+        assert_eq!(any.2, vec!["/base".to_string()]);
+
+        let multi = mapping(
+            "@RequestMapping(path = \"/multi\", method = { RequestMethod.POST, RequestMethod.GET, RequestMethod.GET })",
+        )
+        .expect("RequestMapping with methods should match");
+        assert_eq!(multi.1, vec!["GET".to_string(), "POST".to_string()]);
+        assert_eq!(multi.2, vec!["/multi".to_string()]);
+    }
+
+    #[test]
+    fn mapping_selects_the_earliest_annotation_and_isolates_its_routes() {
+        let selected = mapping("@GetMappingCustom(\"/decoy\") @PostMapping(\"/real\")")
+            .expect("exact PostMapping should still match");
+        assert_eq!(selected.0, SpringMappingAnnotation::PostMapping);
+        assert_eq!(selected.1, vec!["POST".to_string()]);
+        assert_eq!(selected.2, vec!["/real".to_string()]);
+
+        let leftmost = mapping("@PutMapping(\"/first\") @GetMapping(\"/second\")")
+            .expect("leftmost Mapping should win");
+        assert_eq!(leftmost.0, SpringMappingAnnotation::PutMapping);
+        assert_eq!(leftmost.2, vec!["/first".to_string()]);
     }
 }

--- a/rust/lithe-core/src/languages/spring.rs
+++ b/rust/lithe-core/src/languages/spring.rs
@@ -1546,9 +1546,7 @@ fn endpoint_index(sources: &[(String, String)]) -> Vec<SpringEndpointResponse> {
 /// When several Mapping annotations appear in one context, the leftmost source
 /// span wins so selection does not depend on declaration order in
 /// [`SpringMappingAnnotation::ALL`].
-fn mapping(
-    annotation_text: &str,
-) -> Option<(SpringMappingAnnotation, Vec<String>, Vec<String>)> {
+fn mapping(annotation_text: &str) -> Option<(SpringMappingAnnotation, Vec<String>, Vec<String>)> {
     let (annotation, isolated) = find_mapping_annotation(annotation_text)?;
     let methods = match annotation.fixed_http_method() {
         Some(method) => vec![method.to_string()],
@@ -1893,8 +1891,8 @@ mod tests {
 
     #[test]
     fn mapping_does_not_take_routes_from_a_following_unrelated_annotation() {
-        let bare = mapping("@GetMapping @Custom(\"/decoy\")")
-            .expect("bare GetMapping should still match");
+        let bare =
+            mapping("@GetMapping @Custom(\"/decoy\")").expect("bare GetMapping should still match");
         assert_eq!(bare.0, SpringMappingAnnotation::GetMapping);
         assert_eq!(bare.1, vec!["GET".to_string()]);
         assert_eq!(bare.2, vec![String::new()]);

--- a/rust/lithe-core/src/tests/spring.rs
+++ b/rust/lithe-core/src/tests/spring.rs
@@ -347,6 +347,52 @@ public class RealConfig {
     fs::remove_dir_all(root).expect("Spring fixture should be removable");
 }
 
+/// Custom annotations that only share a Mapping prefix must not become
+/// endpoints or class-level base routes; exact Spring Mapping names still do.
+#[test]
+fn spring_index_ignores_mapping_annotations_that_only_share_a_prefix() {
+    let root = temporary_root("spring-mapping-prefix");
+    let java = root.join("src/main/java/demo");
+    fs::create_dir_all(&java).expect("Java fixture directory should be creatable");
+    fs::write(
+        java.join("DemoController.java"),
+        r#"package demo;
+@RestController
+@RequestMappingFoo("/base")
+public class DemoController {
+  @GetMappingCustom("/x")
+  public String custom() { return ""; }
+  @PostMappingCustom("/post")
+  public String postCustom() { return ""; }
+  @PutMappingCustom("/put")
+  public String putCustom() { return ""; }
+  @DeleteMappingCustom("/delete")
+  public String deleteCustom() { return ""; }
+  @PatchMappingCustom("/patch")
+  public String patchCustom() { return ""; }
+  @GetMapping("/real")
+  public String real() { return ""; }
+}
+"#,
+    )
+    .expect("controller fixture should be writable");
+
+    let response = execute_spring(
+        &root,
+        &["src/main/java/demo/DemoController.java"],
+        serde_json::json!({}),
+    );
+    assert_eq!(response["ok"], true, "{response}");
+
+    let endpoints = response["data"]["endpoints"].as_array().unwrap();
+    assert_eq!(endpoints.len(), 1, "{response}");
+    assert_eq!(endpoints[0]["route"], "/real");
+    assert_eq!(endpoints[0]["httpMethods"][0], "GET");
+    assert_eq!(endpoints[0]["method"], "real");
+
+    fs::remove_dir_all(root).expect("Spring fixture should be removable");
+}
+
 #[test]
 fn spring_dependency_metadata_cache_refresh_is_explicit() {
     let root = temporary_root("spring-metadata-cache");


### PR DESCRIPTION
fix #316 

﻿## Summary
- Spring endpoint indexing now matches `@GetMapping` / `@RequestMapping` by exact annotation boundaries instead of substring `contains`.
- Custom names such as `@GetMappingCustom` and `@RequestMappingFoo` no longer produce endpoints or class-level base routes.
- This lives in `lithe-core`, so macOS and Windows both pick it up through `spring.index`.

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml -p lithe-core`
- [x] `./scripts/verify-rust-core-comments.sh`
- [ ] macOS: open Spring Endpoints on a controller with `@GetMappingCustom("/x")` and `@GetMapping("/real")`; only `GET /real` should appear
