### PR TITLE
fix(macOS): prevent RunEntryPoint activation race during module teardown

### DIFF
--- a/macos/Sources/Lithe/Models/AppModel/AppModel+ExecutionModules.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+ExecutionModules.swift
@@ -22,6 +22,11 @@ extension AppModel {
     }
 
     func activateExecutionModule() async -> ExecutionFeatureAccess? {
+        // Run and Debug activate on demand, so they can arrive while the previous
+        // session's module graph is still being torn down. Activating first would
+        // hand back a run feature that teardown releases moments later, and the
+        // deferred action waiting on it would never be resumed.
+        await awaitModuleRuntimeShutdown()
         if let mavenFeature = mavenFeatureIfActive,
            let runFeature = runFeatureIfActive,
            let tests = languageTestServiceIfActive,
@@ -50,6 +55,7 @@ extension AppModel {
     }
 
     func activateDebugModule() async -> DebugFeatureAccess? {
+        await awaitModuleRuntimeShutdown()
         if let genericFeature = genericDebugFeatureIfActive {
             configureDebugHostHandlers(genericFeature)
             if let workspaceURL { genericFeature.openWorkspace(at: workspaceURL) }

--- a/macos/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -485,7 +485,7 @@ final class AppModel: ObservableObject, Identifiable {
             },
             reloadProjectServices: { [weak self] in
                 guard let self, let workspaceURL = self.workspaceURL else { return }
-                await self.loadProjectServices(at: workspaceURL, files: self.projectFiles)
+                await self.loadProjectServicesForAppliedSnapshot(at: workspaceURL)
             },
             refreshGit: { [weak self] in
                 guard let feature = self?.gitFeatureIfActive else { return }
@@ -496,9 +496,15 @@ final class AppModel: ObservableObject, Identifiable {
                 await feature.updateVisibilityRules(rules.localHistoryRules)
             },
             onSnapshotLoaded: { [weak self] snapshot, isInitialLoad in
-                guard let self, let workspaceURL = self.workspaceURL else { return }
-                // WorkspaceFeatureModel requests the single Git refresh after this callback.
-                await self.loadProjectServices(at: workspaceURL, files: snapshot.files)
+                guard let self else { return }
+                // The snapshot callback owns the transition from a provisional
+                // inventory to a ready run project and resumes any deferred action.
+                await self.loadProjectServices(
+                    at: snapshot.root.url,
+                    files: snapshot.files,
+                    snapshotID: snapshot.id,
+                    resumesDeferredRunAction: true
+                )
                 if isInitialLoad {
                     self.projectHistoryFeatureIfActive?.seed(files: snapshot.files)
                 }
@@ -696,9 +702,6 @@ final class AppModel: ObservableObject, Identifiable {
 
     func shutdownProjectSession() async {
         shortcutDetector?.stop()
-        Task { [weak self] in
-            await self?.services.moduleRuntime.shutdownAll()
-        }
         cancelJavaTestWorkflows()
         languageToolingSessionsIfActive?.stopAll()
         languageTestServiceIfActive?.stop()
@@ -711,22 +714,35 @@ final class AppModel: ObservableObject, Identifiable {
         await shutdownModuleRuntime()
     }
 
+    /// Records this session's module-graph teardown before it can yield, so an
+    /// on-demand activation that follows a project switch can join the same
+    /// operation instead of racing a capability release.
+    private func beginModuleRuntimeShutdown() {
+        guard moduleRuntimeShutdownTask == nil else { return }
+        let moduleRuntime = services.moduleRuntime
+        moduleRuntimeShutdownTask = Task { @MainActor [weak self] in
+            await moduleRuntime.shutdownAll()
+            guard let self else { return }
+            self.moduleRuntimeShutdownTask = nil
+            self.clearModuleBindings(for: .database)
+        }
+    }
+
     /// Shuts down this session's module graph once, even when multiple
     /// lifecycle paths request cleanup at the same time.
     private func shutdownModuleRuntime() async {
-        if let moduleRuntimeShutdownTask {
-            await moduleRuntimeShutdownTask.value
-            return
-        }
+        beginModuleRuntimeShutdown()
+        await moduleRuntimeShutdownTask?.value
+    }
 
-        let moduleRuntime = services.moduleRuntime
-        let shutdownTask = Task { @MainActor in
-            await moduleRuntime.shutdownAll()
+    /// Lets an on-demand activation resume after a session teardown finishes.
+    ///
+    /// A shutdown that starts while this wait is suspended is joined as well, so
+    /// activation never returns a capability the runtime is about to release.
+    func awaitModuleRuntimeShutdown() async {
+        while let shutdownTask = moduleRuntimeShutdownTask {
+            await shutdownTask.value
         }
-        moduleRuntimeShutdownTask = shutdownTask
-        await shutdownTask.value
-        moduleRuntimeShutdownTask = nil
-        clearModuleBindings(for: .database)
     }
 
     private func reloadJavaRuntimeServices() {
@@ -743,28 +759,9 @@ final class AppModel: ObservableObject, Identifiable {
             }
             Task { [weak self] in
                 guard let self else { return }
-                await self.loadProjectServices(at: workspaceURL, files: self.projectFiles)
+                await self.loadProjectServicesForAppliedSnapshot(at: workspaceURL)
             }
         }
-    }
-
-    /// Loads build-system and run state at the workspace boundary. The generic
-    /// run lifecycle is intentionally not owned by JavaFeatureModel.
-    func loadProjectServices(at workspaceURL: URL, files: [URL]) async {
-        prepareJavaLanguageServerForWorkspaceIfNeeded(
-            at: workspaceURL,
-            files: files
-        )
-        await springFeature.load(
-            workspaceURL: workspaceURL,
-            files: files,
-            textOverrides: Dictionary(uniqueKeysWithValues: openDocuments.map {
-                ($0.url.standardizedFileURL, $0.text)
-            })
-        )
-        guard let execution = await activateExecutionModule() else { return }
-        execution.tests.discover(workspaceURL: workspaceURL, files: files)
-        await execution.projectDevelopment.loadProject(at: workspaceURL, files: files)
     }
 
     var projectName: String {
@@ -909,10 +906,7 @@ final class AppModel: ObservableObject, Identifiable {
 
     func openProjectDirectly(_ url: URL) {
         let normalizedURL = url.standardizedFileURL
-        Task { [weak self] in
-            guard let self else { return }
-            await self.shutdownModuleRuntime()
-        }
+        beginModuleRuntimeShutdown()
         if let previousWorkspaceURL = workspaceURL {
             workspaceFeature.persistWorkspaceSession(for: previousWorkspaceURL)
         }
@@ -929,6 +923,8 @@ final class AppModel: ObservableObject, Identifiable {
         runtimeFeature.openProject(at: normalizedURL)
         mavenFeatureIfActive?.reset()
         runFeatureIfActive?.reset()
+        pendingRunAction = nil
+        scheduleObjectWillChangeRelay()
         genericDebugFeatureIfActive?.reset()
         debugBreakpointPresentation.reset()
         clearLanguageNavigationProjection()
@@ -963,13 +959,21 @@ final class AppModel: ObservableObject, Identifiable {
         pendingProjectItemDeletion = nil
         recentProjects = recentProjectsStore.record(normalizedURL, in: recentProjects)
 
+        // The rebuild belongs to this opening. Reopening the same path advances
+        // the generation, so a rebuild left over from the previous opening
+        // cannot publish its snapshot into this one.
+        let generation = workspaceFeature.workspaceGeneration
         Task {
             await restoreDebugBreakpoints(for: normalizedURL)
-            guard workspaceURL == normalizedURL else { return }
+            guard workspaceURL == normalizedURL,
+                  workspaceFeature.workspaceGeneration == generation else { return }
             _ = await workspaceFeature.rebuild(
                 at: normalizedURL,
                 rules: visibilityRules,
-                isCurrent: { [weak self] in self?.workspaceURL == normalizedURL }
+                isCurrent: { [weak self] in
+                    self?.workspaceURL == normalizedURL
+                        && self?.workspaceFeature.workspaceGeneration == generation
+                }
             )
         }
     }
@@ -996,10 +1000,7 @@ final class AppModel: ObservableObject, Identifiable {
 
     private func performCloseProject() {
         cancelJavaLanguageServerPreparation()
-        Task { [weak self] in
-            guard let self else { return }
-            await self.shutdownModuleRuntime()
-        }
+        beginModuleRuntimeShutdown()
         if let workspaceURL {
             workspaceFeature.persistWorkspaceSession(for: workspaceURL)
         }
@@ -1039,6 +1040,8 @@ final class AppModel: ObservableObject, Identifiable {
         runtimeFeature.closeProject()
         mavenFeatureIfActive?.reset()
         runFeatureIfActive?.reset()
+        pendingRunAction = nil
+        scheduleObjectWillChangeRelay()
         genericDebugFeatureIfActive?.reset()
         debugBreakpointPresentation.reset()
         javaFeature.stop()


### PR DESCRIPTION
## Summary

- Restore the serialized module-runtime shutdown lifecycle before on-demand Run/Debug activation.
- Prevent the shutdown task from remaining observable after completion, which previously caused a MainActor busy-wait/deadlock.
- Restore snapshot identity propagation and deferred Run resumption so RunEntryPointTests can reach a ready project after the workspace scan.
- Restore workspace-generation and pending-action guards across project switches/reopens.

## Root cause

PR #359 removed the teardown/activation ordering and simplified the snapshot callback. With the partial restoration, `awaitModuleRuntimeShutdown()` observed a completed task while `moduleRuntimeShutdownTask` was still non-nil and repeatedly reacquired the MainActor, preventing the cleanup task from clearing its state.

## Validation

- `./scripts/test-macos.sh --no-parallel --filter RunEntryPointTests`
- `./scripts/test-macos.sh --no-parallel` (878 tests, 0 failures)
- `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh -- --filter RunEntryPointTests` (12/12 passed, no timeout)
- `./scripts/verify-service-boundaries.sh`
- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`

Separate from CI harness PR #371.