### PR TITLE
feat(maven): unify shared Maven context and macOS tool window

### DIFF
--- a/docs/architecture/language-tooling.md
+++ b/docs/architecture/language-tooling.md
@@ -157,9 +157,10 @@ timeout。Core、service 和 adapter 只返回稳定原因，面向用户的提�
 
 1. 平台完成可执行文件、运行时和 provider 专用资源发现，向 Rust 提交 typed `startServer`；JDTLS 包内计划必须包含 `jdtlsLaunchResources`；
 2. Rust provider adapter 生成最终参数，engine 创建 session、直接启动目标进程并安装 stdout/stderr reader，再发送 `initialize`；
-3. 收到响应后，Rust 保存服务器 capability，发送 `initialized` 和 provider adapter 通知；JDTLS 继续等待 `language/status: ServiceReady`，项目导入完成前仍是 `initializing`；
-4. manager 只在真实 `ready` 后发布 capability；打开文档发送 `didOpen`，后续编辑优先按服务器协商结果发送增量 `didChange`；
-5. Rust 以 LSP request ID 关联 deadline，并用不透明 operation ID 把 terminal result 投影给 Swift。
+3. 收到响应后，Rust 保存服务器 capability，发送 `initialized` 和 provider adapter 通知；JDTLS 的配置通知和 `workspace/configuration` 响应通过 `java.configuration.maven.userSettings` 消费当前 Maven `settings.xml`，随后继续等待 `language/status: ServiceReady`；
+4. JDTLS 报告 `ServiceReady` 后，Rust 对 reactor 和每个递归 Maven module 发送 `java.project.updateSettings`，以 `org.eclipse.m2e.core.selectedProfiles` 应用排序后的 Profiles；所有响应成功前仍保持 `initializing`，拒绝或超时会明确失败而不沿用旧 Maven model；
+5. manager 只在真实 `ready` 后发布 capability；打开文档发送 `didOpen`，后续编辑优先按服务器协商结果发送增量 `didChange`；
+6. Rust 以 LSP request ID 关联 deadline，并用不透明 operation ID 把 terminal result 投影给 Swift。
 
 `initializeTimeoutMilliseconds` 只约束标准 LSP 握手。JDTLS 返回 initialize
 结果后，Core 立即切换到独立的 `ServiceReady` 等待：连续 45 秒没有变化的

--- a/macos/Sources/Lithe/Application/Features/JavaDebugFeatureModel.swift
+++ b/macos/Sources/Lithe/Application/Features/JavaDebugFeatureModel.swift
@@ -92,8 +92,17 @@ final class JavaDebugFeatureModel: ObservableObject, JavaDebugFeatureTarget {
         configuration: RunConfiguration,
         project: MavenProject,
         projectURL: URL,
-        options: RunOptions
-    ) { service.startMaven(configuration: configuration, project: project, projectURL: projectURL, options: options) }
+        options: RunOptions,
+        mavenContext: MavenLaunchContext?
+    ) {
+        service.startMaven(
+            configuration: configuration,
+            project: project,
+            projectURL: projectURL,
+            options: options,
+            mavenContext: mavenContext
+        )
+    }
     func attachRemote() { service.attachRemote() }
     func toggleBreakpoint(fileURL: URL, line: Int, className: String) {
         service.toggleBreakpoint(fileURL: fileURL, line: line, className: className)

--- a/macos/Sources/Lithe/Application/Features/JavaFeatureModel.swift
+++ b/macos/Sources/Lithe/Application/Features/JavaFeatureModel.swift
@@ -233,7 +233,8 @@ final class JavaFeatureModel: ObservableObject {
                 configuration: configuration,
                 project: mavenProject,
                 projectURL: workspaceURL,
-                options: runFeature.options(for: configuration)
+                options: runFeature.options(for: configuration),
+                mavenContext: mavenFeature?.launchContext
             )
         case .remote:
             debugFeature.attachRemote()

--- a/macos/Sources/Lithe/Core/Rust/RustCoreBridge.swift
+++ b/macos/Sources/Lithe/Core/Rust/RustCoreBridge.swift
@@ -296,6 +296,28 @@ struct RustCoreBridge: Sendable {
         let issues: [Issue]
     }
 
+    struct MavenLaunchPlanPayload: Decodable, Sendable {
+        struct Executable: Decodable, Sendable {
+            let toolchain: String
+        }
+
+        let version: Int
+        let executable: Executable
+        let arguments: [String]
+        let workingDirectory: String
+        let configurationFingerprint: String
+
+        func makeModel() -> MavenLaunchPlan {
+            MavenLaunchPlan(
+                version: version,
+                toolchain: executable.toolchain,
+                arguments: arguments,
+                workingDirectory: workingDirectory,
+                configurationFingerprint: configurationFingerprint
+            )
+        }
+    }
+
     struct JavaRunConfigurationsPayload: Decodable, Sendable {
         struct MainClass: Decodable, Sendable {
             let path: String
@@ -1178,6 +1200,13 @@ struct RustCoreBridge: Sendable {
         let paths: [String]
     }
 
+    private struct MavenLaunchPlanRequest: Encodable {
+        let root: String
+        let context: MavenLaunchContext
+        let module: String?
+        let goals: [String]
+    }
+
     private struct MarkdownRenderRequest: Encodable {
         let source: String
     }
@@ -1416,6 +1445,7 @@ struct RustCoreBridge: Sendable {
         let jdtlsLaunchResources: LspJdtlsLaunchResourcesRequest?
         let cacheDirectory: String?
         let workspaceFingerprint: String?
+        let mavenContext: MavenLaunchContext?
         let initializeTimeoutMilliseconds: Int
         let requestTimeoutMilliseconds: Int
         let shutdownTimeoutMilliseconds: Int
@@ -1618,6 +1648,7 @@ struct RustCoreBridge: Sendable {
         let currentFile: String?
         let classPath: String?
         let debugPort: Int?
+        let mavenContext: MavenLaunchContext?
     }
 
     private struct JavaStructureRequest: Encodable {
@@ -2250,11 +2281,36 @@ struct RustCoreBridge: Sendable {
     }
 
     func scanMaven(at rootURL: URL, paths: [String] = []) -> MavenScanPayload? {
-        execute(
+        try? scanMavenResult(at: rootURL, paths: paths).get()
+    }
+
+    func scanMavenResult(
+        at rootURL: URL,
+        paths: [String] = []
+    ) -> Result<MavenScanPayload?, CoreCallError> {
+        let result: Result<Envelope<MavenScanPayload>, CoreCallError> = decodeEnvelope(
             command: "maven.scan",
             payload: MavenScanRequest(
                 root: rootURL.standardizedFileURL.path,
                 paths: paths
+            )
+        )
+        return result.map(\.data)
+    }
+
+    func mavenLaunchPlan(
+        at rootURL: URL,
+        context: MavenLaunchContext,
+        module: String?,
+        goals: [String]
+    ) -> Result<MavenLaunchPlanPayload, CoreCallError> {
+        executeResult(
+            command: "maven.launchPlan",
+            payload: MavenLaunchPlanRequest(
+                root: rootURL.standardizedFileURL.path,
+                context: context,
+                module: module,
+                goals: goals
             )
         )
     }
@@ -2324,7 +2380,8 @@ struct RustCoreBridge: Sendable {
         configurationID: String,
         currentFile: String? = nil,
         classPath: String? = nil,
-        debugPort: Int? = nil
+        debugPort: Int? = nil,
+        mavenContext: MavenLaunchContext? = nil
     ) -> Result<LaunchPlanPayload, CoreCallError> {
         executeResult(
             command: "runConfig.createLaunchPlan",
@@ -2333,7 +2390,8 @@ struct RustCoreBridge: Sendable {
                 configurationId: configurationID,
                 currentFile: currentFile,
                 classPath: classPath,
-                debugPort: debugPort
+                debugPort: debugPort,
+                mavenContext: mavenContext
             )
         )
     }
@@ -2952,6 +3010,7 @@ struct RustCoreBridge: Sendable {
         jdtlsLaunchResources: JDTLSLaunchResources? = nil,
         cacheDirectoryURL: URL? = nil,
         workspaceFingerprint: String? = nil,
+        mavenContext: MavenLaunchContext? = nil,
         initializeTimeout: TimeInterval = 30,
         requestTimeout: TimeInterval = 30,
         shutdownTimeout: TimeInterval = 2
@@ -2976,6 +3035,7 @@ struct RustCoreBridge: Sendable {
                 },
                 cacheDirectory: cacheDirectoryURL?.standardizedFileURL.path,
                 workspaceFingerprint: workspaceFingerprint,
+                mavenContext: mavenContext,
                 initializeTimeoutMilliseconds: Self.milliseconds(initializeTimeout),
                 requestTimeoutMilliseconds: Self.milliseconds(requestTimeout),
                 shutdownTimeoutMilliseconds: Self.milliseconds(shutdownTimeout)

--- a/macos/Sources/Lithe/Core/Rust/RustCoreBridge.swift
+++ b/macos/Sources/Lithe/Core/Rust/RustCoreBridge.swift
@@ -432,6 +432,7 @@ struct RustCoreBridge: Sendable {
                 let jvmArguments: [String]?
                 let programArguments: [String]?
                 let profiles: [String]?
+                let skipTests: Bool?
             }
             struct Java: Codable, Sendable {
                 let homePath: String?
@@ -1629,6 +1630,7 @@ struct RustCoreBridge: Sendable {
         let arguments: String
         let environment: [String: String]
         let mavenProfiles: [String]
+        let mavenSkipTests: Bool?
         let javaHomePath: String
         let mavenExecutablePath: String
         let mavenJavaHomePath: String
@@ -2413,6 +2415,7 @@ struct RustCoreBridge: Sendable {
                 arguments: options.arguments,
                 environment: options.environment,
                 mavenProfiles: options.activeProfiles.sorted(),
+                mavenSkipTests: options.mavenSkipTests,
                 javaHomePath: options.javaHomePath,
                 mavenExecutablePath: options.mavenExecutablePath,
                 mavenJavaHomePath: options.mavenJavaHomePath,
@@ -2439,6 +2442,7 @@ struct RustCoreBridge: Sendable {
                 arguments: options.arguments,
                 environment: options.environment,
                 mavenProfiles: options.activeProfiles.sorted(),
+                mavenSkipTests: options.mavenSkipTests,
                 javaHomePath: options.javaHomePath,
                 mavenExecutablePath: options.mavenExecutablePath,
                 mavenJavaHomePath: options.mavenJavaHomePath,

--- a/macos/Sources/Lithe/Core/Rust/RustJavaMavenOperations.swift
+++ b/macos/Sources/Lithe/Core/Rust/RustJavaMavenOperations.swift
@@ -6,7 +6,13 @@ protocol JavaMavenOperations: MavenProjectOperations, RunServerPortParsing, Send
         files: [URL],
         changedFiles: [URL]
     ) -> JavaWorkspacePolicyResult?
-    func scanMavenProject(at rootURL: URL, files: [URL]) -> MavenProject?
+    func scanMavenProject(at rootURL: URL, files: [URL]) throws -> MavenProject?
+    func mavenLaunchPlan(
+        at rootURL: URL,
+        context: MavenLaunchContext,
+        module: String?,
+        goals: [String]
+    ) throws -> MavenLaunchPlan
     func mavenDiagnostics(output: String, projectRoot: URL) -> [MavenBuildIssue]
     func codeVision(
         at rootURL: URL,
@@ -38,6 +44,18 @@ protocol JavaMavenOperations: MavenProjectOperations, RunServerPortParsing, Send
 }
 
 extension JavaMavenOperations {
+    func mavenLaunchPlan(
+        at _: URL,
+        context _: MavenLaunchContext,
+        module _: String?,
+        goals _: [String]
+    ) throws -> MavenLaunchPlan {
+        throw MavenOperationError(
+            code: "not_supported",
+            message: "Maven launch planning is unavailable."
+        )
+    }
+
     func javaWorkspacePolicy(
         at _: URL,
         files _: [URL],
@@ -132,7 +150,7 @@ struct RustJavaMavenOperations: JavaMavenOperations, Sendable {
         )
     }
 
-    func scanMavenProject(at rootURL: URL, files: [URL]) -> MavenProject? {
+    func scanMavenProject(at rootURL: URL, files: [URL]) throws -> MavenProject? {
         let root = rootURL.standardizedFileURL
         let rootComponents = root.pathComponents
         let paths = files.compactMap { fileURL -> String? in
@@ -143,7 +161,27 @@ struct RustJavaMavenOperations: JavaMavenOperations, Sendable {
                 .dropFirst(rootComponents.count)
                 .joined(separator: "/")
         }
-        return core.scanMaven(at: root, paths: paths)?.makeProject(workspaceRootURL: root)
+        return try core.scanMavenResult(at: root, paths: paths)
+            .mapError(MavenOperationError.init)
+            .get()?
+            .makeProject(workspaceRootURL: root)
+    }
+
+    func mavenLaunchPlan(
+        at rootURL: URL,
+        context: MavenLaunchContext,
+        module: String?,
+        goals: [String]
+    ) throws -> MavenLaunchPlan {
+        try core.mavenLaunchPlan(
+            at: rootURL,
+            context: context,
+            module: module,
+            goals: goals
+        )
+        .mapError(MavenOperationError.init)
+        .get()
+        .makeModel()
     }
 
     func mavenDiagnostics(output: String, projectRoot: URL) -> [MavenBuildIssue] {
@@ -342,5 +380,11 @@ struct RustJavaMavenOperations: JavaMavenOperations, Sendable {
                 )
             }
         )
+    }
+}
+
+private extension MavenOperationError {
+    init(_ error: RustCoreBridge.CoreCallError) {
+        self.init(code: error.code, message: error.message, details: error.details)
     }
 }

--- a/macos/Sources/Lithe/Core/Rust/RustLanguageServerRuntimeAdapter.swift
+++ b/macos/Sources/Lithe/Core/Rust/RustLanguageServerRuntimeAdapter.swift
@@ -19,6 +19,42 @@ extension RustCoreBridge: LanguageServerRuntimeCore {
         requestTimeout: TimeInterval,
         shutdownTimeout: TimeInterval
     ) -> Result<LanguageServerRuntimeStart, LanguageServerRuntimeFailure> {
+        startLanguageServer(
+            providerID: providerID,
+            executableURL: executableURL,
+            arguments: arguments,
+            environment: environment,
+            rootURL: rootURL,
+            workingDirectoryURL: workingDirectoryURL,
+            initializationOptions: initializationOptions,
+            runtimeExecutableURL: runtimeExecutableURL,
+            jdtlsLaunchResources: jdtlsLaunchResources,
+            cacheDirectoryURL: cacheDirectoryURL,
+            workspaceFingerprint: workspaceFingerprint,
+            mavenContext: nil,
+            initializeTimeout: initializeTimeout,
+            requestTimeout: requestTimeout,
+            shutdownTimeout: shutdownTimeout
+        )
+    }
+
+    func startLanguageServer(
+        providerID: String,
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        rootURL: URL,
+        workingDirectoryURL: URL,
+        initializationOptions: ToolingJSONValue?,
+        runtimeExecutableURL: URL?,
+        jdtlsLaunchResources: JDTLSLaunchResources?,
+        cacheDirectoryURL: URL?,
+        workspaceFingerprint: String?,
+        mavenContext: MavenLaunchContext?,
+        initializeTimeout: TimeInterval,
+        requestTimeout: TimeInterval,
+        shutdownTimeout: TimeInterval
+    ) -> Result<LanguageServerRuntimeStart, LanguageServerRuntimeFailure> {
         lspStartServer(
             providerID: providerID,
             executableURL: executableURL,
@@ -31,6 +67,7 @@ extension RustCoreBridge: LanguageServerRuntimeCore {
             jdtlsLaunchResources: jdtlsLaunchResources,
             cacheDirectoryURL: cacheDirectoryURL,
             workspaceFingerprint: workspaceFingerprint,
+            mavenContext: mavenContext,
             initializeTimeout: initializeTimeout,
             requestTimeout: requestTimeout,
             shutdownTimeout: shutdownTimeout

--- a/macos/Sources/Lithe/Models/AppModel/AppModel+Development.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+Development.swift
@@ -77,8 +77,7 @@ extension AppModel {
 
     func runMaven(
         phase: MavenLifecyclePhase,
-        module: MavenModule?,
-        profiles: Set<String>
+        module: MavenModule?
     ) {
         isMavenVisible = true
         isGitLogVisible = false
@@ -89,7 +88,15 @@ extension AppModel {
         isDebugVisible = false
         Task { [weak self] in
             guard let feature = await self?.activateExecutionModule()?.mavenFeature else { return }
-            feature.run(phase: phase, module: module, profiles: profiles)
+            feature.run(phase: phase, module: module)
+        }
+    }
+
+    func runMavenGoal(_ goal: String, module: MavenModule?) {
+        isMavenVisible = true
+        Task { [weak self] in
+            guard let feature = await self?.activateExecutionModule()?.mavenFeature else { return }
+            feature.runCustomGoal(goal, module: module)
         }
     }
 

--- a/macos/Sources/Lithe/Models/AppModel/AppModel+JavaIndex.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+JavaIndex.swift
@@ -46,6 +46,13 @@ extension AppModel {
                 self?.handleLanguageSessionChange()
             }
         )
+        capability.sessions.configureMavenContextProvider { [weak self] descriptor, rootURL in
+            guard descriptor.id == "java",
+                  self?.workspaceURL?.standardizedFileURL == rootURL.standardizedFileURL else {
+                return nil
+            }
+            return self?.mavenFeatureIfActive?.launchContext
+        }
         capability.tools.onCandidatesChanged = { [weak self] providerID in
             guard let self,
                   self.languageToolingFeature.shouldRetryCandidate(providerID: providerID),

--- a/macos/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -772,6 +772,10 @@ final class AppModel: ObservableObject, Identifiable {
     /// Loads build-system and run state at the workspace boundary. The generic
     /// run lifecycle is intentionally not owned by JavaFeatureModel.
     func loadProjectServices(at workspaceURL: URL, files: [URL]) async {
+        let execution = await activateExecutionModule()
+        if let execution {
+            await execution.projectDevelopment.loadProject(at: workspaceURL, files: files)
+        }
         prepareJavaLanguageServerForWorkspaceIfNeeded(
             at: workspaceURL,
             files: files
@@ -783,9 +787,7 @@ final class AppModel: ObservableObject, Identifiable {
                 ($0.url.standardizedFileURL, $0.text)
             })
         )
-        guard let execution = await activateExecutionModule() else { return }
-        execution.tests.discover(workspaceURL: workspaceURL, files: files)
-        await execution.projectDevelopment.loadProject(at: workspaceURL, files: files)
+        execution?.tests.discover(workspaceURL: workspaceURL, files: files)
     }
 
     var projectName: String {

--- a/macos/Sources/Lithe/Platform/MacOS/MacServiceContainer.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/MacServiceContainer.swift
@@ -310,7 +310,8 @@ final class MacServiceContainer {
                         maven: MavenService(
                             runtimeService: runtimeService,
                             process: MacStreamingProcess(processRegistry: processRegistry, moduleID: .execution),
-                            mavenOperations: javaMavenOperations
+                            mavenOperations: javaMavenOperations,
+                            configurationStore: MacMavenConfigurationStore(storage: fileStorage)
                         ),
                         run: RunService(
                             runtime: runtimeService,

--- a/macos/Sources/Lithe/Platform/MacOS/Persistence/MacMavenConfigurationStore.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/Persistence/MacMavenConfigurationStore.swift
@@ -51,7 +51,10 @@ struct MacMavenConfigurationStore: MavenConfigurationStoring, Sendable {
     }
 
     private func localConfigurationURL(workspaceURL: URL, reactorPath: String) -> URL {
-        let identity = workspaceURL.standardizedFileURL.path + "\0" + reactorPath
+        let identity = Self.storageIdentity(
+            workspacePath: workspaceURL.standardizedFileURL.path,
+            reactorPath: reactorPath
+        )
         let digest = SHA256.hash(data: Data(identity.utf8))
             .map { String(format: "%02x", $0) }
             .joined()
@@ -59,6 +62,10 @@ struct MacMavenConfigurationStore: MavenConfigurationStoring, Sendable {
             .appendingPathComponent("Lithe", isDirectory: true)
             .appendingPathComponent("Maven", isDirectory: true)
             .appendingPathComponent(digest + ".json")
+    }
+
+    static func storageIdentity(workspacePath: String, reactorPath: String) -> String {
+        workspacePath + "\0" + reactorPath
     }
 
     private func decodeIfPresent<Value: Decodable>(

--- a/macos/Sources/Lithe/Platform/MacOS/Persistence/MacMavenConfigurationStore.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/Persistence/MacMavenConfigurationStore.swift
@@ -1,0 +1,112 @@
+import CryptoKit
+import Foundation
+import LitheCoreContracts
+
+struct MacMavenConfigurationStore: MavenConfigurationStoring, Sendable {
+    private let storage: any FileStorage
+
+    init(storage: any FileStorage) {
+        self.storage = storage
+    }
+
+    func loadMavenConfiguration(
+        workspaceURL: URL,
+        reactorPath: String
+    ) throws -> MavenStoredConfiguration {
+        let portable = try decodeIfPresent(
+            MavenPortableConfiguration.self,
+            at: portableConfigurationURL(workspaceURL: workspaceURL)
+        )
+        let local = try decodeIfPresent(
+            MavenLocalConfiguration.self,
+            at: localConfigurationURL(workspaceURL: workspaceURL, reactorPath: reactorPath)
+        )
+        guard portable?.version == nil || portable?.version == MavenPortableConfiguration.currentVersion,
+              local?.version == nil || local?.version == MavenLocalConfiguration.currentVersion else {
+            throw MacMavenConfigurationStoreError.unsupportedVersion
+        }
+        return MavenStoredConfiguration(portable: portable, local: local)
+    }
+
+    func saveMavenConfiguration(
+        _ configuration: MavenStoredConfiguration,
+        workspaceURL: URL,
+        reactorPath: String
+    ) throws {
+        try write(
+            configuration.portable,
+            to: portableConfigurationURL(workspaceURL: workspaceURL)
+        )
+        try write(
+            configuration.local,
+            to: localConfigurationURL(workspaceURL: workspaceURL, reactorPath: reactorPath)
+        )
+    }
+
+    private func portableConfigurationURL(workspaceURL: URL) -> URL {
+        workspaceURL.standardizedFileURL
+            .appendingPathComponent(".lithe", isDirectory: true)
+            .appendingPathComponent("maven", isDirectory: true)
+            .appendingPathComponent("config.json")
+    }
+
+    private func localConfigurationURL(workspaceURL: URL, reactorPath: String) -> URL {
+        let identity = workspaceURL.standardizedFileURL.path + "\0" + reactorPath
+        let digest = SHA256.hash(data: Data(identity.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return storage.applicationSupportDirectory()
+            .appendingPathComponent("Lithe", isDirectory: true)
+            .appendingPathComponent("Maven", isDirectory: true)
+            .appendingPathComponent(digest + ".json")
+    }
+
+    private func decodeIfPresent<Value: Decodable>(
+        _ type: Value.Type,
+        at url: URL
+    ) throws -> Value? {
+        guard storage.fileExists(at: url) else { return nil }
+        do {
+            return try JSONDecoder().decode(type, from: storage.readData(from: url, options: []))
+        } catch {
+            throw MacMavenConfigurationStoreError.invalidConfiguration(url.lastPathComponent)
+        }
+    }
+
+    private func write<Value: Encodable>(_ value: Value?, to url: URL) throws {
+        guard let value else {
+            if storage.fileExists(at: url) {
+                try storage.removeItem(at: url)
+            }
+            return
+        }
+        do {
+            try storage.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            try storage.writeData(encoder.encode(value), to: url, options: .atomic)
+        } catch {
+            throw MacMavenConfigurationStoreError.writeFailed(error.localizedDescription)
+        }
+    }
+}
+
+private enum MacMavenConfigurationStoreError: LocalizedError {
+    case invalidConfiguration(String)
+    case unsupportedVersion
+    case writeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration(let name):
+            "The Maven configuration in \(name) is invalid."
+        case .unsupportedVersion:
+            "The Maven configuration was created by an unsupported version of Lithe."
+        case .writeFailed(let details):
+            "Unable to save Maven configuration: \(details)"
+        }
+    }
+}

--- a/macos/Sources/Lithe/Platform/MacOS/RunConfiguration/MacRunConfigurationStore.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/RunConfiguration/MacRunConfigurationStore.swift
@@ -100,6 +100,7 @@ struct MacRunConfigurationStore: RunConfigurationOperations, @unchecked Sendable
                     vmArguments: (maven?.jvmArguments ?? []).joined(separator: " "),
                     programArguments: (maven?.programArguments ?? value.args ?? []).joined(separator: " "),
                     activeProfiles: Set(maven?.profiles ?? []),
+                    mavenSkipTests: maven?.skipTests,
                     mavenExecutablePath: java?.mavenExecutablePath ?? "",
                     mavenJavaHomePath: java?.mavenJavaHomePath ?? "",
                     environment: value.env ?? [:]

--- a/macos/Sources/Lithe/Platform/MacOS/RunConfiguration/MacRunConfigurationStore.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/RunConfiguration/MacRunConfigurationStore.swift
@@ -126,13 +126,32 @@ struct MacRunConfigurationStore: RunConfigurationOperations, @unchecked Sendable
         classPath: String?,
         debugPort: Int?
     ) throws -> SharedLaunchPlan {
+        try launchPlan(
+            at: projectURL,
+            configurationID: configurationID,
+            currentFile: currentFile,
+            classPath: classPath,
+            debugPort: debugPort,
+            mavenContext: nil
+        )
+    }
+
+    func launchPlan(
+        at projectURL: URL,
+        configurationID: String,
+        currentFile: String?,
+        classPath: String?,
+        debugPort: Int?,
+        mavenContext: MavenLaunchContext?
+    ) throws -> SharedLaunchPlan {
         let value: RustCoreBridge.LaunchPlanPayload
         switch core.createLaunchPlan(
             at: projectURL,
             configurationID: configurationID,
             currentFile: currentFile,
             classPath: classPath,
-            debugPort: debugPort
+            debugPort: debugPort,
+            mavenContext: mavenContext
         ) {
         case .success(let payload): value = payload
         case .failure(let error): throw RunConfigurationOperationFailure(message: error.userMessage)

--- a/macos/Sources/Lithe/Platform/MacOS/Runtime/MacRuntimeDiscovery.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/Runtime/MacRuntimeDiscovery.swift
@@ -32,11 +32,22 @@ enum MacRuntimeDiscovery {
     static func mavenExecutable(forHomePath path: String) -> URL? {
         let expanded = (path as NSString).expandingTildeInPath
         let url = URL(fileURLWithPath: expanded).standardizedFileURL
-        let candidates = [
-            url,
-            url.appendingPathComponent("bin/mvn")
-        ]
-        return candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0.path) })
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return nil
+        }
+        let executable = isDirectory.boolValue
+            ? url.appendingPathComponent("bin/mvn")
+            : url
+        var executableIsDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(
+            atPath: executable.path,
+            isDirectory: &executableIsDirectory
+        ), !executableIsDirectory.boolValue,
+        FileManager.default.isExecutableFile(atPath: executable.path) else {
+            return nil
+        }
+        return executable.standardizedFileURL
     }
 
     static func validJavaHome(_ path: String) -> URL? {

--- a/macos/Sources/Lithe/Services/Java/JavaDebugService.swift
+++ b/macos/Sources/Lithe/Services/Java/JavaDebugService.swift
@@ -127,12 +127,20 @@ final class JavaDebugService: ObservableObject {
         configuration: RunConfiguration,
         project: MavenProject,
         projectURL: URL,
-        options: RunOptions
+        options: RunOptions,
+        mavenContext: MavenLaunchContext? = nil
     ) {
         stop()
         guard configuration.kind.isMavenBacked else {
             fail("Select a Spring Boot or Maven Module configuration before starting Debug.")
             return
+        }
+        var options = options
+        if options.mavenExecutablePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            options.mavenExecutablePath = mavenContext?.mavenExecutablePath ?? ""
+        }
+        if options.mavenJavaHomePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            options.mavenJavaHomePath = mavenContext?.javaHomePath ?? ""
         }
         let debugPort = Self.nextPort()
         let plan: SharedLaunchPlan
@@ -142,7 +150,8 @@ final class JavaDebugService: ObservableObject {
                 configurationID: configuration.id,
                 currentFile: nil,
                 classPath: nil,
-                debugPort: debugPort
+                debugPort: debugPort,
+                mavenContext: mavenContext
             )
             guard plan.toolchainID == "project-maven" else {
                 throw RunConfigurationOperationFailure(message: "The selected configuration does not use Maven.")
@@ -176,7 +185,10 @@ final class JavaDebugService: ObservableObject {
             fail("No Maven executable was found. Edit this service configuration.")
             return
         }
-        append("$ " + executable.lastPathComponent + " " + plan.arguments.joined(separator: " ") + "\n\n")
+        append(
+            "$ " + executable.lastPathComponent + " "
+                + redactedMavenArgumentsForDisplay(plan.arguments).joined(separator: " ") + "\n\n"
+        )
         startDebuggee(
             executable: executable,
             arguments: plan.arguments,

--- a/macos/Sources/Lithe/Services/Java/ProjectRuntimeService.swift
+++ b/macos/Sources/Lithe/Services/Java/ProjectRuntimeService.swift
@@ -373,8 +373,12 @@ final class ProjectRuntimeService: ObservableObject {
             let resolved = configured.hasPrefix("/")
                 ? URL(fileURLWithPath: configured)
                 : rootURL.appendingPathComponent(configured)
+            let standardized = resolved.standardizedFileURL
+            if runtimeLocator.isExecutable(at: standardized) {
+                return standardized
+            }
             return runtimeLocator.mavenExecutable(
-                forHomePath: resolved.standardizedFileURL.path
+                forHomePath: standardized.path
             )
         }
         let wrapper = rootURL.appendingPathComponent("mvnw")

--- a/macos/Sources/Lithe/Services/Java/ProjectRuntimeService.swift
+++ b/macos/Sources/Lithe/Services/Java/ProjectRuntimeService.swift
@@ -19,12 +19,8 @@ extension ProjectRuntimeService: LanguageToolRuntimePort {
 }
 
 extension ProjectRuntimeService: MavenRuntimePort {
-    package func mavenExecutable(for project: MavenProject) -> URL? {
-        mavenExecutable(for: project, overridePath: nil)
-    }
-
-    package func mavenProcessEnvironment() -> [String: String] {
-        environment(for: .maven)
+    package func mavenProcessEnvironment(javaHomePath: String?) -> [String: String] {
+        environment(for: .maven, javaHomeOverride: javaHomePath)
     }
 }
 
@@ -377,14 +373,9 @@ final class ProjectRuntimeService: ObservableObject {
             let resolved = configured.hasPrefix("/")
                 ? URL(fileURLWithPath: configured)
                 : rootURL.appendingPathComponent(configured)
-            let candidates = [
-                resolved,
-                resolved.appendingPathComponent("bin/mvn")
-            ]
-            if let candidate = candidates.first(where: { runtimeLocator.isExecutable(at: $0.standardizedFileURL) }) {
-                return candidate.standardizedFileURL
-            }
-            return nil
+            return runtimeLocator.mavenExecutable(
+                forHomePath: resolved.standardizedFileURL.path
+            )
         }
         let wrapper = rootURL.appendingPathComponent("mvnw")
         if runtimeLocator.isExecutable(at: wrapper) {

--- a/macos/Sources/Lithe/Views/Run/JavaRunConfigurationEditorView.swift
+++ b/macos/Sources/Lithe/Views/Run/JavaRunConfigurationEditorView.swift
@@ -40,8 +40,9 @@ struct RunConfigurationEditorView: View {
                     if effectiveCapabilities.contains(.environment) {
                         environmentSection
                     }
-                    if effectiveCapabilities.contains(.mavenProfiles) && !feature.mavenProfiles.isEmpty {
-                        profilesSection
+                    if effectiveCapabilities.contains(.mavenSkipTests)
+                        || (effectiveCapabilities.contains(.mavenProfiles) && !feature.mavenProfiles.isEmpty) {
+                        mavenOptionsSection
                     }
                 }
                 .padding(18)
@@ -270,23 +271,36 @@ struct RunConfigurationEditorView: View {
         }
     }
 
-    private var profilesSection: some View {
-        section(title: "Active Maven Profiles") {
-            ForEach(feature.mavenProfiles) { profile in
-                Toggle(isOn: profileBinding(for: profile)) {
-                    HStack(spacing: 0) {
-                        Text(profile.id)
-                            .lineLimit(1)
-                        Spacer(minLength: 0)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
+    private var mavenOptionsSection: some View {
+        section(title: "Maven") {
+            if effectiveCapabilities.contains(.mavenSkipTests) {
+                Picker("Tests", selection: Binding(
+                    get: { options.mavenSkipTests },
+                    set: { options.mavenSkipTests = $0 }
+                )) {
+                    Text("Project default").tag(Bool?.none)
+                    Text("Run tests").tag(Bool?.some(false))
+                    Text("Skip tests").tag(Bool?.some(true))
                 }
-                .toggleStyle(.checkbox)
-                .lithePointer()
-                .font(.system(size: 12))
-                .foregroundStyle(LitheTheme.primaryText)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .pickerStyle(.segmented)
+            }
+            if effectiveCapabilities.contains(.mavenProfiles) {
+                ForEach(feature.mavenProfiles) { profile in
+                    Toggle(isOn: profileBinding(for: profile)) {
+                        HStack(spacing: 0) {
+                            Text(profile.id)
+                                .lineLimit(1)
+                            Spacer(minLength: 0)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                    }
+                    .toggleStyle(.checkbox)
+                    .lithePointer()
+                    .font(.system(size: 12))
+                    .foregroundStyle(LitheTheme.primaryText)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
         }
     }

--- a/macos/Sources/Lithe/Views/Run/MavenView.swift
+++ b/macos/Sources/Lithe/Views/Run/MavenView.swift
@@ -4,17 +4,34 @@ struct MavenView: View {
     @EnvironmentObject private var model: AppModel
     @ObservedObject var feature: MavenFeatureModel
     @State private var selectedModuleID: String?
-    @State private var enabledProfiles: Set<String> = []
+    @State private var selectedPhase: MavenLifecyclePhase?
     @State private var expandedNodeIDs: Set<String> = []
+    @State private var isGoalSheetPresented = false
+    @State private var isSettingsSheetPresented = false
+    @State private var isAddProfilePresented = false
+    @State private var customGoal = ""
+    @State private var customProfile = ""
+    @State private var settingsPath = ""
+    @State private var mavenExecutablePath = ""
+    @State private var javaHomePath = ""
 
     var body: some View {
         VStack(spacing: 0) {
             toolWindowHeader
 
+            if let error = feature.configurationSaveError {
+                configurationErrorBanner(error)
+            }
+            if feature.isReloadRequired {
+                reloadBanner
+            }
+
             if feature.isLoadingProject {
                 ProgressView("Scanning Maven project...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .foregroundStyle(LitheTheme.secondaryText)
+            } else if case .failed(let message) = feature.projectState {
+                failedState(message)
             } else if let project = feature.project {
                 HStack(spacing: 0) {
                     projectPane(project)
@@ -35,6 +52,12 @@ struct MavenView: View {
         .onChange(of: feature.project?.id) { _ in
             resetTreeState()
         }
+        .sheet(isPresented: $isGoalSheetPresented) {
+            goalSheet
+        }
+        .sheet(isPresented: $isSettingsSheetPresented) {
+            settingsSheet
+        }
     }
 
     private var toolWindowHeader: some View {
@@ -52,6 +75,10 @@ struct MavenView: View {
                     .font(.system(size: 11.5, weight: .medium))
                     .foregroundStyle(LitheTheme.secondaryText)
                     .lineLimit(1)
+            } else if feature.taskState == .cancelled {
+                Label("Cancelled", systemImage: "stop.circle.fill")
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundStyle(LitheTheme.warning)
             } else if let exitCode = feature.lastExitCode {
                 Label(
                     exitCode == 0 ? "Succeeded" : "Failed",
@@ -60,6 +87,23 @@ struct MavenView: View {
                 .font(.system(size: 11.5, weight: .medium))
                 .foregroundStyle(exitCode == 0 ? LitheTheme.success : LitheTheme.error)
             }
+
+            Button(action: runSelected) {
+                LitheSystemIcon(systemImage: "play.fill")
+            }
+            .litheIconButton()
+            .disabled(selectedPhase == nil || feature.isRunning)
+            .help("Run selected Maven lifecycle phase")
+
+            Button {
+                customGoal = ""
+                isGoalSheetPresented = true
+            } label: {
+                LitheSystemIcon(systemImage: "terminal")
+            }
+            .litheIconButton()
+            .disabled(feature.isRunning)
+            .help("Execute Maven goal")
 
             Button(action: refreshProject) {
                 LitheSystemIcon(systemImage: "arrow.clockwise")
@@ -76,6 +120,29 @@ struct MavenView: View {
                 .help("Stop Maven task")
             }
 
+            Button {
+                feature.setSkipTests(!feature.skipTests)
+            } label: {
+                LitheSystemIcon(systemImage: feature.skipTests ? "checkmark.square.fill" : "square")
+            }
+            .litheIconButton()
+            .foregroundStyle(feature.skipTests ? LitheTheme.accent : LitheTheme.secondaryText)
+            .help("Skip tests")
+
+            Button {
+                expandedNodeIDs.removeAll()
+            } label: {
+                LitheSystemIcon(systemImage: "rectangle.compress.vertical")
+            }
+            .litheIconButton()
+            .help("Collapse all")
+
+            Button(action: presentSettings) {
+                LitheSystemIcon(systemImage: "slider.horizontal.3")
+            }
+            .litheIconButton()
+            .help("Maven settings")
+
             Button(action: feature.clearOutput) {
                 Image(systemName: "trash")
             }
@@ -90,17 +157,58 @@ struct MavenView: View {
         Task { await feature.loadProject(at: workspaceURL, files: model.projectFiles) }
     }
 
+    private var reloadBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .foregroundStyle(LitheTheme.warning)
+            Text("Maven configuration changed")
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(LitheTheme.primaryText)
+            Spacer(minLength: 8)
+            Button("Reload JDT LS") {
+                model.restartLanguageServers()
+                feature.acknowledgeReload()
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 32)
+        .background(LitheTheme.warning.opacity(0.1))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(LitheTheme.divider).frame(height: 1)
+        }
+    }
+
+    private func configurationErrorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(LitheTheme.error)
+            Text(message)
+                .font(.system(size: 11.5))
+                .foregroundStyle(LitheTheme.primaryText)
+                .lineLimit(2)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(LitheTheme.error.opacity(0.08))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(LitheTheme.divider).frame(height: 1)
+        }
+    }
+
     private func projectPane(_ project: MavenProject) -> some View {
         ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: 1) {
-                if !project.profiles.isEmpty {
+                if !feature.availableProfiles.isEmpty {
                     treeNode(
                         id: profilesNodeID,
                         title: "Profiles",
                         systemImage: "folder",
                         onLabelAction: { toggleNode(profilesNodeID) }
                     ) {
-                        ForEach(project.profiles) { profile in
+                        profileActions
+                        ForEach(feature.availableProfiles) { profile in
                             profileRow(profile)
                         }
                     }
@@ -179,13 +287,52 @@ struct MavenView: View {
         .frame(height: 24)
     }
 
+    private var profileActions: some View {
+        HStack(spacing: 4) {
+            Button {
+                customProfile = ""
+                isAddProfilePresented = true
+            } label: {
+                Image(systemName: "plus")
+                    .frame(width: 18, height: 20)
+            }
+            .buttonStyle(.plain)
+            .help("Add profile")
+            .popover(isPresented: $isAddProfilePresented, arrowEdge: .trailing) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Add Maven Profile")
+                        .font(.system(size: 13, weight: .semibold))
+                    TextField("Profile ID", text: $customProfile)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 220)
+                        .onSubmit(addCustomProfile)
+                    HStack {
+                        Spacer()
+                        Button("Cancel") { isAddProfilePresented = false }
+                        Button("Add", action: addCustomProfile)
+                            .keyboardShortcut(.defaultAction)
+                            .disabled(customProfile.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+                .padding(14)
+            }
+
+            Button(action: feature.restoreDefaultProfiles) {
+                Image(systemName: "arrow.uturn.backward")
+                    .frame(width: 18, height: 20)
+            }
+            .buttonStyle(.plain)
+            .help("Restore default profiles")
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(LitheTheme.secondaryText)
+        .padding(.leading, 2)
+    }
+
     private func lifecycleRow(_ phase: MavenLifecyclePhase, module: MavenModule?) -> some View {
         Button {
-            model.runMaven(
-                phase: phase,
-                module: module,
-                profiles: enabledProfiles
-            )
+            selectedModuleID = module?.id
+            selectedPhase = phase
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: phase.systemImage)
@@ -195,20 +342,31 @@ struct MavenView: View {
                 Text(LocalizedStringKey(phase.title))
                     .lineLimit(1)
                 Spacer(minLength: 0)
-                LitheSystemIcon(systemImage: "play.fill")
-                    .font(.system(size: 8))
-                    .foregroundStyle(LitheTheme.accent)
+                if selectedModuleID == module?.id, selectedPhase == phase {
+                    LitheSystemIcon(systemImage: "play.fill")
+                        .font(.system(size: 8))
+                        .foregroundStyle(LitheTheme.accent)
+                }
             }
             .font(.system(size: 12))
             .foregroundStyle(LitheTheme.primaryText)
             .padding(.horizontal, 2)
             .frame(maxWidth: .infinity, alignment: .leading)
             .frame(height: 24)
+            .background(
+                selectedModuleID == module?.id && selectedPhase == phase
+                    ? LitheTheme.subtleSelection
+                    : .clear
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 4))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .lithePointer()
-        .disabled(feature.isRunning)
+        .simultaneousGesture(TapGesture(count: 2).onEnded {
+            guard !feature.isRunning else { return }
+            feature.run(phase: phase, module: module)
+        })
     }
 
     private func treeNode<Content: View>(
@@ -367,17 +525,174 @@ struct MavenView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    private func failedState(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "xmark.octagon")
+                .font(.system(size: 28, weight: .light))
+                .foregroundStyle(LitheTheme.error)
+            Text("Unable to load Maven project")
+                .font(.system(size: 14, weight: .semibold))
+            Text(message)
+                .font(LitheTheme.uiFont)
+                .foregroundStyle(LitheTheme.secondaryText)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 440)
+            Button("Retry", action: refreshProject)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var goalSheet: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Execute Maven Goal")
+                .font(.system(size: 16, weight: .semibold))
+            TextField("Goal", text: $customGoal, prompt: Text("spring-boot:run"))
+                .textFieldStyle(.roundedBorder)
+                .onSubmit(executeCustomGoal)
+            HStack {
+                Spacer()
+                Button("Cancel") { isGoalSheetPresented = false }
+                    .keyboardShortcut(.cancelAction)
+                Button("Run", action: executeCustomGoal)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(customGoal.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+    }
+
+    private var settingsSheet: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Maven Settings")
+                .font(.system(size: 16, weight: .semibold))
+
+            settingsPathRow(
+                title: "settings.xml",
+                value: $settingsPath,
+                choose: {
+                    model.platformUI.chooseFile(title: "Choose Maven settings.xml", prompt: "Choose")
+                }
+            )
+            settingsPathRow(
+                title: "Maven Home or Executable",
+                value: $mavenExecutablePath,
+                choose: {
+                    model.platformUI.chooseDirectory(title: "Choose Maven Home", prompt: "Choose")
+                }
+            )
+            settingsPathRow(
+                title: "Maven JDK",
+                value: $javaHomePath,
+                choose: {
+                    model.platformUI.chooseDirectory(title: "Choose Maven JDK", prompt: "Choose")
+                }
+            )
+
+            if let error = feature.configurationSaveError {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(LitheTheme.error)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { isSettingsSheetPresented = false }
+                    .keyboardShortcut(.cancelAction)
+                Button("Save", action: saveSettings)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 560)
+    }
+
+    private func settingsPathRow(
+        title: String,
+        value: Binding<String>,
+        choose: @escaping () -> URL?
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(LitheTheme.primaryText)
+            HStack(spacing: 6) {
+                TextField("Automatic", text: value)
+                    .textFieldStyle(.roundedBorder)
+                Button {
+                    value.wrappedValue = ""
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .litheIconButton()
+                .help("Use automatic value")
+                Button {
+                    if let url = choose() {
+                        value.wrappedValue = url.standardizedFileURL.path
+                    }
+                } label: {
+                    Image(systemName: "folder")
+                }
+                .litheIconButton()
+                .help("Choose path")
+            }
+        }
+    }
+
     private func profileBinding(for profile: MavenProfile) -> Binding<Bool> {
         Binding(
-            get: { enabledProfiles.contains(profile.id) },
+            get: { feature.selectedProfiles.contains(profile.id) },
             set: { enabled in
+                var profiles = feature.selectedProfiles
                 if enabled {
-                    enabledProfiles.insert(profile.id)
+                    profiles.insert(profile.id)
                 } else {
-                    enabledProfiles.remove(profile.id)
+                    profiles.remove(profile.id)
                 }
+                feature.setSelectedProfiles(profiles)
             }
         )
+    }
+
+    private func runSelected() {
+        guard let phase = selectedPhase, !feature.isRunning else { return }
+        feature.run(phase: phase, module: selectedModule)
+    }
+
+    private func executeCustomGoal() {
+        let goal = customGoal.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !goal.isEmpty else { return }
+        isGoalSheetPresented = false
+        feature.runCustomGoal(goal, module: selectedModule)
+    }
+
+    private func addCustomProfile() {
+        if feature.addCustomProfile(customProfile) {
+            customProfile = ""
+            isAddProfilePresented = false
+        }
+    }
+
+    private func presentSettings() {
+        settingsPath = feature.settingsPath ?? ""
+        mavenExecutablePath = feature.mavenExecutablePath ?? ""
+        javaHomePath = feature.javaHomePath ?? ""
+        isSettingsSheetPresented = true
+    }
+
+    private func saveSettings() {
+        feature.updateLocalConfiguration(
+            settingsPath: settingsPath,
+            mavenExecutablePath: mavenExecutablePath,
+            javaHomePath: javaHomePath
+        )
+        isSettingsSheetPresented = false
+    }
+
+    private var selectedModule: MavenModule? {
+        guard let selectedModuleID else { return nil }
+        return feature.project?.allModules.first(where: { $0.id == selectedModuleID })
     }
 
     private var profilesNodeID: String { "profiles" }
@@ -408,10 +723,10 @@ struct MavenView: View {
 
     private func resetTreeState() {
         selectedModuleID = nil
-        enabledProfiles = Set(feature.project?.profiles.filter(\.isActiveByDefault).map(\.id) ?? [])
+        selectedPhase = .compile
         expandedNodeIDs = feature.project.map { project in
             var ids: Set<String> = [projectNodeID(project)]
-            if !project.profiles.isEmpty {
+            if !feature.availableProfiles.isEmpty {
                 ids.insert(profilesNodeID)
             }
             return ids

--- a/macos/Sources/LitheCoreContracts/Execution/ExecutionContracts.swift
+++ b/macos/Sources/LitheCoreContracts/Execution/ExecutionContracts.swift
@@ -7,9 +7,11 @@ package struct RunOptions: Codable, Hashable, Sendable {
         package var mavenJavaHomePath = ""
         package var vmArguments = ""
         package var activeMavenProfiles: Set<String> = []
+        package var skipTests: Bool?
 
         private enum CodingKeys: String, CodingKey {
             case homePath, mavenExecutablePath, mavenJavaHomePath, vmArguments, activeMavenProfiles
+            case skipTests
         }
 
         package init(
@@ -17,13 +19,15 @@ package struct RunOptions: Codable, Hashable, Sendable {
             mavenExecutablePath: String = "",
             mavenJavaHomePath: String = "",
             vmArguments: String = "",
-            activeMavenProfiles: Set<String> = []
+            activeMavenProfiles: Set<String> = [],
+            skipTests: Bool? = nil
         ) {
             self.homePath = homePath
             self.mavenExecutablePath = mavenExecutablePath
             self.mavenJavaHomePath = mavenJavaHomePath
             self.vmArguments = vmArguments
             self.activeMavenProfiles = activeMavenProfiles
+            self.skipTests = skipTests
         }
 
         package init(from decoder: Decoder) throws {
@@ -33,6 +37,7 @@ package struct RunOptions: Codable, Hashable, Sendable {
             mavenJavaHomePath = try container.decodeIfPresent(String.self, forKey: .mavenJavaHomePath) ?? ""
             vmArguments = try container.decodeIfPresent(String.self, forKey: .vmArguments) ?? ""
             activeMavenProfiles = try container.decodeIfPresent(Set<String>.self, forKey: .activeMavenProfiles) ?? []
+            skipTests = try container.decodeIfPresent(Bool.self, forKey: .skipTests)
         }
     }
 
@@ -47,6 +52,7 @@ package struct RunOptions: Codable, Hashable, Sendable {
         vmArguments: String = "",
         programArguments: String = "",
         activeProfiles: Set<String> = [],
+        mavenSkipTests: Bool? = nil,
         mavenExecutablePath: String = "",
         mavenJavaHomePath: String = "",
         environment: [String: String] = [:]
@@ -59,7 +65,8 @@ package struct RunOptions: Codable, Hashable, Sendable {
             mavenExecutablePath: mavenExecutablePath,
             mavenJavaHomePath: mavenJavaHomePath,
             vmArguments: vmArguments,
-            activeMavenProfiles: activeProfiles
+            activeMavenProfiles: activeProfiles,
+            skipTests: mavenSkipTests
         )
     }
 
@@ -86,6 +93,10 @@ package struct RunOptions: Codable, Hashable, Sendable {
     package var activeProfiles: Set<String> {
         get { java.activeMavenProfiles }
         set { java.activeMavenProfiles = newValue }
+    }
+    package var mavenSkipTests: Bool? {
+        get { java.skipTests }
+        set { java.skipTests = newValue }
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/macos/Sources/LitheCoreContracts/Execution/MavenContracts.swift
+++ b/macos/Sources/LitheCoreContracts/Execution/MavenContracts.swift
@@ -139,13 +139,194 @@ package struct MavenBuildIssue: Identifiable, Hashable, Sendable {
     }
 }
 
+package enum MavenProjectLoadState: Equatable, Sendable {
+    case idle
+    case loading
+    case ready
+    case failed(String)
+}
+
+package enum MavenTaskState: Equatable, Sendable {
+    case idle
+    case running
+    case stopping
+    case cancelled
+    case failed(String)
+}
+
+package struct MavenPortableConfiguration: Codable, Equatable, Sendable {
+    package static let currentVersion = 1
+
+    package var version: Int
+    package var selectedProfiles: [String]
+    package var customProfiles: [String]
+    package var skipTests: Bool
+
+    package init(
+        version: Int = currentVersion,
+        selectedProfiles: [String] = [],
+        customProfiles: [String] = [],
+        skipTests: Bool = false
+    ) {
+        self.version = version
+        self.selectedProfiles = selectedProfiles
+        self.customProfiles = customProfiles
+        self.skipTests = skipTests
+    }
+}
+
+package struct MavenLocalConfiguration: Codable, Equatable, Sendable {
+    package static let currentVersion = 1
+
+    package var version: Int
+    package var settingsPath: String?
+    package var mavenExecutablePath: String?
+    package var javaHomePath: String?
+
+    package init(
+        version: Int = currentVersion,
+        settingsPath: String? = nil,
+        mavenExecutablePath: String? = nil,
+        javaHomePath: String? = nil
+    ) {
+        self.version = version
+        self.settingsPath = settingsPath
+        self.mavenExecutablePath = mavenExecutablePath
+        self.javaHomePath = javaHomePath
+    }
+}
+
+package struct MavenStoredConfiguration: Equatable, Sendable {
+    package let portable: MavenPortableConfiguration?
+    package let local: MavenLocalConfiguration?
+
+    package init(
+        portable: MavenPortableConfiguration?,
+        local: MavenLocalConfiguration?
+    ) {
+        self.portable = portable
+        self.local = local
+    }
+}
+
+package struct MavenLaunchContext: Codable, Equatable, Sendable {
+    package static let currentVersion = 1
+
+    package let version: Int
+    package let reactorPath: String
+    package let profiles: [String]
+    package let settingsPath: String?
+    package let skipTests: Bool
+    package let mavenExecutablePath: String?
+    package let javaHomePath: String?
+
+    package init(
+        version: Int = currentVersion,
+        reactorPath: String,
+        profiles: [String],
+        settingsPath: String?,
+        skipTests: Bool,
+        mavenExecutablePath: String?,
+        javaHomePath: String?
+    ) {
+        self.version = version
+        self.reactorPath = reactorPath
+        self.profiles = profiles
+        self.settingsPath = settingsPath
+        self.skipTests = skipTests
+        self.mavenExecutablePath = mavenExecutablePath
+        self.javaHomePath = javaHomePath
+    }
+}
+
+package struct MavenLaunchPlan: Equatable, Sendable {
+    package let version: Int
+    package let toolchain: String
+    package let arguments: [String]
+    package let workingDirectory: String
+    package let configurationFingerprint: String
+
+    package init(
+        version: Int,
+        toolchain: String,
+        arguments: [String],
+        workingDirectory: String,
+        configurationFingerprint: String
+    ) {
+        self.version = version
+        self.toolchain = toolchain
+        self.arguments = arguments
+        self.workingDirectory = workingDirectory
+        self.configurationFingerprint = configurationFingerprint
+    }
+}
+
+package func redactedMavenArgumentsForDisplay(_ arguments: [String]) -> [String] {
+    var result: [String] = []
+    var index = 0
+    while index < arguments.count {
+        let argument = arguments[index]
+        if argument == "-s" || argument == "--settings" {
+            result.append(argument)
+            if arguments.indices.contains(index + 1) {
+                result.append("<settings.xml>")
+                index += 2
+            } else {
+                index += 1
+            }
+        } else if argument.hasPrefix("--settings=") || argument.hasPrefix("-s=") {
+            result.append(String(argument.prefix { $0 != "=" }) + "=<settings.xml>")
+            index += 1
+        } else {
+            result.append(argument)
+            index += 1
+        }
+    }
+    return result
+}
+
+package struct MavenOperationError: LocalizedError, Equatable, Sendable {
+    package let code: String
+    package let message: String
+    package let details: String?
+
+    package init(code: String, message: String, details: String? = nil) {
+        self.code = code
+        self.message = message
+        self.details = details
+    }
+
+    package var errorDescription: String? {
+        guard let details, !details.isEmpty else { return message }
+        return message + ": " + details
+    }
+}
+
 package protocol MavenProjectOperations: Sendable {
-    func scanMavenProject(at rootURL: URL, files: [URL]) -> MavenProject?
+    func scanMavenProject(at rootURL: URL, files: [URL]) throws -> MavenProject?
+    func mavenLaunchPlan(
+        at rootURL: URL,
+        context: MavenLaunchContext,
+        module: String?,
+        goals: [String]
+    ) throws -> MavenLaunchPlan
     func mavenDiagnostics(output: String, projectRoot: URL) -> [MavenBuildIssue]
+}
+
+package protocol MavenConfigurationStoring: Sendable {
+    func loadMavenConfiguration(
+        workspaceURL: URL,
+        reactorPath: String
+    ) throws -> MavenStoredConfiguration
+    func saveMavenConfiguration(
+        _ configuration: MavenStoredConfiguration,
+        workspaceURL: URL,
+        reactorPath: String
+    ) throws
 }
 
 @MainActor
 package protocol MavenRuntimePort: AnyObject {
-    func mavenExecutable(for project: MavenProject) -> URL?
-    func mavenProcessEnvironment() -> [String: String]
+    func mavenExecutable(for project: MavenProject, overridePath: String?) -> URL?
+    func mavenProcessEnvironment(javaHomePath: String?) -> [String: String]
 }

--- a/macos/Sources/LitheCoreContracts/Execution/RunConfigurationContracts.swift
+++ b/macos/Sources/LitheCoreContracts/Execution/RunConfigurationContracts.swift
@@ -221,6 +221,14 @@ package protocol RunConfigurationOperations: Sendable {
         classPath: String?,
         debugPort: Int?
     ) throws -> SharedLaunchPlan
+    func launchPlan(
+        at projectURL: URL,
+        configurationID: String,
+        currentFile: String?,
+        classPath: String?,
+        debugPort: Int?,
+        mavenContext: MavenLaunchContext?
+    ) throws -> SharedLaunchPlan
     func saveEditorChanges(
         _ options: RunOptions,
         toolchain: ProjectToolchainSelection,
@@ -233,6 +241,23 @@ package protocol RunConfigurationOperations: Sendable {
 }
 
 package extension RunConfigurationOperations {
+    func launchPlan(
+        at projectURL: URL,
+        configurationID: String,
+        currentFile: String?,
+        classPath: String?,
+        debugPort: Int?,
+        mavenContext _: MavenLaunchContext?
+    ) throws -> SharedLaunchPlan {
+        try launchPlan(
+            at: projectURL,
+            configurationID: configurationID,
+            currentFile: currentFile,
+            classPath: classPath,
+            debugPort: debugPort
+        )
+    }
+
     func saveEditorChanges(
         _: RunOptions,
         toolchain _: ProjectToolchainSelection,

--- a/macos/Sources/LitheCoreContracts/Execution/RunModels.swift
+++ b/macos/Sources/LitheCoreContracts/Execution/RunModels.swift
@@ -52,6 +52,7 @@ package struct RunConfigurationCapabilities: OptionSet, Hashable, Sendable {
     package static let javaVMArguments = Self(rawValue: 1 << 4)
     package static let mavenProfiles = Self(rawValue: 1 << 5)
     package static let jdwpDebug = Self(rawValue: 1 << 6)
+    package static let mavenSkipTests = Self(rawValue: 1 << 7)
 
     package static let process: Self = [.workingDirectory, .arguments, .environment]
 }
@@ -148,7 +149,10 @@ package enum RunConfigurationKind: Hashable, Identifiable, Sendable {
         case .currentFile, .javaMain:
             return [.workingDirectory, .arguments, .environment, .javaRuntime, .javaVMArguments, .jdwpDebug]
         case .mavenModule, .mavenFramework:
-            return [.workingDirectory, .arguments, .environment, .javaRuntime, .javaVMArguments, .mavenProfiles, .jdwpDebug]
+            return [
+                .workingDirectory, .arguments, .environment, .javaRuntime,
+                .javaVMArguments, .mavenProfiles, .mavenSkipTests, .jdwpDebug
+            ]
         case .process:
             return .process
         }

--- a/macos/Sources/LitheCoreContracts/Language/LanguageServerRuntimeContracts.swift
+++ b/macos/Sources/LitheCoreContracts/Language/LanguageServerRuntimeContracts.swift
@@ -194,6 +194,23 @@ package protocol LanguageServerRuntimeCore: Sendable {
         requestTimeout: TimeInterval,
         shutdownTimeout: TimeInterval
     ) -> Result<LanguageServerRuntimeStart, LanguageServerRuntimeFailure>
+    func startLanguageServer(
+        providerID: String,
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        rootURL: URL,
+        workingDirectoryURL: URL,
+        initializationOptions: ToolingJSONValue?,
+        runtimeExecutableURL: URL?,
+        jdtlsLaunchResources: JDTLSLaunchResources?,
+        cacheDirectoryURL: URL?,
+        workspaceFingerprint: String?,
+        mavenContext: MavenLaunchContext?,
+        initializeTimeout: TimeInterval,
+        requestTimeout: TimeInterval,
+        shutdownTimeout: TimeInterval
+    ) -> Result<LanguageServerRuntimeStart, LanguageServerRuntimeFailure>
 
     func stopLanguageServer(sessionID: String)
     func syncLanguageServerDocument(
@@ -234,6 +251,43 @@ package protocol LanguageServerRuntimeCore: Sendable {
     func cancelLanguageServerOperation(sessionID: String, operationID: String)
     func pollLanguageServerEvents(sessionID: String) -> [LanguageServerRuntimeEvent]
     func destroyLanguageServer(sessionID: String)
+}
+
+package extension LanguageServerRuntimeCore {
+    func startLanguageServer(
+        providerID: String,
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        rootURL: URL,
+        workingDirectoryURL: URL,
+        initializationOptions: ToolingJSONValue?,
+        runtimeExecutableURL: URL?,
+        jdtlsLaunchResources: JDTLSLaunchResources?,
+        cacheDirectoryURL: URL?,
+        workspaceFingerprint: String?,
+        mavenContext _: MavenLaunchContext?,
+        initializeTimeout: TimeInterval,
+        requestTimeout: TimeInterval,
+        shutdownTimeout: TimeInterval
+    ) -> Result<LanguageServerRuntimeStart, LanguageServerRuntimeFailure> {
+        startLanguageServer(
+            providerID: providerID,
+            executableURL: executableURL,
+            arguments: arguments,
+            environment: environment,
+            rootURL: rootURL,
+            workingDirectoryURL: workingDirectoryURL,
+            initializationOptions: initializationOptions,
+            runtimeExecutableURL: runtimeExecutableURL,
+            jdtlsLaunchResources: jdtlsLaunchResources,
+            cacheDirectoryURL: cacheDirectoryURL,
+            workspaceFingerprint: workspaceFingerprint,
+            initializeTimeout: initializeTimeout,
+            requestTimeout: requestTimeout,
+            shutdownTimeout: shutdownTimeout
+        )
+    }
 }
 
 package extension LanguageServerRuntimeCore {

--- a/macos/Sources/LitheCoreContracts/Language/LanguageToolingContracts.swift
+++ b/macos/Sources/LitheCoreContracts/Language/LanguageToolingContracts.swift
@@ -539,6 +539,11 @@ package protocol LanguageServerSession: AnyObject {
     ///   state directory so structural changes (add/remove module, edit root
     ///   pom.xml) never reuse a stale project model.
     func start(rootURL: URL, workspaceFingerprint: String?) throws
+    func start(
+        rootURL: URL,
+        workspaceFingerprint: String?,
+        mavenContext: MavenLaunchContext?
+    ) throws
     func synchronize(fileURL: URL, text: String, languageID: String) throws
     func notifyWorkspaceFilesChanged(_ changes: [LanguageServerWorkspaceFileChange]) throws
     func closeDocument(_ fileURL: URL)
@@ -603,6 +608,16 @@ package protocol LanguageServerSession: AnyObject {
         completion: @escaping (Result<[LanguageServerLocation], Error>) -> Void
     ) throws
     func stop()
+}
+
+package extension LanguageServerSession {
+    func start(
+        rootURL: URL,
+        workspaceFingerprint: String?,
+        mavenContext _: MavenLaunchContext?
+    ) throws {
+        try start(rootURL: rootURL, workspaceFingerprint: workspaceFingerprint)
+    }
 }
 
 package extension LanguageServerSession {

--- a/macos/Sources/LitheExecutionModule/Application/ExecutionFeatureModels.swift
+++ b/macos/Sources/LitheExecutionModule/Application/ExecutionFeatureModels.swift
@@ -18,19 +18,67 @@ package final class MavenFeatureModel: ObservableObject {
     }
 
     package var project: MavenProject? { service.project }
+    package var projectState: MavenProjectLoadState { service.projectState }
+    package var taskState: MavenTaskState { service.taskState }
     package var isLoadingProject: Bool { service.isLoadingProject }
     package var isRunning: Bool { service.isRunning }
     package var runningTitle: String? { service.runningTitle }
     package var output: String { service.output }
     package var issues: [MavenBuildIssue] { service.issues }
     package var lastExitCode: Int32? { service.lastExitCode }
+    package var availableProfiles: [MavenProfile] { service.availableProfiles }
+    package var selectedProfiles: Set<String> { service.selectedProfiles }
+    package var skipTests: Bool { service.skipTests }
+    package var settingsPath: String? { service.settingsPath }
+    package var mavenExecutablePath: String? { service.mavenExecutablePath }
+    package var javaHomePath: String? { service.javaHomePath }
+    package var configurationSaveError: String? { service.configurationSaveError }
+    package var isReloadRequired: Bool { service.isReloadRequired }
+    package var launchContext: MavenLaunchContext? { service.launchContext }
 
     package func loadProject(at workspaceURL: URL, files: [URL]) async {
         await service.loadProject(at: workspaceURL, files: files)
     }
 
-    package func run(phase: MavenLifecyclePhase, module: MavenModule?, profiles: Set<String>) {
-        service.run(phase: phase, module: module, profiles: profiles)
+    package func run(phase: MavenLifecyclePhase, module: MavenModule?) {
+        service.run(phase: phase, module: module)
+    }
+
+    package func runCustomGoal(_ value: String, module: MavenModule?) {
+        service.runCustomGoal(value, module: module)
+    }
+
+    package func setSelectedProfiles(_ profiles: Set<String>) {
+        service.setSelectedProfiles(profiles)
+    }
+
+    @discardableResult
+    package func addCustomProfile(_ value: String) -> Bool {
+        service.addCustomProfile(value)
+    }
+
+    package func restoreDefaultProfiles() {
+        service.restoreDefaultProfiles()
+    }
+
+    package func setSkipTests(_ enabled: Bool) {
+        service.setSkipTests(enabled)
+    }
+
+    package func updateLocalConfiguration(
+        settingsPath: String?,
+        mavenExecutablePath: String?,
+        javaHomePath: String?
+    ) {
+        service.updateLocalConfiguration(
+            settingsPath: settingsPath,
+            mavenExecutablePath: mavenExecutablePath,
+            javaHomePath: javaHomePath
+        )
+    }
+
+    package func acknowledgeReload() {
+        service.acknowledgeReload()
     }
 
     package func reset() { service.reset() }

--- a/macos/Sources/LitheExecutionModule/Module/ExecutionFeatureGraph.swift
+++ b/macos/Sources/LitheExecutionModule/Module/ExecutionFeatureGraph.swift
@@ -21,6 +21,9 @@ package final class ExecutionFeatureGraph: NSObject, ExecutionServiceGraph {
         mavenFeature = MavenFeatureModel(service: maven)
         runFeature = RunFeatureModel(service: run)
         projectDevelopment = ProjectDevelopmentFeatureModel(mavenFeature: mavenFeature, runFeature: runFeature)
+        run.configureMavenContextProvider { [weak maven] in
+            maven?.launchContext
+        }
     }
 
     package var isActive: Bool { maven.isRunning || run.isRunning || tests.isRunning }
@@ -33,7 +36,12 @@ package final class ExecutionFeatureGraph: NSObject, ExecutionServiceGraph {
     }
 
     package func configureModuleLeases(acquire: @escaping @MainActor (String) -> ModuleLease) {
-        maven.$isRunning.removeDuplicates().sink { [weak self] active in
+        maven.$taskState.map { state in
+            switch state {
+            case .running, .stopping: true
+            case .idle, .cancelled, .failed: false
+            }
+        }.removeDuplicates().sink { [weak self] active in
             guard let self else { return }
             if active, mavenLease == nil { mavenLease = acquire("Maven build is running") }
             if !active { mavenLease?.release(); mavenLease = nil }

--- a/macos/Sources/LitheExecutionModule/Services/MavenService.swift
+++ b/macos/Sources/LitheExecutionModule/Services/MavenService.swift
@@ -65,6 +65,7 @@ package final class MavenService: ObservableObject {
     private var activeOperationID: String?
     private var configurationRevision = 0
     private var configurationFingerprint: String?
+    private var fingerprintRevision = 0
     private let maximumOutputCharacters = 500_000
 
     package init(
@@ -138,6 +139,20 @@ package final class MavenService: ObservableObject {
             reactorPath = result.reactorPath
             project = result.project
             applyStoredConfiguration(result.stored, project: result.project)
+            if let context = launchContext {
+                let fingerprint = await Task.detached(priority: .utility) {
+                    try? mavenOperations.mavenLaunchPlan(
+                        at: rootURL,
+                        context: context,
+                        module: nil,
+                        goals: [MavenLifecyclePhase.validate.rawValue]
+                    ).configurationFingerprint
+                }.value
+                guard !Task.isCancelled, projectLoadID == loadID else { return }
+                configurationFingerprint = fingerprint
+            } else {
+                configurationFingerprint = nil
+            }
             projectState = .ready
             configurationSaveError = nil
             isReloadRequired = false
@@ -211,6 +226,7 @@ package final class MavenService: ObservableObject {
 
     package func acknowledgeReload() {
         isReloadRequired = false
+        refreshConfigurationFingerprint(establishBaseline: true)
     }
 
     package func stop() {
@@ -250,6 +266,7 @@ package final class MavenService: ObservableObject {
         mavenExecutablePath = nil
         javaHomePath = nil
         configurationFingerprint = nil
+        fingerprintRevision += 1
         configurationSaveError = nil
         isReloadRequired = false
     }
@@ -324,7 +341,7 @@ package final class MavenService: ObservableObject {
         }
         runningTitle = title
         taskState = .running
-        configurationFingerprint = plan.configurationFingerprint
+        recordConfigurationFingerprint(plan.configurationFingerprint)
         append(
             "$ " + executable.lastPathComponent + " "
                 + redactedMavenArgumentsForDisplay(plan.arguments).joined(separator: " ") + "\n\n"
@@ -414,9 +431,43 @@ package final class MavenService: ObservableObject {
     }
 
     private func configurationDidChange() {
-        isReloadRequired = true
+        isReloadRequired = configurationFingerprint != nil
         configurationSaveError = nil
         persistConfiguration()
+        refreshConfigurationFingerprint()
+    }
+
+    private func refreshConfigurationFingerprint(establishBaseline: Bool = false) {
+        guard let workspaceURL, let context = launchContext else { return }
+        fingerprintRevision += 1
+        let revision = fingerprintRevision
+        let operations = mavenOperations
+        Task { [weak self] in
+            let fingerprint = await Task.detached(priority: .utility) {
+                try? operations.mavenLaunchPlan(
+                    at: workspaceURL,
+                    context: context,
+                    module: nil,
+                    goals: [MavenLifecyclePhase.validate.rawValue]
+                ).configurationFingerprint
+            }.value
+            guard let self, self.fingerprintRevision == revision, let fingerprint else { return }
+            if establishBaseline || self.configurationFingerprint == nil {
+                self.configurationFingerprint = fingerprint
+                self.isReloadRequired = false
+            } else {
+                self.isReloadRequired = self.configurationFingerprint != fingerprint
+            }
+        }
+    }
+
+    private func recordConfigurationFingerprint(_ fingerprint: String) {
+        if let configurationFingerprint {
+            isReloadRequired = configurationFingerprint != fingerprint
+        } else {
+            configurationFingerprint = fingerprint
+            isReloadRequired = false
+        }
     }
 
     private func persistConfiguration() {

--- a/macos/Sources/LitheExecutionModule/Services/MavenService.swift
+++ b/macos/Sources/LitheExecutionModule/Services/MavenService.swift
@@ -5,35 +5,87 @@ import LitheCoreContracts
 @MainActor
 package final class MavenService: ObservableObject {
     @Published package private(set) var project: MavenProject?
-    @Published package private(set) var isLoadingProject = false
-    @Published package private(set) var isRunning = false
+    @Published package private(set) var projectState: MavenProjectLoadState = .idle
+    @Published package private(set) var taskState: MavenTaskState = .idle
     @Published package private(set) var runningTitle: String?
     @Published package private(set) var output = ""
     @Published package private(set) var issues: [MavenBuildIssue] = []
     @Published package private(set) var lastExitCode: Int32?
+    @Published package private(set) var selectedProfiles: Set<String> = []
+    @Published package private(set) var customProfiles: [String] = []
+    @Published package private(set) var skipTests = false
+    @Published package private(set) var settingsPath: String?
+    @Published package private(set) var mavenExecutablePath: String?
+    @Published package private(set) var javaHomePath: String?
+    @Published package private(set) var configurationSaveError: String?
+    @Published package private(set) var isReloadRequired = false
+
+    package var isLoadingProject: Bool {
+        if case .loading = projectState { return true }
+        return false
+    }
+
+    package var isRunning: Bool {
+        switch taskState {
+        case .running, .stopping: true
+        case .idle, .cancelled, .failed: false
+        }
+    }
+
+    package var availableProfiles: [MavenProfile] {
+        var seen = Set<String>()
+        let discovered = project?.profiles.filter { seen.insert($0.id).inserted } ?? []
+        let custom = customProfiles.compactMap { id -> MavenProfile? in
+            guard seen.insert(id).inserted else { return nil }
+            return MavenProfile(id: id, isActiveByDefault: false)
+        }
+        return discovered + custom
+    }
+
+    package var launchContext: MavenLaunchContext? {
+        guard let reactorPath else { return nil }
+        return MavenLaunchContext(
+            reactorPath: reactorPath,
+            profiles: selectedProfiles.sorted(),
+            settingsPath: settingsPath,
+            skipTests: skipTests,
+            mavenExecutablePath: mavenExecutablePath,
+            javaHomePath: javaHomePath
+        )
+    }
 
     private let process: any StreamingProcess
     private let mavenOperations: any MavenProjectOperations
-    private var projectLoadID = UUID()
-    private let maximumOutputCharacters = 500_000
     private let runtimeService: any MavenRuntimePort
+    private let configurationWriter: MavenConfigurationWriter
+    private var workspaceURL: URL?
+    private var reactorPath: String?
+    private var projectLoadID = UUID()
+    private var launchPlanID = UUID()
     private var activeOperationID: String?
+    private var configurationRevision = 0
+    private var configurationFingerprint: String?
+    private let maximumOutputCharacters = 500_000
 
     package init(
         runtimeService: any MavenRuntimePort,
         process: any StreamingProcess,
-        mavenOperations: any MavenProjectOperations
+        mavenOperations: any MavenProjectOperations,
+        configurationStore: (any MavenConfigurationStoring)? = nil
     ) {
         self.runtimeService = runtimeService
         self.process = process
         self.mavenOperations = mavenOperations
+        configurationWriter = MavenConfigurationWriter(store: configurationStore)
         process.onOutput = { [weak self] chunk in
             Task { @MainActor [weak self] in
+                guard self?.activeOperationID != nil else { return }
                 self?.append(chunk)
             }
         }
         process.onTermination = { [weak self] exitCode in
             Task { @MainActor [weak self] in
+                guard self?.activeOperationID != nil else { return }
                 self?.finishProcess(exitCode: exitCode)
             }
         }
@@ -47,112 +99,268 @@ package final class MavenService: ObservableObject {
     package func loadProject(at workspaceURL: URL, files: [URL]) async {
         let loadID = UUID()
         projectLoadID = loadID
-        isLoadingProject = true
+        projectState = .loading
         let rootURL = workspaceURL.standardizedFileURL
         let mavenOperations = mavenOperations
-        let scannedProject = await Task.detached(priority: .utility) {
-            mavenOperations.scanMavenProject(at: rootURL, files: files)
+        let configurationWriter = configurationWriter
+        let result = await Task.detached(priority: .utility) {
+            do {
+                let project = try mavenOperations.scanMavenProject(at: rootURL, files: files)
+                let reactorPath = project.map { Self.relativePath(from: rootURL, to: $0.rootURL) }
+                let stored: MavenStoredConfiguration?
+                if let reactorPath {
+                    stored = try await configurationWriter.load(
+                        workspaceURL: rootURL,
+                        reactorPath: reactorPath
+                    )
+                } else {
+                    stored = nil
+                }
+                return MavenProjectLoadResult(
+                    project: project,
+                    reactorPath: reactorPath,
+                    stored: stored,
+                    errorMessage: nil
+                )
+            } catch {
+                return MavenProjectLoadResult(
+                    project: nil,
+                    reactorPath: nil,
+                    stored: nil,
+                    errorMessage: error.localizedDescription
+                )
+            }
         }.value
         guard !Task.isCancelled, projectLoadID == loadID else { return }
-        project = scannedProject
-        isLoadingProject = false
+
+        guard let errorMessage = result.errorMessage else {
+            self.workspaceURL = rootURL
+            reactorPath = result.reactorPath
+            project = result.project
+            applyStoredConfiguration(result.stored, project: result.project)
+            projectState = .ready
+            configurationSaveError = nil
+            isReloadRequired = false
+            return
+        }
+        project = nil
+        self.workspaceURL = nil
+        reactorPath = nil
+        projectState = .failed(errorMessage)
     }
 
-    package func run(
-        phase: MavenLifecyclePhase,
-        module: MavenModule?,
-        profiles: Set<String>
-    ) {
-        guard project != nil else { return }
-        stop()
-        resetOutput()
-        var arguments = baseArguments(profiles: profiles)
-        if let module {
-            arguments += ["-pl", module.relativePath, "-am"]
+    package func run(phase: MavenLifecyclePhase, module: MavenModule?) {
+        run(goals: [phase.rawValue], module: module, title: taskTitle(name: phase.title, module: module))
+    }
+
+    package func runCustomGoal(_ value: String, module: MavenModule?) {
+        let goals = value.split(whereSeparator: \.isWhitespace).map(String.init)
+        run(goals: goals, module: module, title: taskTitle(name: value, module: module))
+    }
+
+    package func setSelectedProfiles(_ profiles: Set<String>) {
+        let knownProfiles = Set(availableProfiles.map(\.id))
+        let normalized = Set(profiles.filter { knownProfiles.contains($0) })
+        guard normalized != selectedProfiles else { return }
+        selectedProfiles = normalized
+        configurationDidChange()
+    }
+
+    @discardableResult
+    package func addCustomProfile(_ value: String) -> Bool {
+        let profile = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isValidProfile(profile) else { return false }
+        if !customProfiles.contains(profile), project?.profiles.contains(where: { $0.id == profile }) != true {
+            customProfiles.append(profile)
+            customProfiles.sort()
         }
-        arguments.append(phase.rawValue)
-        startProcess(arguments: arguments, title: taskTitle(phase: phase, module: module))
+        selectedProfiles.insert(profile)
+        configurationDidChange()
+        return true
+    }
+
+    package func restoreDefaultProfiles() {
+        let defaults = Set(project?.profiles.filter(\.isActiveByDefault).map(\.id) ?? [])
+        guard selectedProfiles != defaults else { return }
+        selectedProfiles = defaults
+        configurationDidChange()
+    }
+
+    package func setSkipTests(_ enabled: Bool) {
+        guard skipTests != enabled else { return }
+        skipTests = enabled
+        configurationDidChange()
+    }
+
+    package func updateLocalConfiguration(
+        settingsPath: String?,
+        mavenExecutablePath: String?,
+        javaHomePath: String?
+    ) {
+        let settings = normalizedLocalPath(settingsPath)
+        let executable = normalizedLocalPath(mavenExecutablePath)
+        let javaHome = normalizedLocalPath(javaHomePath)
+        guard settings != self.settingsPath
+                || executable != self.mavenExecutablePath
+                || javaHome != self.javaHomePath else { return }
+        self.settingsPath = settings
+        self.mavenExecutablePath = executable
+        self.javaHomePath = javaHome
+        configurationDidChange()
+    }
+
+    package func acknowledgeReload() {
+        isReloadRequired = false
     }
 
     package func stop() {
-        process.stop()
-        isRunning = false
-        runningTitle = nil
+        launchPlanID = UUID()
+        guard isRunning else { return }
+        taskState = .stopping
+        if activeOperationID != nil {
+            process.stop()
+        }
         activeOperationID = nil
+        runningTitle = nil
+        lastExitCode = nil
+        taskState = .cancelled
+        if !output.isEmpty, !output.hasSuffix("\n") {
+            append("\n")
+        }
+        append("Maven task cancelled.\n")
     }
 
     package func reset() {
         stop()
         projectLoadID = UUID()
+        launchPlanID = UUID()
         project = nil
-        isLoadingProject = false
+        workspaceURL = nil
+        reactorPath = nil
+        projectState = .idle
+        taskState = .idle
+        runningTitle = nil
         output = ""
         issues = []
         lastExitCode = nil
+        selectedProfiles = []
+        customProfiles = []
+        skipTests = false
+        settingsPath = nil
+        mavenExecutablePath = nil
+        javaHomePath = nil
+        configurationFingerprint = nil
+        configurationSaveError = nil
+        isReloadRequired = false
     }
 
     package func clearOutput() {
         output = ""
         issues = []
         lastExitCode = nil
-    }
-
-    // MARK: - 进程执行
-
-    private func baseArguments(profiles: Set<String>) -> [String] {
-        var arguments = ["-B", "-ntp"]
-        if !profiles.isEmpty {
-            arguments += ["-P", profiles.sorted().joined(separator: ",")]
+        if taskState == .cancelled {
+            taskState = .idle
         }
-        return arguments
     }
 
-    private func resetOutput() {
-        output = ""
-        issues = []
-        lastExitCode = nil
+    private func run(goals: [String], module: MavenModule?, title: String) {
+        guard let project, let workspaceURL, let reactorPath else { return }
+        stop()
+        resetOutput()
+        let planID = UUID()
+        launchPlanID = planID
+        runningTitle = title
+        taskState = .running
+        let context = MavenLaunchContext(
+            reactorPath: reactorPath,
+            profiles: selectedProfiles.sorted(),
+            settingsPath: settingsPath,
+            skipTests: skipTests,
+            mavenExecutablePath: mavenExecutablePath,
+            javaHomePath: javaHomePath
+        )
+        let operations = mavenOperations
+        Task { [weak self] in
+            let result = await Task.detached(priority: .userInitiated) {
+                do {
+                    return MavenPlanResult(
+                        plan: try operations.mavenLaunchPlan(
+                            at: workspaceURL,
+                            context: context,
+                            module: module?.relativePath,
+                            goals: goals
+                        ),
+                        errorMessage: nil
+                    )
+                } catch {
+                    return MavenPlanResult(
+                        plan: nil,
+                        errorMessage: error.localizedDescription
+                    )
+                }
+            }.value
+            guard let self, self.launchPlanID == planID else { return }
+            if let plan = result.plan {
+                self.startProcess(plan: plan, project: project, context: context, title: title)
+            } else {
+                self.failTask(message: result.errorMessage ?? "Unable to create the Maven launch plan.")
+            }
+        }
     }
 
-    private func startProcess(arguments: [String], title: String) {
-        guard let project else { return }
-        guard let executable = runtimeService.mavenExecutable(for: project) else {
-            output = "No Maven executable was found. Edit the Maven service configuration.\n"
-            lastExitCode = 1
+    private func startProcess(
+        plan: MavenLaunchPlan,
+        project: MavenProject,
+        context: MavenLaunchContext,
+        title: String
+    ) {
+        guard let workspaceURL else { return }
+        guard let executable = runtimeService.mavenExecutable(
+            for: project,
+            overridePath: context.mavenExecutablePath
+        ) else {
+            failTask(message: "No Maven executable was found. Choose Maven Home or an executable in Maven Settings.")
             return
         }
-        isRunning = true
         runningTitle = title
-        append("$ " + executable.lastPathComponent + " " + arguments.joined(separator: " ") + "\n\n")
+        taskState = .running
+        configurationFingerprint = plan.configurationFingerprint
+        append(
+            "$ " + executable.lastPathComponent + " "
+                + redactedMavenArgumentsForDisplay(plan.arguments).joined(separator: " ") + "\n\n"
+        )
 
         let operationID = UUID().uuidString
         activeOperationID = operationID
+        let workingDirectory = plan.workingDirectory == "."
+            ? workspaceURL
+            : workspaceURL.appendingPathComponent(plan.workingDirectory, isDirectory: true)
         do {
             try process.start(ProcessRequest(
                 operationID: operationID,
                 executablePath: executable.path,
-                arguments: arguments,
-                workingDirectory: project.rootURL.path,
-                environment: runtimeService.mavenProcessEnvironment()
+                arguments: plan.arguments,
+                workingDirectory: workingDirectory.standardizedFileURL.path,
+                environment: runtimeService.mavenProcessEnvironment(javaHomePath: context.javaHomePath)
             ))
         } catch {
-            append("Unable to start Maven: " + error.localizedDescription + "\n")
-            isRunning = false
-            runningTitle = nil
-            lastExitCode = 1
-            issues = [MavenBuildIssue(
-                id: "start-error",
-                fileURL: nil,
-                line: nil,
-                column: nil,
-                severity: .error,
-                message: error.localizedDescription
-            )]
+            guard activeOperationID == operationID else { return }
+            activeOperationID = nil
+            failTask(message: "Unable to start Maven: " + error.localizedDescription)
         }
     }
 
     private func finishProcess(exitCode: Int32) {
         guard let project else { return }
-        isRunning = false
+        if taskState == .stopping {
+            activeOperationID = nil
+            runningTitle = nil
+            lastExitCode = nil
+            taskState = .cancelled
+            append("Maven task cancelled.\n")
+            return
+        }
+        taskState = exitCode == 0 ? .idle : .failed("Maven exited with code \(exitCode).")
         runningTitle = nil
         lastExitCode = exitCode
         issues = mavenOperations.mavenDiagnostics(output: output, projectRoot: project.rootURL)
@@ -163,18 +371,87 @@ package final class MavenService: ObservableObject {
         guard event.operationID == activeOperationID else { return }
         switch event.state {
         case .starting, .running:
-            isRunning = true
+            taskState = .running
         case .stopping:
-            isRunning = false
+            taskState = .stopping
         case .failed:
-            isRunning = false
-            runningTitle = nil
-            if let message = event.message, !message.isEmpty {
-                append("Unable to run Maven: " + message + "\n")
-            }
+            activeOperationID = nil
+            failTask(message: event.message ?? "Unable to run Maven.")
         case .finished:
-            break
+            if let exitCode = event.exitCode {
+                finishProcess(exitCode: exitCode)
+            }
         }
+    }
+
+    private func failTask(message: String) {
+        append(message + (message.hasSuffix("\n") ? "" : "\n"))
+        taskState = .failed(message)
+        runningTitle = nil
+        lastExitCode = 1
+        issues = [MavenBuildIssue(
+            id: "maven-error-" + UUID().uuidString,
+            fileURL: nil,
+            line: nil,
+            column: nil,
+            severity: .error,
+            message: message
+        )]
+    }
+
+    private func applyStoredConfiguration(
+        _ stored: MavenStoredConfiguration?,
+        project: MavenProject?
+    ) {
+        let defaults = project?.profiles.filter(\.isActiveByDefault).map(\.id) ?? []
+        let portable = stored?.portable
+        selectedProfiles = Set(portable?.selectedProfiles ?? defaults)
+        customProfiles = normalizedProfiles(portable?.customProfiles ?? [])
+        skipTests = portable?.skipTests ?? false
+        settingsPath = normalizedLocalPath(stored?.local?.settingsPath)
+        mavenExecutablePath = normalizedLocalPath(stored?.local?.mavenExecutablePath)
+        javaHomePath = normalizedLocalPath(stored?.local?.javaHomePath)
+    }
+
+    private func configurationDidChange() {
+        isReloadRequired = true
+        configurationSaveError = nil
+        persistConfiguration()
+    }
+
+    private func persistConfiguration() {
+        guard let workspaceURL, let reactorPath else { return }
+        configurationRevision += 1
+        let revision = configurationRevision
+        let stored = MavenStoredConfiguration(
+            portable: MavenPortableConfiguration(
+                selectedProfiles: selectedProfiles.sorted(),
+                customProfiles: normalizedProfiles(customProfiles),
+                skipTests: skipTests
+            ),
+            local: MavenLocalConfiguration(
+                settingsPath: settingsPath,
+                mavenExecutablePath: mavenExecutablePath,
+                javaHomePath: javaHomePath
+            )
+        )
+        let writer = configurationWriter
+        Task { [weak self] in
+            let errorMessage = await writer.save(
+                revision: revision,
+                configuration: stored,
+                workspaceURL: workspaceURL,
+                reactorPath: reactorPath
+            )
+            guard let self, self.configurationRevision == revision else { return }
+            self.configurationSaveError = errorMessage
+        }
+    }
+
+    private func resetOutput() {
+        output = ""
+        issues = []
+        lastExitCode = nil
     }
 
     private func append(_ value: String) {
@@ -184,9 +461,86 @@ package final class MavenService: ObservableObject {
         }
     }
 
-    private func taskTitle(phase: MavenLifecyclePhase, module: MavenModule?) -> String {
+    private func taskTitle(name: String, module: MavenModule?) -> String {
         let target = module?.displayName ?? project?.displayName ?? "Project"
-        return phase.title + " · " + target
+        return name + " · " + target
     }
 
+    private func isValidProfile(_ value: String) -> Bool {
+        !value.isEmpty
+            && !value.contains(",")
+            && !value.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+    }
+
+    private func normalizedProfiles(_ values: [String]) -> [String] {
+        Array(Set(values.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter(isValidProfile)))
+            .sorted()
+    }
+
+    private func normalizedLocalPath(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : (trimmed as NSString).expandingTildeInPath
+    }
+
+    nonisolated private static func relativePath(from rootURL: URL, to childURL: URL) -> String {
+        let root = rootURL.standardizedFileURL.path
+        let child = childURL.standardizedFileURL.path
+        if root == child { return "." }
+        let prefix = root.hasSuffix("/") ? root : root + "/"
+        guard child.hasPrefix(prefix) else { return "." }
+        return String(child.dropFirst(prefix.count))
+    }
+}
+
+private struct MavenProjectLoadResult: Sendable {
+    let project: MavenProject?
+    let reactorPath: String?
+    let stored: MavenStoredConfiguration?
+    let errorMessage: String?
+}
+
+private struct MavenPlanResult: Sendable {
+    let plan: MavenLaunchPlan?
+    let errorMessage: String?
+}
+
+private actor MavenConfigurationWriter {
+    private let store: (any MavenConfigurationStoring)?
+    private var latestRevision = 0
+
+    init(store: (any MavenConfigurationStoring)?) {
+        self.store = store
+    }
+
+    func load(
+        workspaceURL: URL,
+        reactorPath: String
+    ) throws -> MavenStoredConfiguration {
+        try store?.loadMavenConfiguration(
+            workspaceURL: workspaceURL,
+            reactorPath: reactorPath
+        ) ?? MavenStoredConfiguration(portable: nil, local: nil)
+    }
+
+    func save(
+        revision: Int,
+        configuration: MavenStoredConfiguration,
+        workspaceURL: URL,
+        reactorPath: String
+    ) -> String? {
+        guard revision > latestRevision else { return nil }
+        latestRevision = revision
+        do {
+            try store?.saveMavenConfiguration(
+                configuration,
+                workspaceURL: workspaceURL,
+                reactorPath: reactorPath
+            )
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
 }

--- a/macos/Sources/LitheExecutionModule/Services/RunService.swift
+++ b/macos/Sources/LitheExecutionModule/Services/RunService.swift
@@ -56,6 +56,7 @@ package final class RunService: ObservableObject {
     private let maximumOutputCharacters = 500_000
     private let runtime: any RunRuntimePort
     private let executableResolver: any RunExecutableResolving
+    private var mavenContextProvider: @MainActor () -> MavenLaunchContext? = { nil }
 
     package init(
         runtime: any RunRuntimePort,
@@ -104,6 +105,12 @@ package final class RunService: ObservableObject {
 
     package var lastRunFileURL: URL? { lastCurrentFileURL }
     package var lastConfiguration: RunConfiguration? { lastRunConfiguration }
+
+    package func configureMavenContextProvider(
+        _ provider: @escaping @MainActor () -> MavenLaunchContext?
+    ) {
+        mavenContextProvider = provider
+    }
 
     @discardableResult
     package func registerLanguageRunExtension(
@@ -406,7 +413,8 @@ package final class RunService: ObservableObject {
         lastExitCode = nil
         lastRunConfiguration = configuration
         lastCurrentFileURL = currentFileURL
-        let options = self.options(for: configuration)
+        let mavenContext = configuration.kind.isMavenBacked ? mavenContextProvider() : nil
+        let options = effectiveOptions(for: configuration, mavenContext: mavenContext)
         let usesGenericCurrentFile = configuration.kind == .currentFile
             && isGenericCurrentFile(currentFileURL)
         if !usesGenericCurrentFile {
@@ -469,7 +477,8 @@ package final class RunService: ObservableObject {
                     configurationID: configuration.id,
                     currentFile: currentFile,
                     classPath: planClassPath,
-                    debugPort: nil
+                    debugPort: nil,
+                    mavenContext: mavenContext
                 )
                 extensionSession = languageRunExtension(
                     providerID: configuration.kind.providerID
@@ -491,7 +500,13 @@ package final class RunService: ObservableObject {
 
         runningTitle = configuration.name
         isRunning = true
-        append("$ " + resolved.executableURL.lastPathComponent + " " + arguments.joined(separator: " ") + "\n\n")
+        let displayedArguments = configuration.kind.isMavenBacked
+            ? redactedMavenArgumentsForDisplay(arguments)
+            : arguments
+        append(
+            "$ " + resolved.executableURL.lastPathComponent + " "
+                + displayedArguments.joined(separator: " ") + "\n\n"
+        )
 
         let operationID = UUID().uuidString
         activeOperationID = operationID
@@ -903,7 +918,8 @@ package final class RunService: ObservableObject {
             ))
             return
         }
-        let options = self.options(for: configuration)
+        let mavenContext = configuration.kind.isMavenBacked ? mavenContextProvider() : nil
+        let options = effectiveOptions(for: configuration, mavenContext: mavenContext)
         let configuredJavaHome = (options.mavenJavaHomePath.isEmpty
             ? options.javaHomePath
             : options.mavenJavaHomePath).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -926,7 +942,8 @@ package final class RunService: ObservableObject {
                 configurationID: configuration.id,
                 currentFile: nil,
                 classPath: nil,
-                debugPort: nil
+                debugPort: nil,
+                mavenContext: mavenContext
             )
         } catch {
             moduleSessions.append(RunSession(
@@ -963,7 +980,10 @@ package final class RunService: ObservableObject {
             id: configuration.id,
             configurationID: configuration.id,
             title: configuration.name,
-            output: "$ " + resolved.executableURL.lastPathComponent + " " + arguments.joined(separator: " ") + "\n\n",
+            output: "$ " + resolved.executableURL.lastPathComponent + " "
+                + (configuration.kind.isMavenBacked
+                    ? redactedMavenArgumentsForDisplay(arguments)
+                    : arguments).joined(separator: " ") + "\n\n",
             isRunning: true,
             exitCode: nil
         )
@@ -1216,6 +1236,21 @@ package final class RunService: ObservableObject {
         let filePath = fileURL.standardizedFileURL.path
         let directoryPath = directory.standardizedFileURL.path
         return filePath.hasPrefix(directoryPath + "/")
+    }
+
+    private func effectiveOptions(
+        for configuration: RunConfiguration,
+        mavenContext: MavenLaunchContext?
+    ) -> RunOptions {
+        var options = self.options(for: configuration)
+        guard let mavenContext else { return options }
+        if options.mavenExecutablePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            options.mavenExecutablePath = mavenContext.mavenExecutablePath ?? ""
+        }
+        if options.mavenJavaHomePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            options.mavenJavaHomePath = mavenContext.javaHomePath ?? ""
+        }
+        return options
     }
 
     private func resolvedWorkingDirectory(_ path: String, fallback: URL) -> URL {

--- a/macos/Sources/LitheLanguageIntelligenceModule/Runtime/LanguageServerSession.swift
+++ b/macos/Sources/LitheLanguageIntelligenceModule/Runtime/LanguageServerSession.swift
@@ -91,6 +91,18 @@ package final class LanguageServerRuntimeSession: LanguageServerSession {
     }
 
     package func start(rootURL: URL, workspaceFingerprint: String?) throws {
+        try start(
+            rootURL: rootURL,
+            workspaceFingerprint: workspaceFingerprint,
+            mavenContext: nil
+        )
+    }
+
+    package func start(
+        rootURL: URL,
+        workspaceFingerprint: String?,
+        mavenContext: MavenLaunchContext?
+    ) throws {
         guard sessionID == nil else { return }
         let normalizedRoot = rootURL.standardizedFileURL
         transition(to: .startingProcess)
@@ -112,6 +124,7 @@ package final class LanguageServerRuntimeSession: LanguageServerSession {
             jdtlsLaunchResources: jdtlsLaunchResources,
             cacheDirectoryURL: cacheDirectoryURL,
             workspaceFingerprint: workspaceFingerprint,
+            mavenContext: mavenContext,
             initializeTimeout: initializeTimeout,
             requestTimeout: requestTimeout,
             shutdownTimeout: shutdownTimeout

--- a/macos/Sources/LitheLanguageIntelligenceModule/Services/LanguageToolingSessionManager.swift
+++ b/macos/Sources/LitheLanguageIntelligenceModule/Services/LanguageToolingSessionManager.swift
@@ -54,6 +54,7 @@ package final class LanguageToolingSessionManager: ObservableObject {
     private let workspaceFingerprintProvider: (LanguageProviderDescriptor, URL) throws -> String?
     private let workspaceStateResetter: ((LanguageProviderDescriptor, URL, String?) throws -> Void)?
     private let workspaceStateCleaner: ((LanguageProviderDescriptor, URL, String?) throws -> Int)?
+    private var mavenContextProvider: (LanguageProviderDescriptor, URL) -> MavenLaunchContext? = { _, _ in nil }
 
     package init(
         catalog: LanguageProviderCatalog = .compatibilityFallback,
@@ -85,6 +86,13 @@ package final class LanguageToolingSessionManager: ObservableObject {
             return providerID
         })
     }
+
+    package func configureMavenContextProvider(
+        _ provider: @escaping (LanguageProviderDescriptor, URL) -> MavenLaunchContext?
+    ) {
+        mavenContextProvider = provider
+    }
+
     package func updateCatalog(_ catalog: LanguageProviderCatalog) {
         let previousDescriptors = Dictionary(
             uniqueKeysWithValues: self.catalog.descriptors.map { ($0.id, $0) }
@@ -832,7 +840,8 @@ package final class LanguageToolingSessionManager: ObservableObject {
         do {
             try created.start(
                 rootURL: rootURL,
-                workspaceFingerprint: workspaceFingerprint
+                workspaceFingerprint: workspaceFingerprint,
+                mavenContext: mavenContextProvider(descriptor, rootURL)
             )
         } catch {
             if languageServerSessionIdentities[descriptor.id] == sessionIdentity {

--- a/macos/Tests/LitheExecutionModuleTests/ExecutionModuleTests.swift
+++ b/macos/Tests/LitheExecutionModuleTests/ExecutionModuleTests.swift
@@ -194,6 +194,125 @@ struct ExecutionModuleTests {
         #expect(service.errorMessage == "go testing extension is not active.")
     }
 
+    @Test
+    func mavenServiceExecutesTheSharedLaunchPlanWithLocalRuntimeOverrides() async throws {
+        let workspace = URL(fileURLWithPath: "/workspace", isDirectory: true)
+        let reactor = workspace.appendingPathComponent("projects/demo", isDirectory: true)
+        let module = MavenModule(
+            relativePath: "service-api",
+            url: reactor.appendingPathComponent("service-api", isDirectory: true),
+            groupID: "dev.lithe",
+            artifactID: "service-api",
+            version: "1.0",
+            packaging: "jar",
+            modules: []
+        )
+        let project = MavenProject(
+            rootURL: reactor,
+            pomURL: reactor.appendingPathComponent("pom.xml"),
+            groupID: "dev.lithe",
+            artifactID: "demo",
+            version: "1.0",
+            packaging: "pom",
+            modules: [module],
+            profiles: [MavenProfile(id: "dev", isActiveByDefault: false)],
+            hasWrapper: false
+        )
+        let plan = MavenLaunchPlan(
+            version: 1,
+            toolchain: "project-maven",
+            arguments: ["core-owned-argument", "-s", "/local/settings.xml", "verify"],
+            workingDirectory: "projects/demo",
+            configurationFingerprint: "sha256:test"
+        )
+        let operations = RecordingMavenOperations(project: project, plan: plan)
+        let process = MavenRecordingProcess()
+        let runtime = MavenRecordingRuntime()
+        let store = RecordingMavenConfigurationStore(configuration: MavenStoredConfiguration(
+            portable: MavenPortableConfiguration(
+                selectedProfiles: ["dev"],
+                customProfiles: [],
+                skipTests: true
+            ),
+            local: MavenLocalConfiguration(
+                settingsPath: "/local/settings.xml",
+                mavenExecutablePath: "/local/apache-maven",
+                javaHomePath: "/local/jdk"
+            )
+        ))
+        let service = MavenService(
+            runtimeService: runtime,
+            process: process,
+            mavenOperations: operations,
+            configurationStore: store
+        )
+
+        await service.loadProject(at: workspace, files: [project.pomURL])
+        service.runCustomGoal(
+            "help:evaluate -Dexpression=fixture.config -q -DforceStdout",
+            module: module
+        )
+        let request = try #require(await process.nextStart(timeout: .seconds(1)))
+
+        #expect(request.arguments == plan.arguments)
+        #expect(request.workingDirectory == reactor.path)
+        #expect(request.environment?["TEST_JAVA_HOME"] == "/local/jdk")
+        #expect(runtime.lastMavenOverride == "/local/apache-maven")
+        #expect(operations.lastContext?.reactorPath == "projects/demo")
+        #expect(operations.lastContext?.profiles == ["dev"])
+        #expect(operations.lastContext?.settingsPath == "/local/settings.xml")
+        #expect(operations.lastContext?.skipTests == true)
+        #expect(operations.lastModule == "service-api")
+        #expect(operations.lastGoals == [
+            "help:evaluate",
+            "-Dexpression=fixture.config",
+            "-q",
+            "-DforceStdout"
+        ])
+        #expect(service.output.contains("-s <settings.xml>"))
+        #expect(!service.output.contains("/local/settings.xml"))
+    }
+
+    @Test
+    func mavenServiceReportsCancellationWithoutInventingAnExitCode() async throws {
+        let workspace = URL(fileURLWithPath: "/workspace", isDirectory: true)
+        let project = MavenProject(
+            rootURL: workspace,
+            pomURL: workspace.appendingPathComponent("pom.xml"),
+            groupID: "dev.lithe",
+            artifactID: "demo",
+            version: "1.0",
+            packaging: "jar",
+            modules: [],
+            profiles: [],
+            hasWrapper: false
+        )
+        let plan = MavenLaunchPlan(
+            version: 1,
+            toolchain: "project-maven",
+            arguments: ["-B", "-ntp", "validate"],
+            workingDirectory: ".",
+            configurationFingerprint: "sha256:test"
+        )
+        let process = MavenRecordingProcess()
+        let service = MavenService(
+            runtimeService: MavenRecordingRuntime(),
+            process: process,
+            mavenOperations: RecordingMavenOperations(project: project, plan: plan)
+        )
+
+        await service.loadProject(at: workspace, files: [project.pomURL])
+        service.run(phase: .validate, module: nil)
+        _ = try #require(await process.nextStart(timeout: .seconds(1)))
+        service.stop()
+
+        #expect(service.taskState == .cancelled)
+        #expect(service.runningTitle == nil)
+        #expect(service.lastExitCode == nil)
+        #expect(service.output.hasSuffix("Maven task cancelled.\n"))
+        #expect(!process.isRunning)
+    }
+
     private func factory(recorder: Recorder) -> ModuleFactory {
         ModuleFactory(manifest: ExecutionModule.moduleManifest, contributions: ExecutionModule.moduleContributions) {
             recorder.factoryCalls += 1
@@ -251,8 +370,8 @@ private func makeTestGraph() -> ExecutionFeatureGraph {
 
 @MainActor
 private final class TestRuntime: MavenRuntimePort, RunRuntimePort {
-    func mavenExecutable(for project: MavenProject) -> URL? { nil }
-    func mavenProcessEnvironment() -> [String: String] { [:] }
+    func mavenExecutable(for project: MavenProject, overridePath: String?) -> URL? { nil }
+    func mavenProcessEnvironment(javaHomePath: String?) -> [String: String] { [:] }
     func setActiveServiceJavaHomePath(_ path: String) {}
     func javaHomeURL(overridePath: String?) -> URL? { nil }
     func mavenJavaHomeURL(overridePath: String?) -> URL? { nil }
@@ -279,8 +398,148 @@ private final class TestStreamingProcess: StreamingProcess, @unchecked Sendable 
 }
 
 private struct TestMavenOperations: MavenProjectOperations {
-    func scanMavenProject(at rootURL: URL, files: [URL]) -> MavenProject? { nil }
+    func scanMavenProject(at rootURL: URL, files: [URL]) throws -> MavenProject? { nil }
+    func mavenLaunchPlan(
+        at rootURL: URL,
+        context: MavenLaunchContext,
+        module: String?,
+        goals: [String]
+    ) throws -> MavenLaunchPlan {
+        MavenLaunchPlan(
+            version: 1,
+            toolchain: "project-maven",
+            arguments: goals,
+            workingDirectory: ".",
+            configurationFingerprint: "test"
+        )
+    }
     func mavenDiagnostics(output: String, projectRoot: URL) -> [MavenBuildIssue] { [] }
+}
+
+private final class RecordingMavenOperations: MavenProjectOperations, @unchecked Sendable {
+    private let lock = NSLock()
+    private let project: MavenProject
+    private let plan: MavenLaunchPlan
+    private var recordedContext: MavenLaunchContext?
+    private var recordedModule: String?
+    private var recordedGoals: [String] = []
+
+    init(project: MavenProject, plan: MavenLaunchPlan) {
+        self.project = project
+        self.plan = plan
+    }
+
+    var lastContext: MavenLaunchContext? {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedContext
+    }
+
+    var lastModule: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedModule
+    }
+
+    var lastGoals: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedGoals
+    }
+
+    func scanMavenProject(at rootURL: URL, files: [URL]) throws -> MavenProject? {
+        project
+    }
+
+    func mavenLaunchPlan(
+        at rootURL: URL,
+        context: MavenLaunchContext,
+        module: String?,
+        goals: [String]
+    ) throws -> MavenLaunchPlan {
+        lock.lock()
+        recordedContext = context
+        recordedModule = module
+        recordedGoals = goals
+        lock.unlock()
+        return plan
+    }
+
+    func mavenDiagnostics(output: String, projectRoot: URL) -> [MavenBuildIssue] { [] }
+}
+
+private final class RecordingMavenConfigurationStore: MavenConfigurationStoring, @unchecked Sendable {
+    private let configuration: MavenStoredConfiguration
+
+    init(configuration: MavenStoredConfiguration) {
+        self.configuration = configuration
+    }
+
+    func loadMavenConfiguration(
+        workspaceURL: URL,
+        reactorPath: String
+    ) throws -> MavenStoredConfiguration {
+        configuration
+    }
+
+    func saveMavenConfiguration(
+        _ configuration: MavenStoredConfiguration,
+        workspaceURL: URL,
+        reactorPath: String
+    ) throws {}
+}
+
+@MainActor
+private final class MavenRecordingRuntime: MavenRuntimePort {
+    private(set) var lastMavenOverride: String?
+
+    func mavenExecutable(for project: MavenProject, overridePath: String?) -> URL? {
+        lastMavenOverride = overridePath
+        return URL(fileURLWithPath: "/test/bin/mvn")
+    }
+
+    func mavenProcessEnvironment(javaHomePath: String?) -> [String: String] {
+        ["TEST_JAVA_HOME": javaHomePath ?? ""]
+    }
+}
+
+private final class MavenRecordingProcess: StreamingProcess, @unchecked Sendable {
+    var isRunning = false
+    var onOutput: (@Sendable (String) -> Void)?
+    var onTermination: (@Sendable (Int32) -> Void)?
+    var onStateChange: (@Sendable (ProcessLifecycleEvent) -> Void)?
+
+    private let stream: AsyncStream<ProcessRequest>
+    private let continuation: AsyncStream<ProcessRequest>.Continuation
+
+    init() {
+        (stream, continuation) = AsyncStream.makeStream(bufferingPolicy: .bufferingNewest(4))
+    }
+
+    func start(_ request: ProcessRequest) throws {
+        isRunning = true
+        continuation.yield(request)
+    }
+
+    func send(_ input: Data) throws {}
+    func stop() { isRunning = false }
+
+    func nextStart(timeout: Duration) async -> ProcessRequest? {
+        await withTaskGroup(of: ProcessRequest?.self) { group in
+            let stream = stream
+            group.addTask {
+                var iterator = stream.makeAsyncIterator()
+                return await iterator.next()
+            }
+            group.addTask {
+                try? await ContinuousClock().sleep(for: timeout)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+    }
 }
 
 private struct TestRunFileAccess: RunFileAccess {

--- a/macos/Tests/LitheExecutionModuleTests/ExecutionModuleTests.swift
+++ b/macos/Tests/LitheExecutionModuleTests/ExecutionModuleTests.swift
@@ -313,6 +313,42 @@ struct ExecutionModuleTests {
         #expect(!process.isRunning)
     }
 
+    @Test
+    func mavenServiceClearsReloadWhenConfigurationFingerprintReturnsToBaseline() async throws {
+        let workspace = URL(fileURLWithPath: "/workspace", isDirectory: true)
+        let project = MavenProject(
+            rootURL: workspace,
+            pomURL: workspace.appendingPathComponent("pom.xml"),
+            groupID: "dev.lithe",
+            artifactID: "demo",
+            version: "1.0",
+            packaging: "jar",
+            modules: [],
+            profiles: [],
+            hasWrapper: false
+        )
+        let process = MavenRecordingProcess()
+        let service = MavenService(
+            runtimeService: MavenRecordingRuntime(),
+            process: process,
+            mavenOperations: FingerprintingMavenOperations(project: project)
+        )
+
+        await service.loadProject(at: workspace, files: [project.pomURL])
+        #expect(!service.isReloadRequired)
+
+        service.setSkipTests(true)
+        service.run(phase: .validate, module: nil)
+        _ = try #require(await process.nextStart(timeout: .seconds(1)))
+        #expect(service.isReloadRequired)
+
+        service.stop()
+        service.setSkipTests(false)
+        service.run(phase: .validate, module: nil)
+        _ = try #require(await process.nextStart(timeout: .seconds(1)))
+        #expect(!service.isReloadRequired)
+    }
+
     private func factory(recorder: Recorder) -> ModuleFactory {
         ModuleFactory(manifest: ExecutionModule.moduleManifest, contributions: ExecutionModule.moduleContributions) {
             recorder.factoryCalls += 1
@@ -463,6 +499,35 @@ private final class RecordingMavenOperations: MavenProjectOperations, @unchecked
         recordedGoals = goals
         lock.unlock()
         return plan
+    }
+
+    func mavenDiagnostics(output: String, projectRoot: URL) -> [MavenBuildIssue] { [] }
+}
+
+private final class FingerprintingMavenOperations: MavenProjectOperations, @unchecked Sendable {
+    private let project: MavenProject
+
+    init(project: MavenProject) {
+        self.project = project
+    }
+
+    func scanMavenProject(at rootURL: URL, files: [URL]) throws -> MavenProject? {
+        project
+    }
+
+    func mavenLaunchPlan(
+        at rootURL: URL,
+        context: MavenLaunchContext,
+        module: String?,
+        goals: [String]
+    ) throws -> MavenLaunchPlan {
+        MavenLaunchPlan(
+            version: 1,
+            toolchain: "project-maven",
+            arguments: goals,
+            workingDirectory: context.reactorPath,
+            configurationFingerprint: context.skipTests ? "sha256:skip-tests" : "sha256:run-tests"
+        )
     }
 
     func mavenDiagnostics(output: String, projectRoot: URL) -> [MavenBuildIssue] { [] }

--- a/macos/Tests/LitheLanguageIntelligenceModuleTests/LanguageIntelligenceModuleTests.swift
+++ b/macos/Tests/LitheLanguageIntelligenceModuleTests/LanguageIntelligenceModuleTests.swift
@@ -148,6 +148,40 @@ struct LanguageIntelligenceModuleTests {
     }
 
     @Test
+    func javaSessionReceivesTheCurrentMavenContext() throws {
+        let root = URL(fileURLWithPath: "/workspace/java", isDirectory: true)
+        let source = root.appendingPathComponent("src/Main.java")
+        let descriptor = try #require(
+            LanguageProviderCatalog.compatibilityFallback.provider(for: source)
+        )
+        let context = MavenLaunchContext(
+            reactorPath: ".",
+            profiles: ["dev", "enterprise"],
+            settingsPath: "/local/settings.xml",
+            skipTests: true,
+            mavenExecutablePath: "/local/maven/bin/mvn",
+            javaHomePath: "/local/jdk"
+        )
+        let session = WorkspaceStateLanguageServerSession()
+        let manager = LanguageToolingSessionManager(
+            catalog: .compatibilityFallback,
+            runtimes: [WorkspaceStateLanguageProviderRuntime(
+                descriptor: descriptor,
+                session: session
+            )]
+        )
+        manager.configureMavenContextProvider { requestedDescriptor, requestedRoot in
+            #expect(requestedDescriptor.id == "java")
+            #expect(requestedRoot == root.standardizedFileURL)
+            return context
+        }
+
+        try manager.startLanguageServer(providerID: "java", rootURL: root)
+
+        #expect(session.startedMavenContext == context)
+    }
+
+    @Test
     func languageServerLifecycleLogsAndCallbacksRetainTheOperationID() throws {
         let root = URL(fileURLWithPath: "/workspace/java", isDirectory: true)
         let source = root.appendingPathComponent("Main.java")
@@ -477,12 +511,26 @@ private final class WorkspaceStateLanguageServerSession: LanguageServerSession {
     var serverInfo: LanguageServerInfo?
     var onServerInfoChange: ((LanguageServerInfo?) -> Void)?
     private(set) var startedFingerprint: String?
+    private(set) var startedMavenContext: MavenLaunchContext?
     private(set) var stopCallCount = 0
     var startError: Error?
 
-    func start(rootURL _: URL, workspaceFingerprint: String?) throws {
+    func start(rootURL: URL, workspaceFingerprint: String?) throws {
+        try start(
+            rootURL: rootURL,
+            workspaceFingerprint: workspaceFingerprint,
+            mavenContext: nil
+        )
+    }
+
+    func start(
+        rootURL _: URL,
+        workspaceFingerprint: String?,
+        mavenContext: MavenLaunchContext?
+    ) throws {
         if let startError { throw startError }
         startedFingerprint = workspaceFingerprint
+        startedMavenContext = mavenContext
         isRunning = true
     }
 

--- a/macos/Tests/LitheTests/MavenRuntimeTests.swift
+++ b/macos/Tests/LitheTests/MavenRuntimeTests.swift
@@ -6,6 +6,25 @@ import Testing
 @Suite("Maven and runtime integration")
 struct MavenRuntimeTests {
     @Test
+    func mavenLifecyclePhasesMatchTheSharedPlatformContract() throws {
+        let fixture = try Self.platformContractFixture()
+        #expect(MavenLifecyclePhase.allCases.map(\.rawValue) == fixture.lifecyclePhases)
+    }
+
+    @Test
+    func macMavenStorageIdentityMatchesTheSharedPlatformContract() throws {
+        let fixture = try Self.platformContractFixture()
+        let macCases = fixture.storageIdentityCases.filter { $0.platform == "macos" }
+        #expect(macCases.count == 1)
+        for item in macCases {
+            #expect(MacMavenConfigurationStore.storageIdentity(
+                workspacePath: item.workspacePath,
+                reactorPath: item.reactorPath
+            ) == item.expectedIdentity)
+        }
+    }
+
+    @Test
     func mavenScanPayloadDecodesRustCamelCaseIdentifiers() throws {
         let json = #"""
         {
@@ -242,6 +261,33 @@ struct MavenRuntimeTests {
 
         #expect(!service.isDiscovering)
     }
+
+    private static func platformContractFixture() throws -> MavenPlatformContractFixture {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let url = repositoryRoot.appendingPathComponent(
+            "shared/fixtures/maven/platform-contract-v1.json"
+        )
+        return try JSONDecoder().decode(
+            MavenPlatformContractFixture.self,
+            from: Data(contentsOf: url)
+        )
+    }
+}
+
+private struct MavenPlatformContractFixture: Decodable {
+    struct StorageIdentityCase: Decodable {
+        let platform: String
+        let workspacePath: String
+        let reactorPath: String
+        let expectedIdentity: String
+    }
+
+    let lifecyclePhases: [String]
+    let storageIdentityCases: [StorageIdentityCase]
 }
 
 private struct MavenTestFileStorage: FileStorage {
@@ -322,7 +368,7 @@ private struct MavenOverrideRuntimeLocator: RuntimeLocator {
     func validJavaHome(path: String) -> URL? { nil }
     func javaRuntime(at homeURL: URL) -> JavaRuntimeCandidate? { nil }
     func isExecutable(at url: URL) -> Bool {
-        resolutions[url.standardizedFileURL.path] != nil
+        resolutions[url.standardizedFileURL.path]?.standardizedFileURL == url.standardizedFileURL
     }
     func systemMavenExecutable() -> URL? { nil }
     func mavenExecutable(forHomePath path: String) -> URL? {

--- a/macos/Tests/LitheTests/MavenRuntimeTests.swift
+++ b/macos/Tests/LitheTests/MavenRuntimeTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LitheCoreContracts
 import Testing
 @testable import Lithe
 
@@ -89,6 +90,74 @@ struct MavenRuntimeTests {
     }
 
     @Test
+    func mavenLaunchPlanPayloadDecodesSharedCoreResponse() throws {
+        let json = #"""
+        {
+            "version": 1,
+            "executable": { "toolchain": "project-maven" },
+            "arguments": ["-B", "-ntp", "verify"],
+            "workingDirectory": "projects/demo",
+            "configurationFingerprint": "sha256:fixture"
+        }
+        """#
+
+        let payload = try JSONDecoder().decode(
+            RustCoreBridge.MavenLaunchPlanPayload.self,
+            from: Data(json.utf8)
+        )
+        let plan = payload.makeModel()
+
+        #expect(plan.version == 1)
+        #expect(plan.toolchain == "project-maven")
+        #expect(plan.arguments == ["-B", "-ntp", "verify"])
+        #expect(plan.workingDirectory == "projects/demo")
+        #expect(plan.configurationFingerprint == "sha256:fixture")
+    }
+
+    @Test
+    func mavenConfigurationSeparatesPortableAndLocalPaths() throws {
+        let testRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lithe-maven-store-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let workspace = testRoot.appendingPathComponent("workspace", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+        let storage = MavenTestFileStorage(root: testRoot)
+        let store = MacMavenConfigurationStore(storage: storage)
+        let configuration = MavenStoredConfiguration(
+            portable: MavenPortableConfiguration(
+                selectedProfiles: ["dev", "qa"],
+                customProfiles: ["qa"],
+                skipTests: true
+            ),
+            local: MavenLocalConfiguration(
+                settingsPath: "/private/settings.xml",
+                mavenExecutablePath: "/private/apache-maven",
+                javaHomePath: "/private/jdk"
+            )
+        )
+
+        try store.saveMavenConfiguration(
+            configuration,
+            workspaceURL: workspace,
+            reactorPath: "."
+        )
+
+        let portableURL = workspace.appendingPathComponent(".lithe/maven/config.json")
+        let portableText = String(decoding: try Data(contentsOf: portableURL), as: UTF8.self)
+        #expect(portableText.contains("\"selectedProfiles\""))
+        #expect(!portableText.contains("/private/"))
+        #expect(try store.loadMavenConfiguration(
+            workspaceURL: workspace,
+            reactorPath: "."
+        ) == configuration)
+        let localFiles = try FileManager.default.contentsOfDirectory(
+            at: storage.applicationSupportDirectory().appendingPathComponent("Lithe/Maven"),
+            includingPropertiesForKeys: nil
+        )
+        #expect(localFiles.count == 1)
+    }
+
+    @Test
     @MainActor
     func projectRelativeJavaOverridesResolveAgainstProjectRoot() {
         let root = FileManager.default.temporaryDirectory
@@ -104,6 +173,54 @@ struct MavenRuntimeTests {
 
         #expect(service.javaHomeURL(overridePath: "toolchains/jdk") == javaHome)
         #expect(service.mavenJavaHomeURL(overridePath: "toolchains/maven-jdk") == mavenJavaHome)
+    }
+
+    @Test
+    @MainActor
+    func mavenOverrideUsesRuntimeLocatorForHomeExecutableAndInvalidPaths() {
+        let root = URL(fileURLWithPath: "/workspace", isDirectory: true)
+        let home = root.appendingPathComponent("toolchains/maven", isDirectory: true)
+        let homeExecutable = home.appendingPathComponent("bin/mvn")
+        let directExecutable = root.appendingPathComponent("toolchains/custom-mvn")
+        let locator = MavenOverrideRuntimeLocator(resolutions: [
+            home.standardizedFileURL.path: homeExecutable,
+            directExecutable.standardizedFileURL.path: directExecutable
+        ])
+        let service = ProjectRuntimeService(runtimeLocator: locator, store: EmptyKeyValueStore())
+
+        #expect(service.mavenExecutable(at: root, overridePath: "toolchains/maven") == homeExecutable)
+        #expect(service.mavenExecutable(at: root, overridePath: directExecutable.path) == directExecutable)
+        #expect(service.mavenExecutable(at: root, overridePath: "toolchains/missing") == nil)
+    }
+
+    @Test
+    func macRuntimeDiscoveryDistinguishesMavenHomeFromExecutable() throws {
+        let testRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lithe-maven-runtime-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let home = testRoot.appendingPathComponent("apache-maven", isDirectory: true)
+        let homeExecutable = home.appendingPathComponent("bin/mvn")
+        let directExecutable = testRoot.appendingPathComponent("custom-mvn")
+        let invalidHome = testRoot.appendingPathComponent("invalid-maven", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: homeExecutable.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(at: invalidHome, withIntermediateDirectories: true)
+        #expect(FileManager.default.createFile(atPath: homeExecutable.path, contents: Data()))
+        #expect(FileManager.default.createFile(atPath: directExecutable.path, contents: Data()))
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: homeExecutable.path
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: directExecutable.path
+        )
+
+        #expect(MacRuntimeDiscovery.mavenExecutable(forHomePath: home.path) == homeExecutable)
+        #expect(MacRuntimeDiscovery.mavenExecutable(forHomePath: directExecutable.path) == directExecutable)
+        #expect(MacRuntimeDiscovery.mavenExecutable(forHomePath: invalidHome.path) == nil)
     }
 
     @Test
@@ -127,6 +244,55 @@ struct MavenRuntimeTests {
     }
 }
 
+private struct MavenTestFileStorage: FileStorage {
+    let root: URL
+
+    func homeDirectory() -> URL { root.appendingPathComponent("home", isDirectory: true) }
+    func cacheDirectory() -> URL { root.appendingPathComponent("cache", isDirectory: true) }
+    func applicationSupportDirectory() -> URL {
+        root.appendingPathComponent("application-support", isDirectory: true)
+    }
+    func temporaryDirectory() -> URL { root.appendingPathComponent("temporary", isDirectory: true) }
+    func metadata(for url: URL) -> FileMetadata? {
+        guard let values = try? url.resourceValues(forKeys: [
+            .fileSizeKey, .contentModificationDateKey, .isRegularFileKey, .isDirectoryKey
+        ]) else { return nil }
+        return FileMetadata(
+            byteCount: values.fileSize,
+            modificationDate: values.contentModificationDate,
+            isRegularFile: values.isRegularFile == true,
+            isDirectory: values.isDirectory == true
+        )
+    }
+    func fileExists(at url: URL) -> Bool { FileManager.default.fileExists(atPath: url.path) }
+    func isExecutable(at url: URL) -> Bool { FileManager.default.isExecutableFile(atPath: url.path) }
+    func listDirectory(at url: URL) -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)) ?? []
+    }
+    func readPrefix(from url: URL, byteCount: Int) throws -> Data {
+        Data(try Data(contentsOf: url).prefix(byteCount))
+    }
+    func readData(from url: URL, options: Data.ReadingOptions) throws -> Data {
+        try Data(contentsOf: url, options: options)
+    }
+    func writeData(_ data: Data, to url: URL, options: Data.WritingOptions) throws {
+        try data.write(to: url, options: options)
+    }
+    func createDirectory(at url: URL, withIntermediateDirectories: Bool) throws {
+        try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: withIntermediateDirectories
+        )
+    }
+    func removeItem(at url: URL) throws { try FileManager.default.removeItem(at: url) }
+    func moveItem(at sourceURL: URL, to destinationURL: URL) throws {
+        try FileManager.default.moveItem(at: sourceURL, to: destinationURL)
+    }
+    func copyItem(at sourceURL: URL, to destinationURL: URL) throws {
+        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+    }
+}
+
 private struct ProjectRelativeRuntimeLocator: RuntimeLocator {
     let validJavaHomes: Set<String>
 
@@ -144,6 +310,26 @@ private struct ProjectRelativeRuntimeLocator: RuntimeLocator {
     func mavenRuntime(at executableURL: URL) -> MavenRuntimeCandidate? { nil }
     func systemJDBExecutable() -> URL? { nil }
     func javaLanguageServerExecutable() -> URL? { nil }
+}
+
+private struct MavenOverrideRuntimeLocator: RuntimeLocator {
+    let resolutions: [String: URL]
+
+    func environment() -> [String: String] { [:] }
+    func discover() -> RuntimeDiscoveryResult {
+        RuntimeDiscoveryResult(javaRuntimes: [], mavenRuntimes: [])
+    }
+    func validJavaHome(path: String) -> URL? { nil }
+    func javaRuntime(at homeURL: URL) -> JavaRuntimeCandidate? { nil }
+    func isExecutable(at url: URL) -> Bool {
+        resolutions[url.standardizedFileURL.path] != nil
+    }
+    func systemMavenExecutable() -> URL? { nil }
+    func mavenExecutable(forHomePath path: String) -> URL? {
+        resolutions[URL(fileURLWithPath: path).standardizedFileURL.path]
+    }
+    func mavenRuntime(at executableURL: URL) -> MavenRuntimeCandidate? { nil }
+    func systemJDBExecutable() -> URL? { nil }
 }
 
 private final class BlockingRuntimeLocator: RuntimeLocator, @unchecked Sendable {

--- a/macos/Tests/LitheTests/RunConfigurationIntegrationTests.swift
+++ b/macos/Tests/LitheTests/RunConfigurationIntegrationTests.swift
@@ -1217,15 +1217,26 @@ struct RunConfigurationIntegrationTests {
             jdtlsLaunchResourcesResolver: { _, _ in .available(resources) }
         )
         let session = try #require(runtime.makeLanguageServerSession())
+        let mavenContext = MavenLaunchContext(
+            reactorPath: ".",
+            profiles: ["dev", "enterprise"],
+            settingsPath: "/local/settings.xml",
+            skipTests: true,
+            mavenExecutablePath: "/local/maven/bin/mvn",
+            javaHomePath: "/local/jdk"
+        )
 
         try session.start(
             rootURL: URL(fileURLWithPath: "/workspace", isDirectory: true),
-            workspaceFingerprint: nil
+            workspaceFingerprint: "workspace-fingerprint",
+            mavenContext: mavenContext
         )
 
         let start = try #require(core.startCalls.last)
         #expect(start.runtimeExecutableURL?.path == "/jdk/bin/java")
         #expect(start.jdtlsLaunchResources == resources)
+        #expect(start.workspaceFingerprint == "workspace-fingerprint")
+        #expect(start.mavenContext == mavenContext)
         session.stop()
     }
 
@@ -4295,6 +4306,8 @@ private final class TestLanguageServerRuntimeCore: LanguageServerRuntimeCore, @u
         let runtimeExecutableURL: URL?
         let jdtlsLaunchResources: JDTLSLaunchResources?
         let cacheDirectoryURL: URL?
+        let workspaceFingerprint: String?
+        let mavenContext: MavenLaunchContext?
         let initializeTimeout: TimeInterval
         let requestTimeout: TimeInterval
         let shutdownTimeout: TimeInterval
@@ -4366,6 +4379,42 @@ private final class TestLanguageServerRuntimeCore: LanguageServerRuntimeCore, @u
         requestTimeout: TimeInterval,
         shutdownTimeout: TimeInterval
     ) -> Result<LanguageServerRuntimeStart, LanguageServerRuntimeFailure> {
+        startLanguageServer(
+            providerID: providerID,
+            executableURL: executableURL,
+            arguments: arguments,
+            environment: environment,
+            rootURL: rootURL,
+            workingDirectoryURL: workingDirectoryURL,
+            initializationOptions: initializationOptions,
+            runtimeExecutableURL: runtimeExecutableURL,
+            jdtlsLaunchResources: jdtlsLaunchResources,
+            cacheDirectoryURL: cacheDirectoryURL,
+            workspaceFingerprint: workspaceFingerprint,
+            mavenContext: nil,
+            initializeTimeout: initializeTimeout,
+            requestTimeout: requestTimeout,
+            shutdownTimeout: shutdownTimeout
+        )
+    }
+
+    func startLanguageServer(
+        providerID: String,
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        rootURL: URL,
+        workingDirectoryURL: URL,
+        initializationOptions: ToolingJSONValue?,
+        runtimeExecutableURL: URL?,
+        jdtlsLaunchResources: JDTLSLaunchResources?,
+        cacheDirectoryURL: URL?,
+        workspaceFingerprint: String?,
+        mavenContext: MavenLaunchContext?,
+        initializeTimeout: TimeInterval,
+        requestTimeout: TimeInterval,
+        shutdownTimeout: TimeInterval
+    ) -> Result<LanguageServerRuntimeStart, LanguageServerRuntimeFailure> {
         startCalls.append(StartCall(
             providerID: providerID,
             executableURL: executableURL,
@@ -4377,6 +4426,8 @@ private final class TestLanguageServerRuntimeCore: LanguageServerRuntimeCore, @u
             runtimeExecutableURL: runtimeExecutableURL,
             jdtlsLaunchResources: jdtlsLaunchResources,
             cacheDirectoryURL: cacheDirectoryURL,
+            workspaceFingerprint: workspaceFingerprint,
+            mavenContext: mavenContext,
             initializeTimeout: initializeTimeout,
             requestTimeout: requestTimeout,
             shutdownTimeout: shutdownTimeout

--- a/macos/Tests/LitheTests/RunConfigurationIntegrationTests.swift
+++ b/macos/Tests/LitheTests/RunConfigurationIntegrationTests.swift
@@ -3239,6 +3239,7 @@ struct RunConfigurationIntegrationTests {
         try store.saveOptions(
             RunOptions(
                 javaHomePath: "/test/jdk-21",
+                mavenSkipTests: false,
                 mavenExecutablePath: "/test/maven/bin/mvn",
                 mavenJavaHomePath: "/test/maven-jdk"
             ),
@@ -3252,6 +3253,7 @@ struct RunConfigurationIntegrationTests {
         #expect(options.javaHomePath == "/test/jdk-21")
         #expect(options.mavenExecutablePath == "/test/maven/bin/mvn")
         #expect(options.mavenJavaHomePath == "/test/maven-jdk")
+        #expect(options.mavenSkipTests == false)
     }
 
     @Test
@@ -4766,7 +4768,8 @@ private struct RunTestRuntimeLocator: RuntimeLocator {
     func isExecutable(at url: URL) -> Bool { url.lastPathComponent != "mvnw" }
     func systemMavenExecutable() -> URL? { URL(fileURLWithPath: "/toolchains/maven/bin/mvn") }
     func mavenExecutable(forHomePath path: String) -> URL? {
-        URL(fileURLWithPath: path, isDirectory: true).appendingPathComponent("bin/mvn")
+        let url = URL(fileURLWithPath: path)
+        return url.lastPathComponent == "mvn" ? url : url.appendingPathComponent("bin/mvn")
     }
     func mavenRuntime(at executableURL: URL) -> MavenRuntimeCandidate? {
         MavenRuntimeCandidate(

--- a/rust/lithe-core/src/execution/configuration.rs
+++ b/rust/lithe-core/src/execution/configuration.rs
@@ -81,6 +81,9 @@ pub struct LaunchPlanRequest {
     /// Host-owned local layer. When present, Core uses it instead of `.lithe/run/local.json`.
     #[serde(default)]
     pub local_document: Option<Value>,
+    /// Project Maven defaults supplied by the native host for Maven-backed plans.
+    #[serde(default)]
+    pub maven_context: Option<crate::project::MavenLaunchContextRequest>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1341,7 +1344,7 @@ pub fn create_user_configuration(
 pub fn create_launch_plan(request: LaunchPlanRequest) -> Result<Value, CoreError> {
     let workspace_root = existing_root(&request.root)?;
     let resolved = resolve(ResolveRequest {
-        root: request.root,
+        root: request.root.clone(),
         toolchain_candidates: Vec::new(),
         local_document: request.local_document,
     })?;
@@ -1429,9 +1432,11 @@ pub fn create_launch_plan(request: LaunchPlanRequest) -> Result<Value, CoreError
         arguments.push(json!(current_file));
         arguments.extend(program_arguments);
     } else if is_java_main && uses_maven_toolchain {
-        arguments.extend([json!("-B"), json!("-ntp")]);
-        if let Some(module) = maven["module"].as_str().filter(|m| *m != ".") {
-            arguments.extend([json!("-pl"), json!(module)]);
+        if request.maven_context.is_none() {
+            arguments.extend([json!("-B"), json!("-ntp")]);
+            if let Some(module) = maven["module"].as_str().filter(|m| *m != ".") {
+                arguments.extend([json!("-pl"), json!(module)]);
+            }
         }
         let main = maven["mainClass"].as_str().ok_or_else(|| {
             CoreError::new(
@@ -1476,19 +1481,21 @@ pub fn create_launch_plan(request: LaunchPlanRequest) -> Result<Value, CoreError
     } else {
         // `maven.module` has no framework goal: it runs whatever goals the
         // configuration names, so only the reactor selection applies.
-        arguments.extend([json!("-B"), json!("-ntp")]);
-        if let Some(module) = maven["module"].as_str().filter(|m| *m != ".") {
-            arguments.extend([json!("-pl"), json!(module)]);
-        }
-        if let Some(profiles) = maven["profiles"].as_array().filter(|p| !p.is_empty()) {
-            arguments.extend([
-                json!("-P"),
-                json!(profiles
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .collect::<Vec<_>>()
-                    .join(",")),
-            ]);
+        if request.maven_context.is_none() {
+            arguments.extend([json!("-B"), json!("-ntp")]);
+            if let Some(module) = maven["module"].as_str().filter(|m| *m != ".") {
+                arguments.extend([json!("-pl"), json!(module)]);
+            }
+            if let Some(profiles) = maven["profiles"].as_array().filter(|p| !p.is_empty()) {
+                arguments.extend([
+                    json!("-P"),
+                    json!(profiles
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .collect::<Vec<_>>()
+                        .join(",")),
+                ]);
+            }
         }
         if let Some(goal) = goal {
             arguments.extend(framework_arguments(
@@ -1518,10 +1525,42 @@ pub fn create_launch_plan(request: LaunchPlanRequest) -> Result<Value, CoreError
     let java_toolchain = config["toolchains"]["java"]
         .as_str()
         .unwrap_or("project-jdk");
+    let mut working_directory = config["cwd"].as_str().unwrap_or(".").to_string();
+    if executable_kind == "maven" {
+        if let Some(mut context) = request.maven_context {
+            if let Some(profiles) = maven["profiles"]
+                .as_array()
+                .filter(|items| !items.is_empty())
+            {
+                context.profiles = profiles
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect();
+            }
+            let module = maven["module"].as_str().map(str::to_string);
+            let trailing_arguments = arguments
+                .into_iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect();
+            let shared_plan = crate::project::launch_plan_with_arguments(
+                request.root,
+                context,
+                module,
+                trailing_arguments,
+            )?;
+            arguments = shared_plan
+                .arguments
+                .into_iter()
+                .map(Value::String)
+                .collect();
+            working_directory = shared_plan.working_directory;
+        }
+    }
     Ok(json!({
         "executable": { "toolchain": executable_toolchain },
         "arguments": arguments,
-        "workingDirectory": config["cwd"].as_str().unwrap_or("."),
+        "workingDirectory": working_directory,
         "environment": {
             "JAVA_HOME": { "toolchain": java_toolchain, "property": "home" }
         }

--- a/rust/lithe-core/src/execution/configuration.rs
+++ b/rust/lithe-core/src/execution/configuration.rs
@@ -121,6 +121,11 @@ pub struct UpdateOptionsRequest {
     pub environment: BTreeMap<String, String>,
     #[serde(default)]
     pub maven_profiles: Vec<String>,
+    /// Per-configuration Maven test policy. `None` inherits the project context;
+    /// `Some(false)` must remain distinct so a test configuration can override
+    /// a project-wide Skip Tests default.
+    #[serde(default)]
+    pub maven_skip_tests: Option<bool>,
     #[serde(default)]
     pub java_home_path: String,
     #[serde(default)]
@@ -1120,15 +1125,15 @@ fn update_configuration_options(
         normalize_scoped_toolchain_path(&root, &request.scope, &request.maven_executable_path)?;
     let maven_java_home_path =
         normalize_scoped_toolchain_path(&root, &request.scope, &request.maven_java_home_path)?;
-    let working_directory = normalize_project_directory(
-        &root,
-        if request.working_directory.trim().is_empty() {
-            "."
-        } else {
-            request.working_directory.trim()
-        },
-        false,
-    )?;
+    let working_directory = if request.working_directory.trim().is_empty() {
+        None
+    } else {
+        Some(normalize_project_directory(
+            &root,
+            request.working_directory.trim(),
+            false,
+        )?)
+    };
     let mut document = if request.scope == "local" {
         local_layer_document(&root, request.local_document)?
     } else {
@@ -1141,9 +1146,11 @@ fn update_configuration_options(
         .ok_or_else(|| CoreError::new(ErrorCode::ParseFailed, "configurations must be an array"))?;
     let mut patch = json!({
         "id": request.configuration_id,
-        "cwd": working_directory,
         "env": request.environment
     });
+    if let Some(working_directory) = working_directory.as_ref() {
+        patch["cwd"] = json!(working_directory);
+    }
     let mut java_extension = serde_json::Map::new();
     if !java_home_path.is_empty() {
         java_extension.insert("homePath".to_string(), json!(java_home_path));
@@ -1158,14 +1165,25 @@ fn update_configuration_options(
         java_extension.insert("mavenJavaHomePath".to_string(), json!(maven_java_home_path));
     }
     if uses_maven_capability {
-        let mut extensions = serde_json::Map::from_iter([(
-            "maven".to_string(),
-            json!({
-                "jvmArguments": split_arguments(&request.jvm_arguments),
-                "programArguments": split_arguments(&request.arguments),
-                "profiles": request.maven_profiles.into_iter().collect::<BTreeSet<_>>()
-            }),
-        )]);
+        let mut maven_extension = serde_json::Map::from_iter([
+            (
+                "jvmArguments".to_string(),
+                json!(split_arguments(&request.jvm_arguments)),
+            ),
+            (
+                "programArguments".to_string(),
+                json!(split_arguments(&request.arguments)),
+            ),
+            (
+                "profiles".to_string(),
+                json!(request.maven_profiles.into_iter().collect::<BTreeSet<_>>()),
+            ),
+        ]);
+        if let Some(skip_tests) = request.maven_skip_tests {
+            maven_extension.insert("skipTests".to_string(), json!(skip_tests));
+        }
+        let mut extensions =
+            serde_json::Map::from_iter([("maven".to_string(), Value::Object(maven_extension))]);
         if !java_extension.is_empty() {
             extensions.insert("java".to_string(), Value::Object(java_extension));
         }
@@ -1186,6 +1204,12 @@ fn update_configuration_options(
             )
         })?;
         remove_java_toolchain_overrides(target)?;
+        if working_directory.is_none() {
+            target.remove("cwd");
+        }
+        if uses_maven_capability && request.maven_skip_tests.is_none() {
+            remove_maven_skip_tests_override(target);
+        }
         for (key, value) in patch.as_object_mut().expect("patch is an object") {
             if key == "extensions" {
                 merge_extensions(target, value)?;
@@ -1235,6 +1259,18 @@ fn remove_java_toolchain_overrides(
         configuration.remove("extensions");
     }
     Ok(())
+}
+
+fn remove_maven_skip_tests_override(configuration: &mut serde_json::Map<String, Value>) {
+    let Some(maven) = configuration
+        .get_mut("extensions")
+        .and_then(Value::as_object_mut)
+        .and_then(|extensions| extensions.get_mut("maven"))
+        .and_then(Value::as_object_mut)
+    else {
+        return;
+    };
+    maven.remove("skipTests");
 }
 
 /// Creates a user configuration while preserving stable IDs in existing layers.
@@ -1323,7 +1359,6 @@ pub fn create_user_configuration(
         "execution": if framework_goal(configuration_kind).is_some() { "service" } else { "task" },
         "confidence": "native",
         "toolchains": {"java": "project-jdk", "maven": "project-maven"},
-        "cwd": ".",
         "debug": {"adapter": "jdwp"},
         "extensions": {"maven": maven}
     });
@@ -1343,10 +1378,16 @@ pub fn create_user_configuration(
 /// Resolves one configuration into the exact executable, arguments, and environment.
 pub fn create_launch_plan(request: LaunchPlanRequest) -> Result<Value, CoreError> {
     let workspace_root = existing_root(&request.root)?;
+    let has_explicit_cwd_override = configuration_override_has_key(
+        &workspace_root,
+        request.local_document.as_ref(),
+        &request.configuration_id,
+        "cwd",
+    )?;
     let resolved = resolve(ResolveRequest {
         root: request.root.clone(),
         toolchain_candidates: Vec::new(),
-        local_document: request.local_document,
+        local_document: request.local_document.clone(),
     })?;
     let config = resolved["configurations"]
         .as_array()
@@ -1526,6 +1567,7 @@ pub fn create_launch_plan(request: LaunchPlanRequest) -> Result<Value, CoreError
         .as_str()
         .unwrap_or("project-jdk");
     let mut working_directory = config["cwd"].as_str().unwrap_or(".").to_string();
+    let has_explicit_working_directory = working_directory != "." || has_explicit_cwd_override;
     if executable_kind == "maven" {
         if let Some(mut context) = request.maven_context {
             if let Some(profiles) = maven["profiles"]
@@ -1538,6 +1580,9 @@ pub fn create_launch_plan(request: LaunchPlanRequest) -> Result<Value, CoreError
                     .map(str::to_string)
                     .collect();
             }
+            if let Some(skip_tests) = maven.get("skipTests").and_then(Value::as_bool) {
+                context.skip_tests = skip_tests;
+            }
             let module = maven["module"].as_str().map(str::to_string);
             let trailing_arguments = arguments
                 .into_iter()
@@ -1548,13 +1593,16 @@ pub fn create_launch_plan(request: LaunchPlanRequest) -> Result<Value, CoreError
                 context,
                 module,
                 trailing_arguments,
+                false,
             )?;
             arguments = shared_plan
                 .arguments
                 .into_iter()
                 .map(Value::String)
                 .collect();
-            working_directory = shared_plan.working_directory;
+            if !has_explicit_working_directory {
+                working_directory = shared_plan.working_directory;
+            }
         }
     }
     Ok(json!({
@@ -1565,6 +1613,33 @@ pub fn create_launch_plan(request: LaunchPlanRequest) -> Result<Value, CoreError
             "JAVA_HOME": { "toolchain": java_toolchain, "property": "home" }
         }
     }))
+}
+
+/// Returns whether a user-owned layer explicitly sets one configuration key.
+///
+/// Generated `cwd: "."` is the schema default and may inherit the selected
+/// reactor. A project or local `cwd: "."`, however, is an intentional override
+/// and must keep the workspace root.
+fn configuration_override_has_key(
+    root: &Path,
+    provided_local: Option<&Value>,
+    configuration_id: &str,
+    key: &str,
+) -> Result<bool, CoreError> {
+    let team = read_document_value(root, "run/configurations.json")?
+        .unwrap_or_else(|| json!({"version": VERSION, "configurations": []}));
+    let local = local_layer_document(root, provided_local.cloned())?;
+    for document in [&team, &local] {
+        validate_version_value(document)?;
+        if document["configurations"]
+            .as_array()
+            .and_then(|items| items.iter().find(|item| item["id"] == configuration_id))
+            .is_some_and(|item| item.get(key).is_some())
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Providers the launch layer assembles a JVM command line for, rather than

--- a/rust/lithe-core/src/lsp/interface/engine.rs
+++ b/rust/lithe-core/src/lsp/interface/engine.rs
@@ -2284,6 +2284,7 @@ impl RuntimeSession {
         }
         let now = Instant::now();
         let deadline = now + state.request_timeout;
+        let project_count = requests.len();
         let mut messages = Vec::with_capacity(requests.len());
         for params in requests {
             let response =
@@ -2309,7 +2310,7 @@ impl RuntimeSession {
             &mut state,
             "info",
             "Applying Maven profiles to Java projects",
-            Some(format!("projectCount={}", messages.len())),
+            Some(format!("projectCount={project_count}")),
         );
         Ok((messages, true))
     }

--- a/rust/lithe-core/src/lsp/interface/engine.rs
+++ b/rust/lithe-core/src/lsp/interface/engine.rs
@@ -13,10 +13,11 @@ use super::{
 };
 use crate::lsp::languages::jdt::{
     adapt_initialization_options, adapt_start, import_progress, initialized_notification,
-    is_structured_import_notification, is_virtual_source_uri, normalize_location, readiness_signal,
-    virtual_source_content, virtual_source_resolve_params, waits_for_service_ready,
-    workspace_configuration, JdtDirectLaunchResources, JdtReadinessSignal, JdtStartContext,
-    ProviderLocation, WorkspaceConfigurationItem,
+    is_structured_import_notification, is_virtual_source_uri, maven_profile_update_requests,
+    normalize_location, readiness_signal, virtual_source_content, virtual_source_resolve_params,
+    waits_for_service_ready, workspace_configuration, JdtDirectLaunchResources,
+    JdtMavenConfiguration, JdtReadinessSignal, JdtStartContext, ProviderLocation,
+    WorkspaceConfigurationItem,
 };
 use crate::lsp::languages::jdt_navigation::{JavaNavigationMarkerBatch, MAX_JAVA_NAVIGATION_TASKS};
 use crate::lsp::languages::jdt_progress::JavaPreparationDiagnostics;
@@ -87,6 +88,9 @@ pub struct StartServerRequest {
     /// reuse a stale project model. See `JdtStartContext::workspace_fingerprint`.
     #[serde(default)]
     pub workspace_fingerprint: Option<String>,
+    /// Project Maven context applied to JDT LS settings and imported modules.
+    #[serde(default)]
+    pub maven_context: Option<crate::project::MavenLaunchContextRequest>,
     #[serde(default = "default_initialize_timeout")]
     pub initialize_timeout_milliseconds: u64,
     /// Maximum silence while waiting for a provider-specific readiness signal.
@@ -420,6 +424,8 @@ enum PendingKind {
     JavaNavigationMarkerResolve,
     /// Click-time Java parent or implementation resolution.
     JavaResolveNavigation,
+    /// JDT LS project setting update that applies selected Maven profiles.
+    JdtMavenProfiles,
     /// Shutdown handshake after which the engine sends `exit`.
     Shutdown,
 }
@@ -470,6 +476,7 @@ struct SessionState {
 struct RuntimeSession {
     id: String,
     provider_id: String,
+    jdt_maven_configuration: Option<JdtMavenConfiguration>,
     #[cfg(test)]
     root_uri: String,
     /// Serializes protocol-state commits with complete outbound message batches.
@@ -705,6 +712,40 @@ impl LspEngine {
             self.next_session_id.fetch_add(1, Ordering::Relaxed)
         );
         let workspace_root = PathBuf::from(&request.working_directory);
+        let jdt_maven_configuration = request
+            .maven_context
+            .clone()
+            .map(|context| {
+                crate::project::jdt_configuration(&request.working_directory, context).and_then(
+                    |configuration| {
+                        let project_uris = configuration
+                            .project_paths
+                            .iter()
+                            .map(|path| {
+                                let directory = if path == "." {
+                                    workspace_root.clone()
+                                } else {
+                                    workspace_root.join(path)
+                                };
+                                url::Url::from_directory_path(directory)
+                                    .map(|url| url.to_string())
+                                    .map_err(|_| {
+                                        CoreError::new(
+                                            ErrorCode::InvalidRequest,
+                                            "Maven project path cannot be represented as a URI",
+                                        )
+                                    })
+                            })
+                            .collect::<Result<Vec<_>, _>>()?;
+                        Ok(JdtMavenConfiguration {
+                            settings_path: configuration.settings_path,
+                            profiles: configuration.profiles,
+                            project_uris,
+                        })
+                    },
+                )
+            })
+            .transpose()?;
         let data_root = request
             .cache_directory
             .as_deref()
@@ -790,6 +831,7 @@ impl LspEngine {
         let session = Arc::new(RuntimeSession {
             id: session_id.clone(),
             provider_id: request.provider_id,
+            jdt_maven_configuration,
             #[cfg(test)]
             root_uri: request.root_uri,
             outbound_order: Mutex::new(()),
@@ -1673,7 +1715,9 @@ impl RuntimeSession {
         let mut ready_server_info = None;
         let mut fail_initialize: Option<(String, Option<String>)> = None;
         let mut service_ready = false;
+        let mut apply_maven_context = false;
         let mut fail_service_ready = None;
+        let mut fail_maven_context = None;
         {
             let mut state = self.lock_state()?;
             state.client = reduced.state;
@@ -1927,6 +1971,25 @@ impl RuntimeSession {
                         }
                     }
                 }
+                Some(PendingKind::JdtMavenProfiles) => {
+                    let server_error = value.get("error").map(Value::to_string);
+                    if let Some(detail) = server_error {
+                        fail_maven_context = Some(detail);
+                    } else if !state
+                        .pending
+                        .values()
+                        .any(|pending| pending.kind == PendingKind::JdtMavenProfiles)
+                    {
+                        service_ready = true;
+                        push_log_event(
+                            self,
+                            &mut state,
+                            "info",
+                            "Java language service applied Maven profiles",
+                            None,
+                        );
+                    }
+                }
                 Some(PendingKind::VirtualDocument) => {
                     if let Some(pending) = pending_before.as_ref() {
                         if let Some(operation_id) = &pending.operation_id {
@@ -2007,6 +2070,7 @@ impl RuntimeSession {
                 match readiness.as_ref() {
                     Some(JdtReadinessSignal::Ready) if state.client.initialized => {
                         service_ready = true;
+                        apply_maven_context = true;
                     }
                     Some(JdtReadinessSignal::Failed(detail)) => {
                         fail_service_ready = Some(detail.clone());
@@ -2075,8 +2139,21 @@ impl RuntimeSession {
             self.kill_process();
             return Ok(());
         }
+        if let Some(detail) = fail_maven_context {
+            self.fail(
+                "mavenContextFailed",
+                "serviceReady",
+                "JDT LS could not apply the selected Maven profiles.",
+                Some(detail),
+                None,
+            );
+            self.kill_process();
+            return Ok(());
+        }
         if flush_documents {
-            if let Some(notification) = initialized_notification(&self.provider_id) {
+            if let Some(notification) =
+                initialized_notification(&self.provider_id, self.jdt_maven_configuration.as_ref())
+            {
                 outbound.push(
                     json!({
                         "jsonrpc": "2.0",
@@ -2108,6 +2185,13 @@ impl RuntimeSession {
                 push_features_event(self, &mut state, capabilities);
             }
             return Ok(());
+        }
+        if apply_maven_context {
+            let (profile_requests, profiles_pending) = self.maven_profile_requests()?;
+            if profiles_pending {
+                service_ready = false;
+            }
+            outbound.extend(profile_requests);
         }
         self.send_messages_or_fail(&outbound_order, outbound, "serverResponse")?;
         if service_ready {
@@ -2162,7 +2246,11 @@ impl RuntimeSession {
                     .map(ToString::to_string),
             })
             .collect();
-        let Some(values) = workspace_configuration(&self.provider_id, &items) else {
+        let Some(values) = workspace_configuration(
+            &self.provider_id,
+            &items,
+            self.jdt_maven_configuration.as_ref(),
+        ) else {
             return Ok(None);
         };
         Ok(Some(
@@ -2181,6 +2269,51 @@ impl RuntimeSession {
         ))
     }
 
+    fn maven_profile_requests(&self) -> Result<(Vec<String>, bool), CoreError> {
+        let requests = maven_profile_update_requests(self.jdt_maven_configuration.as_ref());
+        if requests.is_empty() {
+            return Ok((Vec::new(), false));
+        }
+        let mut state = self.lock_state()?;
+        if state
+            .pending
+            .values()
+            .any(|pending| pending.kind == PendingKind::JdtMavenProfiles)
+        {
+            return Ok((Vec::new(), true));
+        }
+        let now = Instant::now();
+        let deadline = now + state.request_timeout;
+        let mut messages = Vec::with_capacity(requests.len());
+        for params in requests {
+            let response =
+                allocate_raw_request(state.client.clone(), "workspace/executeCommand", params)?;
+            let request_id = (response.state.next_request_id - 1).to_string();
+            state.client = response.state;
+            state.pending.insert(
+                request_id,
+                PendingRequest {
+                    kind: PendingKind::JdtMavenProfiles,
+                    operation_id: None,
+                    method: "workspace/executeCommand".to_string(),
+                    document_uri: None,
+                    document_version: None,
+                    created_at: now,
+                    deadline,
+                },
+            );
+            messages.extend(response.messages);
+        }
+        push_log_event(
+            self,
+            &mut state,
+            "info",
+            "Applying Maven profiles to Java projects",
+            Some(format!("projectCount={}", messages.len())),
+        );
+        Ok((messages, true))
+    }
+
     fn flush_queued_documents(&self) -> Result<Vec<String>, CoreError> {
         let mut state = self.lock_state()?;
         flush_queued_documents_locked(&mut state)
@@ -2191,6 +2324,7 @@ impl RuntimeSession {
         let mut cancellations = Vec::new();
         let mut initialize_timeout = false;
         let mut service_ready_timeout = None;
+        let mut maven_context_timeout = false;
         let mut shutdown_timeout = false;
         if let Ok(mut state) = self.lock_state() {
             if state.lifecycle == LspLifecycleState::Initializing
@@ -2201,7 +2335,14 @@ impl RuntimeSession {
                 state.initialize_deadline = None;
                 initialize_timeout = true;
             }
-            if state.lifecycle == LspLifecycleState::Initializing && !initialize_timeout {
+            let applying_maven_context = state
+                .pending
+                .values()
+                .any(|pending| pending.kind == PendingKind::JdtMavenProfiles);
+            if state.lifecycle == LspLifecycleState::Initializing
+                && !initialize_timeout
+                && !applying_maven_context
+            {
                 service_ready_timeout = state
                     .java_preparation
                     .as_mut()
@@ -2253,6 +2394,21 @@ impl RuntimeSession {
                 }
                 cancellations.push(request_id);
             }
+            let expired_maven_requests: Vec<_> = state
+                .pending
+                .iter()
+                .filter(|(_, pending)| {
+                    pending.kind == PendingKind::JdtMavenProfiles && now >= pending.deadline
+                })
+                .map(|(id, _)| id.clone())
+                .collect();
+            if !expired_maven_requests.is_empty() {
+                maven_context_timeout = true;
+                for request_id in expired_maven_requests {
+                    state.pending.remove(&request_id);
+                    state.client.pending_requests.remove(&request_id);
+                }
+            }
             if state.lifecycle == LspLifecycleState::Stopping
                 && state
                     .shutdown_deadline
@@ -2286,6 +2442,15 @@ impl RuntimeSession {
                 "serviceReady",
                 "Java language service project import timed out.",
                 Some(detail),
+                None,
+            );
+            self.kill_process();
+        } else if maven_context_timeout {
+            self.fail(
+                "mavenContextTimeout",
+                "serviceReady",
+                "JDT LS timed out while applying the selected Maven profiles.",
+                None,
                 None,
             );
             self.kill_process();
@@ -3287,6 +3452,7 @@ mod tests {
             jdtls_launch_resources: None,
             cache_directory: None,
             workspace_fingerprint: None,
+            maven_context: None,
             initialize_timeout_milliseconds: 10_000,
             service_ready_idle_timeout_milliseconds: 45_000,
             service_ready_absolute_timeout_milliseconds: 600_000,
@@ -3303,6 +3469,67 @@ mod tests {
         /// Events are drained by every poll, so the harness accumulates them and
         /// tests assert against the whole history.
         events: Vec<LspRuntimeEvent>,
+    }
+
+    struct TemporaryMavenWorkspace {
+        root: PathBuf,
+    }
+
+    impl TemporaryMavenWorkspace {
+        fn recursive(label: &str) -> Self {
+            static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+            let root = std::env::temp_dir().join(format!(
+                "lithe-lsp-{label}-{}-{}",
+                std::process::id(),
+                NEXT_ID.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(root.join("reactor/module-a/nested"))
+                .expect("recursive Maven fixture should be creatable");
+            std::fs::write(
+                root.join("reactor/pom.xml"),
+                r#"<project><artifactId>reactor</artifactId><packaging>pom</packaging><modules><module>module-a</module></modules></project>"#,
+            )
+            .expect("reactor pom should be writable");
+            std::fs::write(
+                root.join("reactor/module-a/pom.xml"),
+                r#"<project><artifactId>module-a</artifactId><packaging>pom</packaging><modules><module>nested</module></modules></project>"#,
+            )
+            .expect("module pom should be writable");
+            std::fs::write(
+                root.join("reactor/module-a/nested/pom.xml"),
+                r#"<project><artifactId>nested</artifactId></project>"#,
+            )
+            .expect("nested module pom should be writable");
+            Self { root }
+        }
+
+        fn configure(&self, request: &mut StartServerRequest) {
+            request.provider_id = "java".to_string();
+            request.root_uri = url::Url::from_directory_path(&self.root)
+                .expect("fixture root should convert to a URI")
+                .to_string();
+            request.working_directory = self.root.to_string_lossy().into_owned();
+            request.cache_directory = Some(self.root.join("cache").to_string_lossy().into_owned());
+            request.maven_context = Some(crate::project::MavenLaunchContextRequest {
+                version: 1,
+                reactor_path: "reactor".to_string(),
+                profiles: vec![
+                    "enterprise".to_string(),
+                    "dev".to_string(),
+                    "enterprise".to_string(),
+                ],
+                settings_path: Some("/local/settings.xml".to_string()),
+                skip_tests: true,
+                maven_executable_path: Some("/local/maven/bin/mvn".to_string()),
+                java_home_path: Some("/local/jdk".to_string()),
+            });
+        }
+    }
+
+    impl Drop for TemporaryMavenWorkspace {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
     }
 
     impl Harness {
@@ -3652,6 +3879,136 @@ mod tests {
             "params": { "type": "ServiceReady", "message": "ServiceReady" }
         }));
         harness.await_state(LspLifecycleState::Ready);
+    }
+
+    #[test]
+    fn java_applies_maven_settings_and_recursive_profiles_before_ready() {
+        let workspace = TemporaryMavenWorkspace::recursive("maven-context-ready");
+        let mut harness = Harness::start(|request| workspace.configure(request));
+        harness.server.complete_initialize(ready_capabilities());
+        assert!(harness
+            .server
+            .await_notification("workspace/didChangeConfiguration"));
+
+        let configuration = harness
+            .notification("workspace/didChangeConfiguration")
+            .expect("Java configuration notification should be sent");
+        assert_eq!(
+            configuration["params"]["settings"]["java"]["configuration"]["maven"]["userSettings"],
+            "/local/settings.xml"
+        );
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "language/status",
+            "params": { "type": "ServiceReady" }
+        }));
+
+        let request_ids: Vec<_> = (0..3)
+            .map(|index| {
+                harness
+                    .server
+                    .await_request_at("workspace/executeCommand", index)
+                    .expect("every recursive Maven project should receive its profile update")
+            })
+            .collect();
+        let updates: Vec<_> = harness
+            .server
+            .messages()
+            .into_iter()
+            .filter(|message| {
+                message.get("method").and_then(Value::as_str) == Some("workspace/executeCommand")
+            })
+            .collect();
+        let expected_uris = ["reactor/", "reactor/module-a/", "reactor/module-a/nested/"];
+        assert_eq!(updates.len(), expected_uris.len());
+        for (update, expected_uri) in updates.iter().zip(expected_uris) {
+            let project_uri = update["params"]["arguments"][0]
+                .as_str()
+                .expect("the project URI should be a string");
+            assert!(
+                project_uri.ends_with(expected_uri),
+                "unexpected URI: {project_uri}"
+            );
+            assert_eq!(
+                update["params"]["arguments"][1]["org.eclipse.m2e.core.selectedProfiles"],
+                "dev,enterprise"
+            );
+        }
+
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "language/status",
+            "params": { "type": "ServiceReady" }
+        }));
+        for request_id in &request_ids[..2] {
+            harness.server.send(json!({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": null
+            }));
+        }
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "test/profile-response-barrier"
+        }));
+        harness
+            .await_event(|event| event.message.as_deref() == Some("test/profile-response-barrier"));
+        assert_eq!(
+            harness
+                .server
+                .messages()
+                .iter()
+                .filter(|message| {
+                    message.get("method").and_then(Value::as_str)
+                        == Some("workspace/executeCommand")
+                })
+                .count(),
+            3,
+            "a duplicate readiness notification must not enqueue duplicate profile updates"
+        );
+        assert_eq!(harness.snapshot().state, LspLifecycleState::Initializing);
+
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "id": request_ids[2],
+            "result": null
+        }));
+        harness.await_state(LspLifecycleState::Ready);
+    }
+
+    #[test]
+    fn java_profile_update_error_fails_instead_of_using_a_stale_model() {
+        let workspace = TemporaryMavenWorkspace::recursive("maven-context-failure");
+        let mut harness = Harness::start(|request| workspace.configure(request));
+        harness.server.complete_initialize(ready_capabilities());
+        assert!(harness.server.await_notification("initialized"));
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "method": "language/status",
+            "params": { "type": "ServiceReady" }
+        }));
+        let request_id = harness
+            .server
+            .await_request("workspace/executeCommand")
+            .expect("the Maven profile request should be sent");
+        harness.server.send(json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": { "code": -32603, "message": "Maven project update failed" }
+        }));
+        harness.await_state(LspLifecycleState::Failed);
+
+        let failure = harness
+            .events
+            .iter()
+            .find_map(|event| event.error.as_ref())
+            .expect("the Maven profile failure should be reported");
+        assert_eq!(failure.code, "mavenContextFailed");
+        assert_eq!(failure.stage, "serviceReady");
+        assert!(failure
+            .underlying_message
+            .as_deref()
+            .is_some_and(|detail| detail.contains("Maven project update failed")));
     }
 
     #[test]
@@ -5282,6 +5639,7 @@ public class Main {
                 jdtls_launch_resources: None,
                 cache_directory: Some(root.join("cache").to_string_lossy().into_owned()),
                 workspace_fingerprint: None,
+                maven_context: None,
                 initialize_timeout_milliseconds: 90_000,
                 service_ready_idle_timeout_milliseconds: 45_000,
                 service_ready_absolute_timeout_milliseconds: 600_000,
@@ -6008,6 +6366,7 @@ public class Main {
             jdtls_launch_resources: None,
             cache_directory: None,
             workspace_fingerprint: None,
+            maven_context: None,
             initialize_timeout_milliseconds: 1,
             service_ready_idle_timeout_milliseconds: 1,
             service_ready_absolute_timeout_milliseconds: 1,

--- a/rust/lithe-core/src/lsp/languages/jdt.rs
+++ b/rust/lithe-core/src/lsp/languages/jdt.rs
@@ -89,6 +89,17 @@ pub(crate) struct JdtStartContext {
     pub workspace_fingerprint: Option<String>,
 }
 
+/// Maven import settings already validated by the shared project domain.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct JdtMavenConfiguration {
+    /// Optional machine-local Maven settings file consumed by JDT LS.
+    pub settings_path: Option<String>,
+    /// Sorted, de-duplicated Maven profile IDs selected for this workspace.
+    pub profiles: Vec<String>,
+    /// Deterministically ordered reactor and recursive-module directory URIs.
+    pub project_uris: Vec<String>,
+}
+
 /// Platform-resolved files required to launch JDT LS without a shell wrapper.
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -242,6 +253,7 @@ pub(crate) fn adapt_initialization_options(
 pub(crate) fn workspace_configuration(
     provider_id: &str,
     items: &[WorkspaceConfigurationItem],
+    maven_configuration: Option<&JdtMavenConfiguration>,
 ) -> Option<Vec<Value>> {
     if !is_java_provider(provider_id) {
         return None;
@@ -249,19 +261,47 @@ pub(crate) fn workspace_configuration(
     Some(
         items
             .iter()
-            .map(|item| java_configuration_for_section(item.section.as_deref()))
+            .map(|item| {
+                java_configuration_for_section(item.section.as_deref(), maven_configuration)
+            })
             .collect(),
     )
 }
 
 /// Notification the engine sends after the generic `initialized` handshake.
-pub(crate) fn initialized_notification(provider_id: &str) -> Option<ProviderNotification> {
+pub(crate) fn initialized_notification(
+    provider_id: &str,
+    maven_configuration: Option<&JdtMavenConfiguration>,
+) -> Option<ProviderNotification> {
     is_java_provider(provider_id).then(|| ProviderNotification {
         method: DID_CHANGE_CONFIGURATION_METHOD.to_string(),
         params: json!({
-            "settings": java_settings()
+            "settings": java_settings(maven_configuration)
         }),
     })
+}
+
+/// Commands that apply the selected Maven profiles to every imported project.
+pub(crate) fn maven_profile_update_requests(
+    configuration: Option<&JdtMavenConfiguration>,
+) -> Vec<Value> {
+    let Some(configuration) = configuration else {
+        return Vec::new();
+    };
+    let profiles = configuration.profiles.join(",");
+    configuration
+        .project_uris
+        .iter()
+        .map(|uri| {
+            json!({
+                "command": "java.project.updateSettings",
+                "arguments": [
+                    uri,
+                    { "org.eclipse.m2e.core.selectedProfiles": profiles }
+                ]
+            })
+        })
+        .collect()
 }
 
 /// Returns whether the provider has a readiness phase after standard LSP
@@ -645,8 +685,8 @@ fn without_wrapper_owned_arguments(arguments: &[String]) -> Vec<String> {
     retained
 }
 
-fn java_settings() -> Value {
-    json!({
+fn java_settings(maven_configuration: Option<&JdtMavenConfiguration>) -> Value {
+    let mut settings = json!({
         "java": {
             "eclipse": {
                 "downloadSources": false
@@ -671,33 +711,22 @@ fn java_settings() -> Value {
                 "enabled": true
             }
         }
-    })
+    });
+    if let Some(settings_path) = maven_configuration.and_then(|value| value.settings_path.as_ref())
+    {
+        settings["java"]["configuration"]["maven"] = json!({
+            "userSettings": settings_path
+        });
+    }
+    settings
 }
 
-fn java_configuration_for_section(section: Option<&str>) -> Value {
+fn java_configuration_for_section(
+    section: Option<&str>,
+    maven_configuration: Option<&JdtMavenConfiguration>,
+) -> Value {
     match section {
-        Some("java") => json!({
-            "eclipse": {
-                "downloadSources": false
-            },
-            "maven": {
-                "downloadSources": false
-            },
-            "configuration": {
-                "updateBuildConfiguration": "automatic"
-            },
-            "inlayHints": {
-                "parameterNames": {
-                    "enabled": "all"
-                }
-            },
-            "implementationsCodeLens": {
-                "enabled": true
-            },
-            "referencesCodeLens": {
-                "enabled": true
-            }
-        }),
+        Some("java") => java_settings(maven_configuration)["java"].clone(),
         Some("java.inlayHints") => json!({
             "parameterNames": {
                 "enabled": "all"
@@ -709,8 +738,17 @@ fn java_configuration_for_section(section: Option<&str>) -> Value {
         Some("java.eclipse.downloadSources") => json!(false),
         Some("java.maven") => json!({ "downloadSources": false }),
         Some("java.maven.downloadSources") => json!(false),
-        Some("java.configuration") => json!({ "updateBuildConfiguration": "automatic" }),
+        Some("java.configuration") => {
+            java_settings(maven_configuration)["java"]["configuration"].clone()
+        }
         Some("java.configuration.updateBuildConfiguration") => json!("automatic"),
+        Some("java.configuration.maven") => maven_configuration
+            .and_then(|value| value.settings_path.as_ref())
+            .map(|path| json!({ "userSettings": path }))
+            .unwrap_or(Value::Null),
+        Some("java.configuration.maven.userSettings") => maven_configuration
+            .and_then(|value| value.settings_path.as_ref())
+            .map_or(Value::Null, |path| json!(path)),
         Some("java.implementationsCodeLens") => json!({ "enabled": true }),
         Some("java.implementationsCodeLens.enabled") => json!(true),
         Some("java.referencesCodeLens") => json!({ "enabled": true }),
@@ -1103,8 +1141,8 @@ mod tests {
 
         assert_eq!(adapted.arguments, context.arguments);
         assert_eq!(adapted.data_directory, None);
-        assert!(workspace_configuration("rust", &[]).is_none());
-        assert!(initialized_notification("rust").is_none());
+        assert!(workspace_configuration("rust", &[], None).is_none());
+        assert!(initialized_notification("rust", None).is_none());
         assert!(virtual_source_resolve_params("rust", "jdt://contents/A.class").is_none());
         assert_eq!(
             adapt_initialization_options("rust", Some(json!({ "custom": true }))),
@@ -1162,7 +1200,7 @@ mod tests {
             scope_uri: Some("file:///workspace/project".to_string()),
             section: Some(section.to_string()),
         });
-        let values = workspace_configuration("java", &items).unwrap();
+        let values = workspace_configuration("java", &items, None).unwrap();
 
         assert_eq!(values[0]["inlayHints"]["parameterNames"]["enabled"], "all");
         assert_eq!(values[0]["eclipse"]["downloadSources"], false);
@@ -1183,7 +1221,7 @@ mod tests {
 
     #[test]
     fn java_initialized_notification_publishes_inlay_settings() {
-        let notification = initialized_notification("JAVA").unwrap();
+        let notification = initialized_notification("JAVA", None).unwrap();
 
         assert_eq!(notification.method, "workspace/didChangeConfiguration");
         assert_eq!(
@@ -1205,6 +1243,70 @@ mod tests {
         assert_eq!(
             notification.params["settings"]["java"]["referencesCodeLens"]["enabled"],
             true
+        );
+    }
+
+    #[test]
+    fn java_configuration_and_profile_updates_consume_the_maven_context() {
+        let configuration = JdtMavenConfiguration {
+            settings_path: Some("/local/settings.xml".to_string()),
+            profiles: vec!["dev".to_string(), "enterprise".to_string()],
+            project_uris: vec![
+                "file:///workspace/reactor/".to_string(),
+                "file:///workspace/reactor/module-a/".to_string(),
+                "file:///workspace/reactor/module-a/nested/".to_string(),
+            ],
+        };
+        let items = [
+            "java",
+            "java.configuration",
+            "java.configuration.maven",
+            "java.configuration.maven.userSettings",
+        ]
+        .map(|section| WorkspaceConfigurationItem {
+            scope_uri: Some("file:///workspace/reactor/".to_string()),
+            section: Some(section.to_string()),
+        });
+
+        let values = workspace_configuration("java", &items, Some(&configuration)).unwrap();
+        assert_eq!(
+            values[0]["configuration"]["maven"]["userSettings"],
+            "/local/settings.xml"
+        );
+        assert_eq!(values[1]["maven"]["userSettings"], "/local/settings.xml");
+        assert_eq!(values[2]["userSettings"], "/local/settings.xml");
+        assert_eq!(values[3], "/local/settings.xml");
+
+        let notification = initialized_notification("java", Some(&configuration)).unwrap();
+        assert_eq!(
+            notification.params["settings"]["java"]["configuration"]["maven"]["userSettings"],
+            "/local/settings.xml"
+        );
+        assert_eq!(
+            maven_profile_update_requests(Some(&configuration)),
+            vec![
+                json!({
+                    "command": "java.project.updateSettings",
+                    "arguments": [
+                        "file:///workspace/reactor/",
+                        { "org.eclipse.m2e.core.selectedProfiles": "dev,enterprise" }
+                    ]
+                }),
+                json!({
+                    "command": "java.project.updateSettings",
+                    "arguments": [
+                        "file:///workspace/reactor/module-a/",
+                        { "org.eclipse.m2e.core.selectedProfiles": "dev,enterprise" }
+                    ]
+                }),
+                json!({
+                    "command": "java.project.updateSettings",
+                    "arguments": [
+                        "file:///workspace/reactor/module-a/nested/",
+                        { "org.eclipse.m2e.core.selectedProfiles": "dev,enterprise" }
+                    ]
+                }),
+            ]
         );
     }
 

--- a/rust/lithe-core/src/project/maven.rs
+++ b/rust/lithe-core/src/project/maven.rs
@@ -87,7 +87,13 @@ struct ValidatedMavenContext {
 /// Produces a deterministic Maven plan without resolving a native executable.
 pub fn launch_plan(request: MavenLaunchPlanRequest) -> Result<MavenLaunchPlanResponse, CoreError> {
     let arguments = normalized_tool_window_arguments(request.goals)?;
-    launch_plan_with_arguments(request.root, request.context, request.module, arguments)
+    launch_plan_with_arguments(
+        request.root,
+        request.context,
+        request.module,
+        arguments,
+        true,
+    )
 }
 
 /// Applies a validated Maven context to Core-owned run/debug arguments.
@@ -100,6 +106,7 @@ pub(crate) fn launch_plan_with_arguments(
     context: MavenLaunchContextRequest,
     module: Option<String>,
     trailing_arguments: Vec<String>,
+    also_make: bool,
 ) -> Result<MavenLaunchPlanResponse, CoreError> {
     let validated = validated_maven_context(&root, context)?;
 
@@ -125,6 +132,7 @@ pub(crate) fn launch_plan_with_arguments(
         &validated.profiles,
         validated.settings_path.as_deref(),
         module.as_deref(),
+        also_make,
         validated.skip_tests,
         &trailing_arguments,
     );
@@ -223,6 +231,7 @@ pub(crate) fn maven_arguments(
     profiles: &[String],
     settings_path: Option<&str>,
     module: Option<&str>,
+    also_make: bool,
     skip_tests: bool,
     goals: &[String],
 ) -> Vec<String> {
@@ -234,7 +243,10 @@ pub(crate) fn maven_arguments(
         arguments.extend(["-s".to_string(), settings_path.to_string()]);
     }
     if let Some(module) = module.filter(|value| *value != ".") {
-        arguments.extend(["-pl".to_string(), module.to_string(), "-am".to_string()]);
+        arguments.extend(["-pl".to_string(), module.to_string()]);
+        if also_make {
+            arguments.push("-am".to_string());
+        }
     }
     if skip_tests {
         arguments.push("-DskipTests".to_string());

--- a/rust/lithe-core/src/project/maven.rs
+++ b/rust/lithe-core/src/project/maven.rs
@@ -2,13 +2,14 @@
 
 use crate::protocol::{CoreError, ErrorCode};
 use crate::protocol::{
-    MavenDiagnosticResponse, MavenDiagnosticsResponse, MavenModuleResponse, MavenProfileResponse,
-    MavenScanResponse,
+    MavenDiagnosticResponse, MavenDiagnosticsResponse, MavenLaunchExecutableResponse,
+    MavenLaunchPlanResponse, MavenModuleResponse, MavenProfileResponse, MavenScanResponse,
 };
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use regex::Regex;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -28,6 +29,319 @@ pub struct MavenScanRequest {
 pub struct MavenDiagnosticsRequest {
     pub root: String,
     pub output: String,
+}
+
+const MAVEN_CONTEXT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+/// Versioned Maven defaults merged by the platform before launch planning.
+pub struct MavenLaunchContextRequest {
+    pub version: u32,
+    pub reactor_path: String,
+    #[serde(default)]
+    pub profiles: Vec<String>,
+    #[serde(default)]
+    pub settings_path: Option<String>,
+    #[serde(default)]
+    pub skip_tests: bool,
+    #[serde(default)]
+    pub maven_executable_path: Option<String>,
+    #[serde(default)]
+    pub java_home_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+/// Ordered Maven invocation tokens selected by a tool-window consumer.
+///
+/// The first token is a lifecycle or custom goal. Remaining tokens are passed
+/// directly to Maven as arguments without shell interpretation.
+pub struct MavenLaunchPlanRequest {
+    pub root: String,
+    pub context: MavenLaunchContextRequest,
+    #[serde(default)]
+    pub module: Option<String>,
+    pub goals: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+/// Validated Maven import settings consumed by the JDT LS adapter.
+pub(crate) struct MavenJdtConfiguration {
+    pub profiles: Vec<String>,
+    pub settings_path: Option<String>,
+    /// Workspace-relative reactor and recursive module directories.
+    pub project_paths: Vec<String>,
+}
+
+struct ValidatedMavenContext {
+    reactor_path: String,
+    canonical_reactor: PathBuf,
+    profiles: Vec<String>,
+    settings_path: Option<String>,
+    skip_tests: bool,
+    maven_executable_path: Option<String>,
+    java_home_path: Option<String>,
+}
+
+/// Produces a deterministic Maven plan without resolving a native executable.
+pub fn launch_plan(request: MavenLaunchPlanRequest) -> Result<MavenLaunchPlanResponse, CoreError> {
+    let arguments = normalized_tool_window_arguments(request.goals)?;
+    launch_plan_with_arguments(request.root, request.context, request.module, arguments)
+}
+
+/// Applies a validated Maven context to Core-owned run/debug arguments.
+///
+/// Unlike the public tool-window command, the trailing arguments may contain
+/// properties such as `-Dexec.mainClass`: those values were generated and
+/// validated by the run-configuration domain rather than entered as goals.
+pub(crate) fn launch_plan_with_arguments(
+    root: String,
+    context: MavenLaunchContextRequest,
+    module: Option<String>,
+    trailing_arguments: Vec<String>,
+) -> Result<MavenLaunchPlanResponse, CoreError> {
+    let validated = validated_maven_context(&root, context)?;
+
+    let module = module
+        .as_deref()
+        .map(|value| normalized_project_path(value, "Maven module"))
+        .transpose()?;
+    if let Some(module) = module.as_deref().filter(|value| *value != ".") {
+        let declared = declared_modules(&validated.canonical_reactor)?;
+        if !declared
+            .iter()
+            .any(|candidate| candidate.relative_path == module)
+        {
+            return Err(CoreError::new(
+                ErrorCode::InvalidRequest,
+                "Maven module is not part of the selected reactor",
+            )
+            .with_details(module));
+        }
+    }
+
+    let arguments = maven_arguments(
+        &validated.profiles,
+        validated.settings_path.as_deref(),
+        module.as_deref(),
+        validated.skip_tests,
+        &trailing_arguments,
+    );
+    let configuration_fingerprint = maven_context_fingerprint(
+        &validated.reactor_path,
+        &validated.profiles,
+        validated.settings_path.as_deref(),
+        validated.skip_tests,
+        validated.maven_executable_path.as_deref(),
+        validated.java_home_path.as_deref(),
+    );
+
+    Ok(MavenLaunchPlanResponse {
+        version: MAVEN_CONTEXT_VERSION,
+        executable: MavenLaunchExecutableResponse {
+            toolchain: "project-maven".to_string(),
+        },
+        arguments,
+        working_directory: validated.reactor_path,
+        configuration_fingerprint,
+    })
+}
+
+/// Resolves the same Maven profiles and settings for JDT LS project import.
+pub(crate) fn jdt_configuration(
+    root: &str,
+    context: MavenLaunchContextRequest,
+) -> Result<MavenJdtConfiguration, CoreError> {
+    let validated = validated_maven_context(root, context)?;
+    let project_paths = declared_modules(&validated.canonical_reactor)?
+        .into_iter()
+        .map(|module| {
+            if module.relative_path == "." {
+                validated.reactor_path.clone()
+            } else if validated.reactor_path == "." {
+                module.relative_path
+            } else {
+                format!("{}/{}", validated.reactor_path, module.relative_path)
+            }
+        })
+        .collect();
+    Ok(MavenJdtConfiguration {
+        profiles: validated.profiles,
+        settings_path: validated.settings_path,
+        project_paths,
+    })
+}
+
+fn validated_maven_context(
+    root: &str,
+    context: MavenLaunchContextRequest,
+) -> Result<ValidatedMavenContext, CoreError> {
+    let workspace_root = existing_root(root)?;
+    if context.version != MAVEN_CONTEXT_VERSION {
+        return Err(CoreError::new(
+            ErrorCode::InvalidRequest,
+            "Unsupported Maven context version",
+        )
+        .with_details(context.version.to_string()));
+    }
+
+    let reactor_path = normalized_project_path(&context.reactor_path, "Maven reactor")?;
+    let reactor_root = if reactor_path == "." {
+        workspace_root.clone()
+    } else {
+        workspace_root.join(&reactor_path)
+    };
+    let canonical_reactor = reactor_root.canonicalize().map_err(|_| {
+        CoreError::new(ErrorCode::WorkspaceNotFound, "Maven reactor does not exist")
+    })?;
+    if !canonical_reactor.starts_with(&workspace_root)
+        || !canonical_reactor.join("pom.xml").is_file()
+    {
+        return Err(CoreError::new(
+            ErrorCode::InvalidRequest,
+            "Maven reactor must contain pom.xml inside the workspace",
+        ));
+    }
+
+    Ok(ValidatedMavenContext {
+        reactor_path,
+        canonical_reactor,
+        profiles: normalized_profiles(context.profiles)?,
+        settings_path: normalized_local_path(context.settings_path, "Maven settings")?,
+        skip_tests: context.skip_tests,
+        maven_executable_path: normalized_local_path(
+            context.maven_executable_path,
+            "Maven executable",
+        )?,
+        java_home_path: normalized_local_path(context.java_home_path, "Maven JDK")?,
+    })
+}
+
+/// Builds the shared Maven option prefix used by tool-window and run plans.
+pub(crate) fn maven_arguments(
+    profiles: &[String],
+    settings_path: Option<&str>,
+    module: Option<&str>,
+    skip_tests: bool,
+    goals: &[String],
+) -> Vec<String> {
+    let mut arguments = vec!["-B".to_string(), "-ntp".to_string()];
+    if !profiles.is_empty() {
+        arguments.extend(["-P".to_string(), profiles.join(",")]);
+    }
+    if let Some(settings_path) = settings_path {
+        arguments.extend(["-s".to_string(), settings_path.to_string()]);
+    }
+    if let Some(module) = module.filter(|value| *value != ".") {
+        arguments.extend(["-pl".to_string(), module.to_string(), "-am".to_string()]);
+    }
+    if skip_tests {
+        arguments.push("-DskipTests".to_string());
+    }
+    arguments.extend(goals.iter().cloned());
+    arguments
+}
+
+fn normalized_profiles(values: Vec<String>) -> Result<Vec<String>, CoreError> {
+    let mut profiles = BTreeSet::new();
+    for value in values {
+        let profile = value.trim();
+        if profile.is_empty() || profile.contains(',') || profile.chars().any(char::is_control) {
+            return Err(CoreError::new(
+                ErrorCode::InvalidRequest,
+                "Maven profile ID is invalid",
+            ));
+        }
+        profiles.insert(profile.to_string());
+    }
+    Ok(profiles.into_iter().collect())
+}
+
+fn normalized_tool_window_arguments(values: Vec<String>) -> Result<Vec<String>, CoreError> {
+    if values.is_empty() {
+        return Err(CoreError::new(
+            ErrorCode::InvalidRequest,
+            "At least one Maven goal is required",
+        ));
+    }
+
+    let mut arguments = Vec::with_capacity(values.len());
+    for (index, value) in values.into_iter().enumerate() {
+        let argument = value.trim();
+        if argument.is_empty() || argument.chars().any(char::is_control) {
+            return Err(
+                CoreError::new(ErrorCode::InvalidRequest, "Maven argument is invalid")
+                    .with_details(argument),
+            );
+        }
+        if index == 0 {
+            let valid_goal = !argument.starts_with('-')
+                && argument.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || ".:_-".contains(character)
+                });
+            if !valid_goal {
+                return Err(
+                    CoreError::new(ErrorCode::InvalidRequest, "Maven goal is invalid")
+                        .with_details(argument),
+                );
+            }
+        }
+        arguments.push(argument.to_string());
+    }
+    Ok(arguments)
+}
+
+fn normalized_project_path(value: &str, label: &str) -> Result<String, CoreError> {
+    let trimmed = value.trim();
+    if trimmed == "." {
+        return Ok(".".to_string());
+    }
+    normalize_relative_path(trimmed).ok_or_else(|| {
+        CoreError::new(
+            ErrorCode::InvalidRequest,
+            format!("{label} path is invalid"),
+        )
+    })
+}
+
+fn normalized_local_path(value: Option<String>, label: &str) -> Result<Option<String>, CoreError> {
+    let Some(value) = value else { return Ok(None) };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.chars().any(char::is_control) {
+        return Err(CoreError::new(
+            ErrorCode::InvalidRequest,
+            format!("{label} path is invalid"),
+        ));
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+fn maven_context_fingerprint(
+    reactor_path: &str,
+    profiles: &[String],
+    settings_path: Option<&str>,
+    skip_tests: bool,
+    maven_executable_path: Option<&str>,
+    java_home_path: Option<&str>,
+) -> String {
+    let mut digest = Sha256::new();
+    for value in [
+        MAVEN_CONTEXT_VERSION.to_string(),
+        reactor_path.to_string(),
+        profiles.join(","),
+        settings_path.unwrap_or_default().to_string(),
+        skip_tests.to_string(),
+        maven_executable_path.unwrap_or_default().to_string(),
+        java_home_path.unwrap_or_default().to_string(),
+    ] {
+        digest.update(value.as_bytes());
+        digest.update([0]);
+    }
+    format!("sha256:{:x}", digest.finalize())
 }
 
 #[derive(Debug, Default)]

--- a/rust/lithe-core/src/protocol/command.rs
+++ b/rust/lithe-core/src/protocol/command.rs
@@ -79,6 +79,8 @@ pub enum CoreCommand {
     HistoryDelete,
     /// Inspects a declared Maven reactor (`maven.scan`).
     MavenScan,
+    /// Produces a deterministic Maven invocation (`maven.launchPlan`).
+    MavenLaunchPlan,
     /// Normalizes diagnostics from Maven output (`maven.diagnostics`).
     MavenDiagnostics,
     /// Renders and sanitizes shared Markdown (`markdown.render`).
@@ -227,6 +229,7 @@ impl CoreCommand {
             "history.rename" => Some(Self::HistoryRename),
             "history.delete" => Some(Self::HistoryDelete),
             "maven.scan" => Some(Self::MavenScan),
+            "maven.launchPlan" => Some(Self::MavenLaunchPlan),
             "maven.diagnostics" => Some(Self::MavenDiagnostics),
             "markdown.render" => Some(Self::MarkdownRender),
             "lsp.applyTextEdits" => Some(Self::LspApplyTextEdits),

--- a/rust/lithe-core/src/protocol/contracts.rs
+++ b/rust/lithe-core/src/protocol/contracts.rs
@@ -193,6 +193,24 @@ pub struct MavenScanResponse {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+/// Platform-neutral executable reference returned by Maven launch planning.
+pub struct MavenLaunchExecutableResponse {
+    pub toolchain: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+/// Deterministic Maven invocation consumed by native process adapters.
+pub struct MavenLaunchPlanResponse {
+    pub version: u32,
+    pub executable: MavenLaunchExecutableResponse,
+    pub arguments: Vec<String>,
+    pub working_directory: String,
+    pub configuration_fingerprint: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 /// One normalized issue parsed from Maven process output.
 pub struct MavenDiagnosticResponse {
     pub path: String,

--- a/rust/lithe-core/src/runtime/dispatcher.rs
+++ b/rust/lithe-core/src/runtime/dispatcher.rs
@@ -451,6 +451,24 @@ fn execute(request: &str) -> CoreResponse {
             ),
             Err(error) => CoreResponse::failure(id, error),
         },
+        CoreCommand::MavenLaunchPlan => {
+            match serde_json::from_value::<crate::project::MavenLaunchPlanRequest>(parsed.payload)
+                .map_err(|error| {
+                    CoreError::new(
+                        ErrorCode::InvalidRequest,
+                        "Invalid Maven launch-plan request",
+                    )
+                    .with_details(error.to_string())
+                })
+                .and_then(crate::project::launch_plan)
+            {
+                Ok(data) => CoreResponse::success(
+                    id,
+                    serde_json::to_value(data).expect("Maven launch plan should encode"),
+                ),
+                Err(error) => CoreResponse::failure(id, error),
+            }
+        }
         CoreCommand::MavenDiagnostics => {
             match serde_json::from_value::<MavenDiagnosticsRequest>(parsed.payload)
                 .map_err(|error| {

--- a/rust/lithe-core/src/tests/languages.rs
+++ b/rust/lithe-core/src/tests/languages.rs
@@ -190,6 +190,101 @@ fn maven_scan_returns_recursive_shared_project_model() {
 }
 
 #[test]
+fn maven_launch_plan_matches_the_shared_compatibility_fixture() {
+    let fixture: Value = serde_json::from_str(include_str!(
+        "../../../../shared/fixtures/maven/launch-plan-v1.json"
+    ))
+    .expect("Maven launch-plan fixture should be valid JSON");
+    let root = temporary_root("maven-launch-plan");
+    fs::create_dir_all(root.join("projects/demo/service-api"))
+        .expect("nested Maven reactor should be creatable");
+    fs::write(
+        root.join("projects/demo/pom.xml"),
+        r#"<project><artifactId>demo</artifactId><packaging>pom</packaging><modules><module>service-api</module></modules></project>"#,
+    )
+    .expect("reactor pom should be writable");
+    fs::write(
+        root.join("projects/demo/service-api/pom.xml"),
+        r#"<project><artifactId>service-api</artifactId></project>"#,
+    )
+    .expect("module pom should be writable");
+    fs::write(
+        root.join("pom.xml"),
+        r#"<project><artifactId>root</artifactId></project>"#,
+    )
+    .expect("root pom should be writable");
+    fs::create_dir_all(root.join(".mvn")).expect("Maven config directory should be creatable");
+    fs::write(root.join(".mvn/maven.config"), "-DfromConfig=true\n")
+        .expect("Maven config should be writable");
+
+    for case in fixture["cases"]
+        .as_array()
+        .expect("Maven launch-plan fixture should contain cases")
+    {
+        let request = serde_json::json!({
+            "id": case["name"],
+            "command": "maven.launchPlan",
+            "payload": {
+                "root": root,
+                "context": case["context"],
+                "module": case["module"],
+                "goals": case["goals"]
+            }
+        });
+        let response: Value = serde_json::from_str(&execute_json(&request.to_string()))
+            .expect("Maven launch-plan response should be JSON");
+
+        assert_eq!(response["ok"], true, "case {}: {response}", case["name"]);
+        assert_eq!(response["data"], case["expected"], "case {}", case["name"]);
+        assert!(!response["data"]["arguments"]
+            .as_array()
+            .expect("arguments should be an array")
+            .iter()
+            .any(|argument| argument == "-DfromConfig=true"));
+    }
+    fs::remove_dir_all(root).expect("Maven launch-plan fixture should be removable");
+}
+
+#[test]
+fn maven_launch_plan_rejects_unknown_modules_and_invalid_invocation_tokens() {
+    let root = temporary_root("maven-launch-invalid");
+    fs::create_dir_all(&root).expect("invalid Maven fixture should be creatable");
+    fs::write(
+        root.join("pom.xml"),
+        r#"<project><artifactId>demo</artifactId></project>"#,
+    )
+    .expect("pom should be writable");
+    for (name, module, goals) in [
+        ("unknown-module", Some("missing"), vec!["verify"]),
+        ("missing-goal", None, vec!["-q", "-DskipTests"]),
+        ("invalid-goal", None, vec!["verify;", "-q"]),
+        (
+            "control-character",
+            None,
+            vec!["verify", "-Dvalue=line\nbreak"],
+        ),
+    ] {
+        let response: Value = serde_json::from_str(&execute_json(
+            &serde_json::json!({
+                "id": name,
+                "command": "maven.launchPlan",
+                "payload": {
+                    "root": root,
+                    "context": {"version": 1, "reactorPath": "."},
+                    "module": module,
+                    "goals": goals
+                }
+            })
+            .to_string(),
+        ))
+        .expect("invalid Maven response should be JSON");
+        assert_eq!(response["ok"], false, "case {name}: {response}");
+        assert_eq!(response["error"]["code"], "invalid_request");
+    }
+    fs::remove_dir_all(root).expect("invalid Maven fixture should be removable");
+}
+
+#[test]
 fn maven_scan_discovers_a_deterministic_project_below_the_workspace() {
     let root = temporary_root("nested-maven");
     fs::create_dir_all(root.join("apps-a/module-a")).expect("first project should be creatable");

--- a/rust/lithe-core/src/tests/run_configuration.rs
+++ b/rust/lithe-core/src/tests/run_configuration.rs
@@ -240,7 +240,7 @@ fn run_configuration_generation_uses_a_maven_project_below_the_workspace() {
     assert_eq!(plan["ok"], true, "{plan}");
     assert_eq!(plan["data"]["workingDirectory"], "projects/demo");
     assert_eq!(
-        &plan["data"]["arguments"].as_array().unwrap()[..12],
+        &plan["data"]["arguments"].as_array().unwrap()[..11],
         [
             "-B",
             "-ntp",
@@ -250,20 +250,29 @@ fn run_configuration_generation_uses_a_maven_project_below_the_workspace() {
             "/local/settings.xml",
             "-pl",
             "service",
-            "-am",
             "-DskipTests",
             "-Dspring-boot.run.main-class=com.example.App",
             "spring-boot:run"
         ]
     );
+    assert!(!plan["data"]["arguments"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|argument| argument == "-am"));
 
+    fs::create_dir_all(root.join("custom-run/service")).unwrap();
     fs::write(
         root.join(".lithe/run/configurations.json"),
         serde_json::json!({
             "version": 2,
             "configurations": [{
                 "id": service["id"],
-                "extensions": {"maven": {"profiles": ["release"]}}
+                "cwd": "custom-run",
+                "extensions": {"maven": {
+                    "profiles": ["release"],
+                    "skipTests": false
+                }}
             }]
         })
         .to_string(),
@@ -280,7 +289,7 @@ fn run_configuration_generation_uses_a_maven_project_below_the_workspace() {
                     "version": 1,
                     "reactorPath": "projects/demo",
                     "profiles": ["dev", "qa"],
-                    "skipTests": false
+                    "skipTests": true
                 }
             }
         })
@@ -288,10 +297,16 @@ fn run_configuration_generation_uses_a_maven_project_below_the_workspace() {
     ))
     .unwrap();
     assert_eq!(overridden_plan["ok"], true, "{overridden_plan}");
+    assert_eq!(overridden_plan["data"]["workingDirectory"], "custom-run");
     assert_eq!(
         &overridden_plan["data"]["arguments"].as_array().unwrap()[..4],
         ["-B", "-ntp", "-P", "release"]
     );
+    assert!(!overridden_plan["data"]["arguments"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|argument| argument == "-am" || argument == "-DskipTests"));
 
     let java_plan: Value = serde_json::from_str(&execute_json(
         &serde_json::json!({
@@ -1269,7 +1284,8 @@ fn run_configuration_mutations_are_shared_and_validated() {
                 "workingDirectory": ".",
                 "jvmArguments": "\"-Dlabel=hello world\" -Xmx2g",
                 "programArguments": "--dev",
-                "mavenProfiles": ["dev"]
+                "mavenProfiles": ["dev"],
+                "mavenSkipTests": false
             }
         })
         .to_string(),
@@ -1282,9 +1298,40 @@ fn run_configuration_mutations_are_shared_and_validated() {
         updated_document["configurations"][0]["extensions"]["maven"]["jvmArguments"],
         serde_json::json!(["-Dlabel=hello world", "-Xmx2g"])
     );
+    assert_eq!(
+        updated_document["configurations"][0]["extensions"]["maven"]["skipTests"],
+        false
+    );
     fs::write(
         root.join(".lithe/run/configurations.json"),
         updated["data"]["document"].as_str().unwrap(),
+    )
+    .unwrap();
+
+    let inherited: Value = serde_json::from_str(&execute_json(
+        &serde_json::json!({
+            "id": "clear-inherited-options",
+            "command": "runConfig.updateOptions",
+            "payload": {
+                "root": root,
+                "scope": "project",
+                "configurationId": "current-file",
+                "jvmArguments": "-Xmx2g",
+                "programArguments": "--dev",
+                "mavenProfiles": ["dev"]
+            }
+        })
+        .to_string(),
+    ))
+    .unwrap();
+    assert_eq!(inherited["ok"], true, "{inherited}");
+    let inherited_document: Value =
+        serde_json::from_str(inherited["data"]["document"].as_str().unwrap()).unwrap();
+    assert!(inherited_document["configurations"][0]["cwd"].is_null());
+    assert!(inherited_document["configurations"][0]["extensions"]["maven"]["skipTests"].is_null());
+    fs::write(
+        root.join(".lithe/run/configurations.json"),
+        inherited["data"]["document"].as_str().unwrap(),
     )
     .unwrap();
 

--- a/rust/lithe-core/src/tests/run_configuration.rs
+++ b/rust/lithe-core/src/tests/run_configuration.rs
@@ -222,7 +222,16 @@ fn run_configuration_generation_uses_a_maven_project_below_the_workspace() {
             "command": "runConfig.createLaunchPlan",
             "payload": {
                 "root": root,
-                "configurationId": service["id"]
+                "configurationId": service["id"],
+                "mavenContext": {
+                    "version": 1,
+                    "reactorPath": "projects/demo",
+                    "profiles": ["qa", "dev"],
+                    "settingsPath": "/local/settings.xml",
+                    "skipTests": true,
+                    "mavenExecutablePath": "/local/apache-maven/bin/mvn",
+                    "javaHomePath": "/local/jdk"
+                }
             }
         })
         .to_string(),
@@ -230,11 +239,59 @@ fn run_configuration_generation_uses_a_maven_project_below_the_workspace() {
     .unwrap();
     assert_eq!(plan["ok"], true, "{plan}");
     assert_eq!(plan["data"]["workingDirectory"], "projects/demo");
-    assert!(plan["data"]["arguments"]
-        .as_array()
-        .unwrap()
-        .windows(2)
-        .any(|arguments| arguments == ["-pl", "service"]));
+    assert_eq!(
+        &plan["data"]["arguments"].as_array().unwrap()[..12],
+        [
+            "-B",
+            "-ntp",
+            "-P",
+            "dev,qa",
+            "-s",
+            "/local/settings.xml",
+            "-pl",
+            "service",
+            "-am",
+            "-DskipTests",
+            "-Dspring-boot.run.main-class=com.example.App",
+            "spring-boot:run"
+        ]
+    );
+
+    fs::write(
+        root.join(".lithe/run/configurations.json"),
+        serde_json::json!({
+            "version": 2,
+            "configurations": [{
+                "id": service["id"],
+                "extensions": {"maven": {"profiles": ["release"]}}
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let overridden_plan: Value = serde_json::from_str(&execute_json(
+        &serde_json::json!({
+            "id": "plan-explicit-profile",
+            "command": "runConfig.createLaunchPlan",
+            "payload": {
+                "root": root,
+                "configurationId": service["id"],
+                "mavenContext": {
+                    "version": 1,
+                    "reactorPath": "projects/demo",
+                    "profiles": ["dev", "qa"],
+                    "skipTests": false
+                }
+            }
+        })
+        .to_string(),
+    ))
+    .unwrap();
+    assert_eq!(overridden_plan["ok"], true, "{overridden_plan}");
+    assert_eq!(
+        &overridden_plan["data"]["arguments"].as_array().unwrap()[..4],
+        ["-B", "-ntp", "-P", "release"]
+    );
 
     let java_plan: Value = serde_json::from_str(&execute_json(
         &serde_json::json!({

--- a/scripts/verify-shared-contracts.sh
+++ b/scripts/verify-shared-contracts.sh
@@ -17,8 +17,36 @@ plugin_fixture="shared/fixtures/plugins/official-v1.json"
 github_fixture="shared/fixtures/github/pull-request-v1.json"
 workbench_background_fixture="shared/fixtures/settings/workbench-background-v1.json"
 syntax_theme_fixture="shared/fixtures/editor-themes/lithe-v1.json"
+maven_platform_fixture="shared/fixtures/maven/platform-contract-v1.json"
+maven_portable_schema="shared/contracts/maven-portable-configuration-v1.schema.json"
+maven_launch_context_schema="shared/contracts/maven-launch-context-v1.schema.json"
 macos_syntax_colors="macos/Sources/Lithe/Resources/SyntaxHighlighting/color-mappings.json"
 windows_lithe_theme="windows/tauri/src/extensions/themes/builtin/lithe.json"
+
+/usr/bin/ruby -rjson -e '
+  portable = JSON.parse(File.read(ARGV.fetch(0)))
+  launch = JSON.parse(File.read(ARGV.fetch(1)))
+  fixture = JSON.parse(File.read(ARGV.fetch(2)))
+
+  abort "Maven portable schema ID mismatch" unless portable.fetch("$id").end_with?("/maven-portable-configuration-v1.schema.json")
+  portable_fields = %w[customProfiles selectedProfiles skipTests version]
+  abort "Maven portable fields differ from v1" unless portable.fetch("properties").keys.sort == portable_fields
+  abort "Maven portable required fields differ from v1" unless portable.fetch("required").sort == portable_fields
+
+  abort "Maven launch-context schema ID mismatch" unless launch.fetch("$id").end_with?("/maven-launch-context-v1.schema.json")
+  launch_fields = %w[javaHomePath mavenExecutablePath profiles reactorPath settingsPath skipTests version]
+  abort "Maven launch-context fields differ from v1" unless launch.fetch("properties").keys.sort == launch_fields.sort
+  abort "Maven launch-context required fields differ from v1" unless launch.fetch("required").sort == %w[profiles reactorPath skipTests version]
+
+  abort "Maven platform fixture version must be 1" unless fixture.fetch("version") == 1
+  phases = fixture.fetch("lifecyclePhases")
+  abort "Maven lifecycle phases differ from v1" unless phases == %w[clean validate compile test package verify install site deploy]
+  cases = fixture.fetch("storageIdentityCases")
+  abort "Maven storage fixture must cover both platforms" unless cases.map { |item| item.fetch("platform") }.sort == %w[macos windows]
+  abort "Maven storage fixture names must be unique" unless cases.map { |item| item.fetch("name") }.uniq.length == cases.length
+  abort "Maven storage identities must contain one separator" unless cases.all? { |item| item.fetch("expectedIdentity").count("\0") == 1 }
+' "$maven_portable_schema" "$maven_launch_context_schema" "$maven_platform_fixture"
+
 fixture_ids=$(/usr/bin/ruby -rjson -e 'puts JSON.parse(File.read(ARGV.fetch(0))).fetch("modules").map { |m| m.fetch("id") }.sort' "$module_fixture")
 swift_ids=$(rg '^[[:space:]]*static let .* = ModuleID\("dev\.lithe\.[^"]+"\)' macos/Sources/LitheModuleAPI/Lifecycle/ModuleTypes.swift \
     | sed -E 's/.*ModuleID\("([^"]+)"\).*/\1/' \

--- a/shared/contracts/application-boundary.md
+++ b/shared/contracts/application-boundary.md
@@ -250,7 +250,9 @@ still requires an explicit user selection.
 
 Maven tool-window execution uses `maven.launchPlan`; platform views do not
 assemble Maven arguments. Portable profile and Skip Tests defaults conform to
-[`maven-project-context-v1.schema.json`](maven-project-context-v1.schema.json).
+[`maven-portable-configuration-v1.schema.json`](maven-portable-configuration-v1.schema.json).
+The transient Core request conforms to
+[`maven-launch-context-v1.schema.json`](maven-launch-context-v1.schema.json).
 External `settings.xml`, Maven executable, and Maven JDK paths remain in a
 machine-local store. They may be supplied transiently to Core for planning and
 fingerprinting, but Core never opens `settings.xml` or serializes those paths
@@ -266,5 +268,8 @@ instead of silently retaining the previous Maven model.
 
 Maven-backed Run and Debug launch planning consumes the current project Maven
 context. A Run Configuration's explicit Profiles and toolchain paths take
-precedence; unset values inherit the project settings. The shared Core applies
-the final Maven argument order for all three entry points.
+precedence; explicit `cwd` and `extensions.maven.skipTests` values also take
+precedence, including `skipTests: false`. Unset values inherit the project
+settings. The shared Core applies the final Maven argument order for all three
+entry points. Tool-window module launches add `-am`; Run and Debug retain their
+existing `-pl <module>` behavior without implicitly building dependencies.

--- a/shared/contracts/application-boundary.md
+++ b/shared/contracts/application-boundary.md
@@ -247,3 +247,24 @@ Runtime consumption is declared by the detector from the actual command rather
 than inferred from the provider namespace. An automatically discovered runtime
 path is session-effective: validation and launch share it, but persistence
 still requires an explicit user selection.
+
+Maven tool-window execution uses `maven.launchPlan`; platform views do not
+assemble Maven arguments. Portable profile and Skip Tests defaults conform to
+[`maven-project-context-v1.schema.json`](maven-project-context-v1.schema.json).
+External `settings.xml`, Maven executable, and Maven JDK paths remain in a
+machine-local store. They may be supplied transiently to Core for planning and
+fingerprinting, but Core never opens `settings.xml` or serializes those paths
+into the portable project context.
+
+The Java language-server startup consumes that same context. Core exposes the
+selected `settings.xml` to JDT LS as
+`java.configuration.maven.userSettings`, then applies the sorted Profile set
+to the reactor and every recursively declared Maven module after JDT LS
+reports `ServiceReady`. The Java session remains `initializing` until those
+project updates all succeed; a rejected or timed-out update fails the session
+instead of silently retaining the previous Maven model.
+
+Maven-backed Run and Debug launch planning consumes the current project Maven
+context. A Run Configuration's explicit Profiles and toolchain paths take
+precedence; unset values inherit the project settings. The shared Core applies
+the final Maven argument order for all three entry points.

--- a/shared/contracts/maven-launch-context-v1.schema.json
+++ b/shared/contracts/maven-launch-context-v1.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lithe.dev/contracts/maven-launch-context-v1.schema.json",
+  "title": "Lithe Maven Launch Context v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "reactorPath", "profiles", "skipTests"],
+  "properties": {
+    "version": { "const": 1 },
+    "reactorPath": { "type": "string", "minLength": 1 },
+    "profiles": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "settingsPath": { "type": ["string", "null"] },
+    "skipTests": { "type": "boolean" },
+    "mavenExecutablePath": { "type": ["string", "null"] },
+    "javaHomePath": { "type": ["string", "null"] }
+  }
+}

--- a/shared/contracts/maven-portable-configuration-v1.schema.json
+++ b/shared/contracts/maven-portable-configuration-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lithe.dev/contracts/maven-project-context-v1.schema.json",
-  "title": "Lithe Maven Project Context v1",
+  "$id": "https://lithe.dev/contracts/maven-portable-configuration-v1.schema.json",
+  "title": "Lithe Maven Portable Configuration v1",
   "type": "object",
   "additionalProperties": false,
   "required": ["version", "selectedProfiles", "customProfiles", "skipTests"],

--- a/shared/contracts/maven-project-context-v1.schema.json
+++ b/shared/contracts/maven-project-context-v1.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lithe.dev/contracts/maven-project-context-v1.schema.json",
+  "title": "Lithe Maven Project Context v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "selectedProfiles", "customProfiles", "skipTests"],
+  "properties": {
+    "version": { "const": 1 },
+    "selectedProfiles": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "customProfiles": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "skipTests": { "type": "boolean" }
+  }
+}

--- a/shared/contracts/run-configuration-v1.schema.json
+++ b/shared/contracts/run-configuration-v1.schema.json
@@ -39,6 +39,7 @@
         "jvmArguments": { "type": "array", "items": { "type": "string" } },
         "programArguments": { "type": "array", "items": { "type": "string" } },
         "mavenProfiles": { "type": "array", "items": { "type": "string" } },
+        "mavenSkipTests": { "type": "boolean" },
         "disabled": { "type": "boolean" }
       },
       "additionalProperties": false

--- a/shared/contracts/rust-core-api.md
+++ b/shared/contracts/rust-core-api.md
@@ -80,6 +80,7 @@ stable error code and a user-facing message:
 | `history.rename` | Set or clear a user-visible label on a history entry |
 | `history.delete` | Delete one history entry and its snapshot |
 | `maven.scan` | Parse a Maven project descriptor and recursively return modules/profiles |
+| `maven.launchPlan` | Produce a deterministic Maven invocation from a versioned project context |
 | `maven.diagnostics` | Parse stable Maven compiler diagnostics from build output |
 | `lsp.applyTextEdits` | Apply LSP UTF-16 text edits with range validation |
 | `lsp.plainSnippet` | Convert LSP snippet insert text into plain editor text |
@@ -370,6 +371,14 @@ provider ID, selected executable/arguments/environment, root URI, working
 directory, initialization options, optional runtime executable,
 `jdtlsLaunchResources`, cache directory, and `workspaceFingerprint`, plus
 initialize, post-initialize readiness, request, and shutdown deadlines.
+Java callers may also provide the versioned `mavenContext` accepted by
+`maven.launchPlan`. Core validates its reactor and recursively declared modules,
+publishes `settingsPath` through
+`java.configuration.maven.userSettings`, and, after `ServiceReady`, sends one
+`java.project.updateSettings` command per Maven project with
+`org.eclipse.m2e.core.selectedProfiles`. The session becomes `ready` only after
+every command succeeds; a command error or timeout terminates the session with
+`mavenContextFailed` or `mavenContextTimeout` at the `serviceReady` stage.
 `initializeTimeoutMilliseconds` bounds only the standard LSP handshake. For a
 provider such as JDT LS that has a later readiness signal,
 `serviceReadyIdleTimeoutMilliseconds` bounds time without changed work-done
@@ -528,6 +537,23 @@ contains its workspace `relativePath`,
 and `hasWrapper`. Module paths are relative to the selected Maven root and use
 `/` separators. Malformed XML returns `parse_failed`.
 
+`maven.launchPlan` accepts a workspace `root`, a versioned `context`, an
+optional reactor-relative `module`, and an ordered `goals` array whose first
+entry is a lifecycle or custom goal. Later entries may be ordinary Maven CLI
+arguments such as `-Dname=value` or `-q`. They remain separate process arguments
+and are never interpreted by a shell. Context version 1 contains the
+workspace-relative `reactorPath`,
+selected `profiles`, optional platform-local `settingsPath`, `skipTests`, and
+optional Maven/JDK paths used only for the configuration fingerprint. The
+response contains the `project-maven` toolchain reference, an argument array,
+the workspace-relative reactor working directory, and a deterministic SHA-256
+configuration fingerprint. Profiles are sorted and de-duplicated. Module plans
+use `-pl <module> -am`; settings use `-s`; skipped tests use `-DskipTests`.
+The core never reads `settings.xml` and never copies its path into a portable
+project document. Maven itself continues to read `.mvn/maven.config`; the plan
+does not expand or duplicate that file's arguments. Fixtures are in
+`shared/fixtures/maven/launch-plan-v1.json`.
+
 `maven.diagnostics` accepts `{ "root": string, "output": string }` and returns
 `{ "issues": [] }`. Diagnostic paths may be absolute or workspace-relative;
 the response preserves the path text, uses one-based line and column values,
@@ -625,7 +651,12 @@ shell scripts.
 
 `runConfig.createLaunchPlan` accepts `root`, `configurationId`, optional
 `currentFile` and `classPath`, optional `debugPort`, and optional
-`localDocument`. It returns a toolchain
+`localDocument`. Maven-backed Run and Debug callers may also supply the same
+versioned `mavenContext` accepted by `maven.launchPlan`. Explicit profiles in
+the resolved Run Configuration replace the context profiles; otherwise the
+project profiles are inherited. Core applies the shared settings, module,
+`-am`, Skip Tests, and reactor-working-directory rules to the generated
+framework or Java-main arguments. It returns a toolchain
 reference, argument array, project-relative working directory, and structured
 environment references. It does not return a shell command or platform
 executable path. All project paths use `/`, reject absolute paths and `..`

--- a/shared/contracts/rust-core-api.md
+++ b/shared/contracts/rust-core-api.md
@@ -548,7 +548,10 @@ optional Maven/JDK paths used only for the configuration fingerprint. The
 response contains the `project-maven` toolchain reference, an argument array,
 the workspace-relative reactor working directory, and a deterministic SHA-256
 configuration fingerprint. Profiles are sorted and de-duplicated. Module plans
-use `-pl <module> -am`; settings use `-s`; skipped tests use `-DskipTests`.
+from `maven.launchPlan` use `-pl <module> -am`; Run and Debug plans use
+`-pl <module>` without `-am`. Settings use `-s`; skipped tests use
+`-DskipTests`. Explicit Run `cwd`, Profiles, and `extensions.maven.skipTests`
+values override the project context, including `skipTests: false`.
 The core never reads `settings.xml` and never copies its path into a portable
 project document. Maven itself continues to read `.mvn/maven.config`; the plan
 does not expand or duplicate that file's arguments. Fixtures are in
@@ -611,7 +614,11 @@ per-configuration toolchain path overrides the corresponding project default.
 document transformations. They validate scope, paths, supported types, stable
 IDs, main classes, modules, and argument parsing, then return UTF-8 JSON in the
 `document` field. The platform adapter selects the target project or local
-file and performs the atomic write. These commands never write files.
+file and performs the atomic write. These commands never write files. An empty
+`workingDirectory` removes the layer's `cwd` override. Optional
+`mavenSkipTests` writes `extensions.maven.skipTests`; omission removes the
+override so the project Maven context is inherited, while explicit `false`
+continues to run tests even when the project default skips them.
 For project-scoped option updates, selected toolchain paths must resolve inside
 `root` and are persisted with `/`-separated project-relative paths. Local-scoped
 updates may carry host absolute paths. `runConfig.updateOptions` and
@@ -654,9 +661,11 @@ shell scripts.
 `localDocument`. Maven-backed Run and Debug callers may also supply the same
 versioned `mavenContext` accepted by `maven.launchPlan`. Explicit profiles in
 the resolved Run Configuration replace the context profiles; otherwise the
-project profiles are inherited. Core applies the shared settings, module,
-`-am`, Skip Tests, and reactor-working-directory rules to the generated
-framework or Java-main arguments. It returns a toolchain
+project profiles are inherited. Explicit `extensions.maven.skipTests` and
+`cwd` values also replace the context values. Core applies the shared settings,
+module, Skip Tests, and reactor-working-directory rules to the generated
+framework or Java-main arguments without adding tool-window-only `-am`. It
+returns a toolchain
 reference, argument array, project-relative working directory, and structured
 environment references. It does not return a shell command or platform
 executable path. All project paths use `/`, reject absolute paths and `..`

--- a/shared/fixtures/maven/launch-plan-v1.json
+++ b/shared/fixtures/maven/launch-plan-v1.json
@@ -1,0 +1,86 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "name": "nested reactor module lifecycle with local settings",
+      "context": {
+        "version": 1,
+        "reactorPath": "projects/demo",
+        "profiles": ["qa", "dev", "dev"],
+        "settingsPath": "/Users/example/.m2/settings.xml",
+        "skipTests": true,
+        "mavenExecutablePath": "/opt/apache-maven/bin/mvn",
+        "javaHomePath": "/Library/Java/JavaVirtualMachines/example/Contents/Home"
+      },
+      "module": "service-api",
+      "goals": ["verify"],
+      "expected": {
+        "version": 1,
+        "executable": { "toolchain": "project-maven" },
+        "arguments": [
+          "-B",
+          "-ntp",
+          "-P",
+          "dev,qa",
+          "-s",
+          "/Users/example/.m2/settings.xml",
+          "-pl",
+          "service-api",
+          "-am",
+          "-DskipTests",
+          "verify"
+        ],
+        "workingDirectory": "projects/demo",
+        "configurationFingerprint": "sha256:8e665a85f0c0a9fa5567cfc88d90cc1e794a34810b4617662c5610699ad22df6"
+      }
+    },
+    {
+      "name": "root reactor custom goal preserves maven config behavior",
+      "context": {
+        "version": 1,
+        "reactorPath": ".",
+        "profiles": [],
+        "skipTests": false
+      },
+      "module": null,
+      "goals": ["spring-boot:run"],
+      "expected": {
+        "version": 1,
+        "executable": { "toolchain": "project-maven" },
+        "arguments": ["-B", "-ntp", "spring-boot:run"],
+        "workingDirectory": ".",
+        "configurationFingerprint": "sha256:225165d5264a20dba15802483efebc3a0d29abb16f36702d599324891e242511"
+      }
+    },
+    {
+      "name": "custom goal keeps property and quiet arguments as argv",
+      "context": {
+        "version": 1,
+        "reactorPath": ".",
+        "profiles": [],
+        "skipTests": false
+      },
+      "module": null,
+      "goals": [
+        "help:evaluate",
+        "-Dexpression=fixture.config",
+        "-q",
+        "-DforceStdout"
+      ],
+      "expected": {
+        "version": 1,
+        "executable": { "toolchain": "project-maven" },
+        "arguments": [
+          "-B",
+          "-ntp",
+          "help:evaluate",
+          "-Dexpression=fixture.config",
+          "-q",
+          "-DforceStdout"
+        ],
+        "workingDirectory": ".",
+        "configurationFingerprint": "sha256:225165d5264a20dba15802483efebc3a0d29abb16f36702d599324891e242511"
+      }
+    }
+  ]
+}

--- a/shared/fixtures/maven/platform-contract-v1.json
+++ b/shared/fixtures/maven/platform-contract-v1.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "lifecyclePhases": [
+    "clean",
+    "validate",
+    "compile",
+    "test",
+    "package",
+    "verify",
+    "install",
+    "site",
+    "deploy"
+  ],
+  "storageIdentityCases": [
+    {
+      "name": "macOS preserves workspace path case",
+      "platform": "macos",
+      "workspacePath": "/Users/Example/Projects/Lithe",
+      "reactorPath": "services/api",
+      "expectedIdentity": "/Users/Example/Projects/Lithe\u0000services/api"
+    },
+    {
+      "name": "Windows folds workspace case and normalizes reactor separators",
+      "platform": "windows",
+      "workspacePath": "C:\\Users\\Example\\Projects\\Lithe",
+      "reactorPath": "services\\api",
+      "expectedIdentity": "c:\\users\\example\\projects\\lithe\u0000services/api"
+    }
+  ]
+}


### PR DESCRIPTION
## 关联 Issue

Part of #291.

本 PR 提交共享 Maven Core、版本化契约与 macOS 实现。Windows 实现位于后续 PR #321，避免把两个平台的 UI 和原生适配混在同一个 review 中。

## 主要变更

- 在 `rust/lithe-core` 中统一 Maven reactor/模块/Profile 扫描、配置合并、指纹与 Launch Plan 生成。
- 将持久化配置与 Launch Context 拆成 `maven-portable-configuration-v1` 和 `maven-launch-context-v1` 两份 schema，并增加逐字段契约验证。
- macOS Maven 工具窗口支持递归模块、Profiles、Lifecycle、自定义 Goal、Skip Tests、停止、折叠、Reload 和 Maven Settings。
- Maven Settings 支持外部 `settings.xml`、Maven Home/可执行文件和 Maven 专用 JDK；绝对路径只保存在本机 Application Support。
- Run、Debug、Maven 工具窗口和 JDT LS 消费同一个 Maven 上下文；Swift 不拼接 Maven 参数。

## Review 修复

- Run 配置显式 `cwd` 继续拥有最高优先级，未配置时才继承 reactor 工作目录。
- 新增可选 `mavenSkipTests`：`null` 继承项目设置，显式 `false` 即使项目勾选 Skip Tests 也会运行测试。
- Run/Debug 模块启动保持 `-pl <module>`；只有 Maven 工具窗口默认追加 `-am`。
- macOS 实际比较 `configurationFingerprint`，配置变化时触发 JDT reload 提示。
- 修正 JDT 日志中的 `projectCount` 和 Maven Home 解析为重复 `bin/mvn` 的问题。
- 新增共享 lifecycle/storage identity fixture；macOS 与 Windows 分别验证各自的平台规范化规则。
- `run-configuration-v1` schema 已声明可选 `mavenSkipTests`。

## 安全与边界

- Core 只接收 `settings.xml` 路径，不读取、复制或序列化其中的凭据。
- Build Output 隐藏本机 `settings.xml` 绝对路径。
- 项目配置不保存工作区外的本机绝对路径；自定义 Goal 以结构化 argv 执行，不经过 shell。

## 验证

- Rust Core：272 个单元测试、5 个集成测试通过。
- `./scripts/verify-rust-core.sh`
- `./scripts/verify-shared-contracts.sh`
- `./scripts/verify-service-boundaries.sh`
- `./scripts/verify-module-boundaries.sh`
- `./scripts/verify-rust-core-comments.sh`
- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`
- `swift build --target Lithe`
- macOS 真实 UI：带参数 Goal、停止后 Cancelled、子进程清理均已验证。

## 当前环境限制

本机只有 Command Line Tools，Swift 测试 target 报 `no such module 'Testing'`，因此本地 Swift timing lane 未执行；完整 Xcode 环境由当前 PR CI 验证。
