### PR TITLE
docs(release): add v0.3.7 notes

### DIFF
--- a/docs/releases/v0.3.7.md
+++ b/docs/releases/v0.3.7.md
@@ -1,0 +1,75 @@
+## 中文
+
+Lithe 0.3.7 是一次功能与稳定性更新，汇总了近期 macOS Git 工作流、编辑器导航、Java/Spring 支持和 Windows 适配方面的改进。
+
+### 下载
+
+- **项目主页：** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.7/Lithe-0.3.7-arm64.dmg)
+- **macOS Intel：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.7/Lithe-0.3.7-x86_64.dmg)
+- **Windows x64（预览版）：** [下载安装程序](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.7/Lithe-0.3.7-windows-x64.exe)
+- **全部下载：** [查看 Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.7)
+
+> Windows 版本目前仍处于预览阶段。安装程序在未配置 Authenticode 证书时可能没有数字签名，Windows 可能会显示安全提示。
+
+### 重点更新
+
+- Git 工作流按 IntelliJ IDEA 风格重新整理，项目和分支切换弹窗更紧凑，并支持最近分支、命名空间分组、远程分组折叠和搜索。
+- Git 提交、推送、更新和分支操作入口更加清晰；首次推送、远程选择、上游分支和本地未提交改动的提示更加准确。
+- 编辑器新增并完善跳转到行、Git 日志筛选和提交文件浏览，统一行列边界处理并补充回归测试。
+- 改进 Java 项目就绪、Maven 配置、Spring 注解识别和语言服务启动流程，减少项目模型未准备完成时的误报。
+- 改进 Windows Git、运行、文件粘贴和 CDN 配置边界处理，并同步 Rust Core 与共享协议适配。
+
+### 升级说明
+
+- **macOS DMG：** 退出正在运行的 Lithe，打开对应架构的 DMG，然后将 Lithe 拖入“应用程序”并替换旧版本。
+- **Homebrew：** 运行 `brew update && brew upgrade --cask lithe`。
+- **Windows：** 退出正在运行的 Lithe，然后运行 Windows x64 安装程序并按提示完成安装。
+
+### 兼容性与已知问题
+
+- macOS 需要 macOS 13 或更高版本。
+- Java 项目功能需要 JDK 17 或更高版本，推荐使用 JDK 17 或 JDK 21。
+- macOS 和 Windows 正式安装包均包含 JDTLS，无需单独安装。
+- Windows 版本仍处于预览阶段，部分平台能力和界面细节可能与 macOS 不完全一致；未配置 Authenticode 证书时安装程序可能显示安全提示。
+
+查看 [v0.3.6 到 v0.3.7 的完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.3.6...v0.3.7)。
+
+---
+
+## English
+
+Lithe 0.3.7 is a feature and reliability update covering the recent macOS Git workflow, editor navigation, Java/Spring support, and Windows integration improvements.
+
+### Downloads
+
+- **Project homepage:** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.7/Lithe-0.3.7-arm64.dmg)
+- **macOS Intel:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.7/Lithe-0.3.7-x86_64.dmg)
+- **Windows x64 preview:** [Download installer](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.7/Lithe-0.3.7-windows-x64.exe)
+- **All downloads:** [View Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.7)
+
+> The Windows build remains a preview. If an Authenticode certificate is not configured, the installer may be unsigned and Windows may show a security warning.
+
+### Highlights
+
+- Reorganized the Git workflow around IntelliJ IDEA conventions with more compact project and branch switchers, recent branches, namespace groups, collapsible remote groups, and search.
+- Clarified Git commit, push, update, and branch actions with more accurate guidance for first pushes, remote selection, upstream branches, and uncommitted changes.
+- Added and refined go-to-line, Git log filtering, and commit file browsing, with consistent line and column boundaries plus regression coverage.
+- Improved Java project readiness, Maven configuration, Spring annotation recognition, and language-server startup to reduce false diagnostics before the project model is ready.
+- Improved Windows Git, run, file-paste, and CDN configuration boundaries while keeping Rust Core and shared protocol adapters aligned.
+
+### Upgrade instructions
+
+- **macOS DMG:** Quit Lithe, open the DMG for your Mac architecture, and replace the existing application in the Applications folder.
+- **Homebrew:** Run `brew update && brew upgrade --cask lithe`.
+- **Windows:** Quit Lithe, run the Windows x64 installer, and follow the installation prompts.
+
+### Compatibility and known issues
+
+- macOS requires macOS 13 or later.
+- Java project features require JDK 17 or newer. JDK 17 or JDK 21 is recommended.
+- Release packages for macOS and Windows include JDTLS, so it does not need to be installed separately.
+- The Windows build remains a preview, and some platform capabilities and interface details may differ from macOS. The installer may show a security warning when Authenticode signing is not configured.
+
+Review the [full changes from v0.3.6 to v0.3.7](https://github.com/1lck/Lithe-IDEA/compare/v0.3.6...v0.3.7).


### PR DESCRIPTION
按 release-lithe 规范补充 v0.3.7 双语稳定版 Release notes。

- 基于 v0.3.6..main 的实际变更整理
- 包含 macOS arm64/x86_64、Windows x64 和完整 Release Assets 下载入口
- 已通过 scripts/validate-stable-release-notes.mjs
- 未创建 tag，待该 PR 合入后再发布