### PR TITLE
docs(release): add v0.3.8 notes

### DIFF
--- a/docs/releases/v0.3.8.md
+++ b/docs/releases/v0.3.8.md
@@ -1,0 +1,73 @@
+## 中文
+
+Lithe 0.3.8 是一次 Java 开发体验与跨平台稳定性更新，完善了 macOS 调试工作流，并为 Windows 提供统一的 Maven 工具窗口与更可靠的运行链路。
+
+### 下载
+
+- **项目主页：** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.8/Lithe-0.3.8-arm64.dmg)
+- **macOS Intel：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.8/Lithe-0.3.8-x86_64.dmg)
+- **Windows x64（预览版）：** [下载安装程序](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.8/Lithe-0.3.8-windows-x64.exe)
+- **全部下载：** [查看 Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.8)
+
+> Windows 版本目前仍处于预览阶段。安装程序在未配置 Authenticode 证书时可能没有数字签名，Windows 可能会显示安全提示。
+
+### 重点更新
+
+- macOS Java 调试支持断点管理、断点迁移、变量与作用域检查、表达式求值、线程与调用栈查看、步进过滤器、运行到光标，以及调试控制台和测试调试流程。
+- Windows 新增统一的 Maven 工具窗口，支持 Maven 项目重新加载、生命周期与目标操作，并将 Maven 上下文与运行配置加载流程对齐。
+- 改进工作区重开、文件保存、Maven 项目导入和语言服务启动时的就绪状态与过期结果处理，减少竞态导致的错误诊断。
+- 补充调试、Maven、运行配置、编辑器导航和跨平台协议的回归测试。
+
+### 升级说明
+
+- **macOS DMG：** 退出正在运行的 Lithe，打开对应架构的 DMG，然后将 Lithe 拖入“应用程序”并替换旧版本。
+- **Homebrew：** 运行 `brew update && brew upgrade --cask lithe`。
+- **Windows：** 退出正在运行的 Lithe，然后运行 Windows x64 安装程序并按提示完成安装。
+
+### 兼容性与已知问题
+
+- macOS 需要 macOS 13 或更高版本。
+- Java 项目功能需要 JDK 17 或更高版本，推荐使用 JDK 17 或 JDK 21。
+- macOS 和 Windows 正式安装包均包含 JDTLS，无需单独安装。
+- Windows 版本仍处于预览阶段，部分平台能力和界面细节可能与 macOS 不完全一致；未配置 Authenticode 证书时安装程序可能显示安全提示。
+
+查看 [v0.3.7 到 v0.3.8 的完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.3.7...v0.3.8)。
+
+---
+
+## English
+
+Lithe 0.3.8 is a Java development and cross-platform reliability update that expands the macOS debugging workflow and adds a unified Maven tool window with a more dependable run path on Windows.
+
+### Downloads
+
+- **Project homepage:** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.8/Lithe-0.3.8-arm64.dmg)
+- **macOS Intel:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.8/Lithe-0.3.8-x86_64.dmg)
+- **Windows x64 preview:** [Download installer](https://github.com/1lck/Lithe-IDEA/releases/download/v0.3.8/Lithe-0.3.8-windows-x64.exe)
+- **All downloads:** [View Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.8)
+
+> The Windows build remains a preview. If an Authenticode certificate is not configured, the installer may be unsigned and Windows may show a security warning.
+
+### Highlights
+
+- Expanded macOS Java debugging with breakpoint management and relocation, variable and scope inspection, expression evaluation, thread and stack inspection, stepping filters, run-to-cursor, debugging console support, and Java test debugging.
+- Added a unified Maven tool window on Windows with Maven workspace reload, lifecycle and goal actions, and aligned Maven context and run-configuration loading.
+- Improved readiness tracking and stale-result handling during workspace reopen, file saves, Maven import, and language-server startup to reduce race-related diagnostics.
+- Added regression coverage for debugging, Maven, run configurations, editor navigation, and cross-platform protocol behavior.
+
+### Upgrade instructions
+
+- **macOS DMG:** Quit Lithe, open the DMG for your Mac architecture, and replace the existing application in the Applications folder.
+- **Homebrew:** Run `brew update && brew upgrade --cask lithe`.
+- **Windows:** Quit Lithe, run the Windows x64 installer, and follow the installation prompts.
+
+### Compatibility and known issues
+
+- macOS requires macOS 13 or later.
+- Java project features require JDK 17 or newer. JDK 17 or JDK 21 is recommended.
+- Release packages for macOS and Windows include JDTLS, so it does not need to be installed separately.
+- The Windows build remains a preview, and some platform capabilities and interface details may differ from macOS. The installer may show a security warning when Authenticode signing is not configured.
+
+Review the [full changes from v0.3.7 to v0.3.8](https://github.com/1lck/Lithe-IDEA/compare/v0.3.7...v0.3.8).


### PR DESCRIPTION
## 发布说明

为 `v0.3.8` 正式版本加入双语发布说明。

- 覆盖 macOS Java 调试与 Windows Maven 工具窗口更新。
- 包含 macOS、Windows 下载入口和升级说明。
- 已通过 `scripts/validate-stable-release-notes.mjs` 及对应测试。

请合入后创建 `v0.3.8` 标签触发正式发布工作流。