### PR TITLE
diagnose: run entrypoint fix with stall-aware Swift harness

### DIFF
--- a/.agents/skills/write-stable-tests/references/macos-swift.md
+++ b/.agents/skills/write-stable-tests/references/macos-swift.md
@@ -30,8 +30,13 @@ loaded, or invoked anywhere in this path.
 
 Use `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh`. It forces serial execution so the
 currently running test is unambiguous, records every Swift Testing/XCTest case,
-warns about slow cases, and terminates the suite when one case exceeds its local
-budget. Reports are written below `.artifacts/test-stability/`. Each run
+warns about slow cases, and fails the run when a reported duration exceeds its
+local budget. Because the runner writes to a block-buffered pipe, a finish line
+can arrive late or be lost; the harness therefore never kills the runner on a
+per-test timer. Instead a stall watchdog (`--stall-timeout-seconds`, default
+120) terminates the runner only when it produces no output at all, and reports
+the tests still awaiting a result without asserting a single culprit. Reports
+are written below `.artifacts/test-stability/`. Each run
 produces JSON and raw logs for diagnosis, JUnit XML for CI tooling, and a
 self-contained HTML report for module and performance review.
 

--- a/.agents/skills/write-stable-tests/scripts/run-swift-tests-with-timing.mjs
+++ b/.agents/skills/write-stable-tests/scripts/run-swift-tests-with-timing.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { mkdirSync, writeFileSync, createWriteStream } from "node:fs";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeTestReportArtifacts } from "./generate-test-report.mjs";
@@ -65,6 +66,7 @@ function parseArguments(arguments_) {
   const options = {
     warnMs: 1000,
     maxMs: 15000,
+    stallTimeoutMs: 120000,
     suiteTimeoutMs: 600000,
     report: path.join(REPOSITORY_ROOT, ".artifacts/test-stability/macos-swift.json"),
     command: arguments_[separator + 1],
@@ -74,7 +76,9 @@ function parseArguments(arguments_) {
     const argument = arguments_[index];
     if (argument === "--warn-ms") options.warnMs = positiveInteger(arguments_[++index], "--warn-ms");
     else if (argument === "--max-ms") options.maxMs = positiveInteger(arguments_[++index], "--max-ms");
-    else if (argument === "--suite-timeout-ms") {
+    else if (argument === "--stall-timeout-ms") {
+      options.stallTimeoutMs = positiveInteger(arguments_[++index], "--stall-timeout-ms");
+    } else if (argument === "--suite-timeout-ms") {
       options.suiteTimeoutMs = positiveInteger(arguments_[++index], "--suite-timeout-ms");
     } else if (argument === "--report") options.report = path.resolve(arguments_[++index]);
     else throw new Error(`Unknown argument: ${argument}`);
@@ -90,34 +94,61 @@ export async function run(options, { runProcessImpl = runProcess } = {}) {
   const active = new Map();
   const records = [];
   let currentSuite = null;
-  let timedOutTest = null;
-  let testTimer = null;
+  let stalled = false;
+  let stallTimer = null;
   let terminateChild = () => {};
+  let childPid = null;
+  let lastOutputAt = null;
+  let lastTestEventAt = null;
+  let stallSamplePath = null;
+  // Killing the runner from a per-test timer is unsound: swift test writes to a
+  // block-buffered pipe, so a finish line can sit (or be split mid-line) in the
+  // child's buffer long after the test completed, and the timer would blame an
+  // innocent test. Instead, per-test budgets are enforced after the run from
+  // the durations swift-testing itself reports, and this stall watchdog only
+  // guards against the runner producing no output at all.
+  const stallTimeoutMs = options.stallTimeoutMs ?? 120000;
+  // Best-effort thread-stack snapshot of the hung runner, taken before the
+  // SIGTERM destroys the evidence of where it was stuck.
+  const captureStallSample = () => {
+    if (process.platform !== "darwin" || !childPid) return;
+    const samplePath = options.report.replace(/\.json$/i, ".stall-sample.txt");
+    try {
+      const sample = spawnSync("sample", [String(childPid), "2", "-file", samplePath], {
+        stdio: "ignore",
+        timeout: 15000,
+      });
+      if (sample.status === 0) stallSamplePath = samplePath;
+    } catch {
+      // Sampling is diagnostics only; never let it break termination.
+    }
+  };
+  const armStallTimer = () => {
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => {
+      stalled = true;
+      captureStallSample();
+      terminateChild();
+    }, stallTimeoutMs);
+  };
 
   const recordLine = (line, stream) => {
-    log.write(`${stream}: ${line}\n`);
+    lastOutputAt = new Date().toISOString();
+    log.write(`${lastOutputAt} ${stream}: ${line}\n`);
+    armStallTimer();
     const suiteEvent = parseSwiftSuiteLine(line);
     if (suiteEvent?.event === "started") currentSuite = suiteEvent.name;
     else if (suiteEvent && suiteEvent.name === currentSuite) currentSuite = null;
     const event = parseSwiftTimingLine(line);
     if (!event) return;
+    lastTestEventAt = lastOutputAt;
     if (event.event === "started") {
-      const startedAt = performance.now();
-      active.set(event.name, { startedAt, suite: currentSuite });
-      if (testTimer) clearTimeout(testTimer);
-      testTimer = setTimeout(() => {
-        timedOutTest = { name: event.name, suite: currentSuite };
-        terminateChild();
-      }, options.maxMs);
+      active.set(event.name, { startedAt: performance.now(), suite: currentSuite });
       return;
     }
 
     const activeTest = active.get(event.name);
     active.delete(event.name);
-    if (testTimer) {
-      clearTimeout(testTimer);
-      testTimer = null;
-    }
     records.push({
       name: event.name,
       ...(activeTest?.suite ? { suite: activeTest.suite } : {}),
@@ -130,12 +161,14 @@ export async function run(options, { runProcessImpl = runProcess } = {}) {
   };
 
   const startedAt = new Date().toISOString();
+  armStallTimer();
   const childPromise = runProcessImpl({
     command: options.command,
     args: options.commandArguments,
     cwd: REPOSITORY_ROOT,
     timeoutMs: options.suiteTimeoutMs,
-    onSpawn: ({ terminate }) => {
+    onSpawn: ({ pid, terminate }) => {
+      childPid = pid ?? null;
       terminateChild = terminate;
     },
     onStdoutLine: (line) => recordLine(line, "stdout"),
@@ -144,30 +177,55 @@ export async function run(options, { runProcessImpl = runProcess } = {}) {
     streamStderr: true,
   });
 
-  const result = await childPromise;
-  if (testTimer) clearTimeout(testTimer);
-  await new Promise((resolve, reject) => {
-    log.once("error", reject);
-    log.end(resolve);
-  });
-
-  if (timedOutTest && !records.some((record) => record.name === timedOutTest.name)) {
-    records.push({
-      name: timedOutTest.name,
-      ...(timedOutTest.suite ? { suite: timedOutTest.suite } : {}),
-      status: "timeout",
-      durationMs: options.maxMs,
+  // Clear the watchdog and settle the log stream even when spawn fails and the
+  // await throws; a leaked ref'd timer would keep this process alive for the
+  // full timeout, and an unsettled stream emits an unhandled error event.
+  let result;
+  let logError = null;
+  try {
+    result = await childPromise;
+  } finally {
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = null;
+    await new Promise((resolve) => {
+      log.once("error", (error) => {
+        logError ??= error;
+        resolve();
+      });
+      log.end(resolve);
     });
   }
-  for (const [name, activeTest] of active) {
+  if (logError) throw logError;
+
+  // Tests still in `active` either never finished or had their finish line cut
+  // off in the killed child's stdio buffer; report them without asserting that
+  // any single one of them is the culprit.
+  const unfinished = [...active.entries()];
+  for (const [name, activeTest] of unfinished) {
     if (!records.some((record) => record.name === name)) {
       records.push({
         name,
         ...(activeTest.suite ? { suite: activeTest.suite } : {}),
-        status: result.timedOut ? "timeout" : "incomplete",
-        durationMs: options.maxMs,
+        status: result.timedOut || stalled ? "timeout" : "incomplete",
+        durationMs: Math.round(performance.now() - activeTest.startedAt),
       });
     }
+  }
+  if (stalled) {
+    const unfinishedNames = unfinished.map(([name]) => name);
+    records.push({
+      name: "Swift test runner stall",
+      suite: "Swift test runner",
+      status: "timeout",
+      durationMs: stallTimeoutMs,
+      details:
+        `The Swift runner produced no output for ${stallTimeoutMs}ms. ` +
+        (unfinishedNames.length > 0
+          ? `Tests without a reported result: ${unfinishedNames.join(", ")}. `
+          : "Every parsed test had reported a result; the runner likely hung during teardown or exit. ") +
+        `Last output at ${lastOutputAt ?? "never"}; last parsed test event at ${lastTestEventAt ?? "never"}.` +
+        (stallSamplePath ? ` Thread-stack sample of the hung runner: ${stallSamplePath}.` : ""),
+    });
   }
   if (result.timedOut && !records.some((record) => record.status === "timeout")) {
     records.push({
@@ -190,11 +248,14 @@ export async function run(options, { runProcessImpl = runProcess } = {}) {
     command: [options.command, ...options.commandArguments],
     warnMs: options.warnMs,
     maxMs: options.maxMs,
+    stallTimeoutMs,
     suiteTimeoutMs: options.suiteTimeoutMs,
     process: {
       exitCode: result.code,
       signal: result.signal,
       timedOut: result.timedOut,
+      stalled,
+      terminationConfirmed: result.terminationConfirmed,
       durationMs: Math.round(result.durationMs),
     },
     tests: records,
@@ -207,10 +268,16 @@ export async function run(options, { runProcessImpl = runProcess } = {}) {
     console.log(`SLOW ${record.durationMs}ms ${record.name}`);
   }
 
-  if (timedOutTest) {
-    throw new Error(`Swift test exceeded ${options.maxMs}ms: ${timedOutTest.name}`);
-  }
   if (result.timedOut) throw new Error(`Swift test suite exceeded ${options.suiteTimeoutMs}ms.`);
+  if (stalled) {
+    const unfinishedNames = unfinished.map(([name]) => name);
+    throw new Error(
+      `Swift test runner produced no output for ${stallTimeoutMs}ms` +
+        (unfinishedNames.length > 0
+          ? `; tests without a reported result: ${unfinishedNames.join(", ")}.`
+          : "; every parsed test had reported a result, so the runner likely hung during teardown or exit."),
+    );
+  }
   if (records.length === 0) throw new Error("The Swift runner did not report any individual test durations.");
   if (overBudget.length > 0) throw new Error(`${overBudget.length} Swift test(s) exceeded the local budget.`);
   if (result.code !== 0) throw new Error(`Swift test command exited with code ${result.code}.`);

--- a/.agents/skills/write-stable-tests/scripts/run-swift-tests-with-timing.mjs
+++ b/.agents/skills/write-stable-tests/scripts/run-swift-tests-with-timing.mjs
@@ -109,16 +109,62 @@ export async function run(options, { runProcessImpl = runProcess } = {}) {
   // guards against the runner producing no output at all.
   const stallTimeoutMs = options.stallTimeoutMs ?? 120000;
   // Best-effort thread-stack snapshot of the hung runner, taken before the
-  // SIGTERM destroys the evidence of where it was stuck.
+  // SIGTERM destroys the evidence of where it was stuck. The direct child is a
+  // shell wrapper, so walk its descendant tree: the genuinely hung process
+  // (swift-test or the testing helper, which detaches into its own process
+  // group) is a descendant, and the wrapper's stack would only show it waiting
+  // on its child.
   const captureStallSample = () => {
     if (process.platform !== "darwin" || !childPid) return;
-    const samplePath = options.report.replace(/\.json$/i, ".stall-sample.txt");
+    let treePids = [String(childPid)];
+    let processListing = "";
     try {
-      const sample = spawnSync("sample", [String(childPid), "2", "-file", samplePath], {
-        stdio: "ignore",
+      const everyProcess = spawnSync(
+        "ps",
+        ["-axo", "pid=,ppid=,pgid=,etime=,command="],
+        { encoding: "utf8", timeout: 5000 },
+      );
+      const rows = (everyProcess.stdout ?? "")
+        .split("\n")
+        .map((line) => {
+          const [pid, ppid] = line.trim().split(/\s+/);
+          return { pid, ppid, line };
+        })
+        .filter((row) => row.pid);
+      const wanted = new Set([String(childPid)]);
+      // Multiple passes handle arbitrary depth without recursion.
+      for (let pass = 0; pass < 10; pass += 1) {
+        const before = wanted.size;
+        for (const row of rows) if (wanted.has(row.ppid)) wanted.add(row.pid);
+        if (wanted.size === before) break;
+      }
+      const treeRows = rows.filter((row) => wanted.has(row.pid));
+      if (treeRows.length > 0) {
+        processListing = treeRows.map((row) => row.line).join("\n");
+        treePids = treeRows.map((row) => row.pid);
+      }
+    } catch {
+      // Fall back to sampling only the direct child.
+    }
+    const samplePath = options.report.replace(/\.json$/i, ".stall-sample.txt");
+    const sections = [
+      `Process tree under pid ${childPid} at stall (pid ppid pgid etime command):`,
+      processListing || "(process listing unavailable)",
+    ];
+    // Bound the diagnostics pass; each sample blocks for its full duration.
+    for (const pid of treePids.slice(0, 6)) {
+      const sample = spawnSync("sample", [pid, "2"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
         timeout: 15000,
       });
-      if (sample.status === 0) stallSamplePath = samplePath;
+      if (sample.status === 0 && sample.stdout) {
+        sections.push(`===== sample of pid ${pid} =====`, sample.stdout);
+      }
+    }
+    try {
+      writeFileSync(samplePath, `${sections.join("\n\n")}\n`);
+      stallSamplePath = samplePath;
     } catch {
       // Sampling is diagnostics only; never let it break termination.
     }

--- a/.agents/skills/write-stable-tests/scripts/test-stability-macos.sh
+++ b/.agents/skills/write-stable-tests/scripts/test-stability-macos.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="${0:A:h}"
 ROOT_DIR="$(cd -- "$SCRIPT_DIR/../../../.." && pwd)"
 WARN_SECONDS=1
 MAX_SECONDS=15
+STALL_TIMEOUT_SECONDS=120
 SUITE_TIMEOUT_SECONDS=600
 REPORT="$ROOT_DIR/.artifacts/test-stability/macos-swift.json"
 SWIFT_ARGS=()
@@ -17,6 +18,10 @@ while (( $# > 0 )); do
             ;;
         --max-seconds)
             MAX_SECONDS="$2"
+            shift 2
+            ;;
+        --stall-timeout-seconds)
+            STALL_TIMEOUT_SECONDS="$2"
             shift 2
             ;;
         --suite-timeout-seconds)
@@ -48,7 +53,7 @@ done
 
 for argument in "${SWIFT_ARGS[@]}"; do
     if [[ "$argument" == "--parallel" ]]; then
-        print -u2 -- "--parallel is not allowed: per-test watchdog attribution requires serial execution."
+        print -u2 -- "--parallel is not allowed: per-test duration attribution requires serial execution."
         exit 2
     fi
 done
@@ -57,6 +62,7 @@ done
 node "$SCRIPT_DIR/run-swift-tests-with-timing.mjs" \
     --warn-ms "$(( WARN_SECONDS * 1000 ))" \
     --max-ms "$(( MAX_SECONDS * 1000 ))" \
+    --stall-timeout-ms "$(( STALL_TIMEOUT_SECONDS * 1000 ))" \
     --suite-timeout-ms "$(( SUITE_TIMEOUT_SECONDS * 1000 ))" \
     --report "$REPORT" \
     -- "$ROOT_DIR/scripts/test-macos.sh" --no-parallel "${SWIFT_ARGS[@]}"

--- a/.agents/skills/write-stable-tests/scripts/test-verify-test-stability.mjs
+++ b/.agents/skills/write-stable-tests/scripts/test-verify-test-stability.mjs
@@ -254,6 +254,209 @@ try {
   rmSync(swiftTimeoutRoot, { recursive: true, force: true });
 }
 
+// Regression coverage for the CI misattribution incident: block-buffered pipes
+// can swallow a finish line, so a stall must be reported as runner silence with
+// the unfinished tests listed, never as "test X exceeded the budget".
+const swiftStallRoot = mkdtempSync(path.join(os.tmpdir(), "lithe-test-stability-swift-stall-"));
+try {
+  const reportPath = path.join(swiftStallRoot, "swift-stall.json");
+  await assert.rejects(
+    runSwiftTestsWithTiming(
+      {
+        warnMs: 50,
+        maxMs: 200,
+        stallTimeoutMs: 100,
+        suiteTimeoutMs: 5000,
+        report: reportPath,
+        command: "swift",
+        commandArguments: ["test"],
+      },
+      {
+        runProcessImpl: async ({ onStdoutLine, onSpawn }) => {
+          let resolveTerminated;
+          const terminated = new Promise((resolve) => {
+            resolveTerminated = resolve;
+          });
+          onSpawn({
+            terminate: async () => {
+              resolveTerminated();
+              return true;
+            },
+          });
+          onStdoutLine('◇ Suite "Keyboard shortcuts" started.');
+          onStdoutLine("◇ Test fast() started.");
+          onStdoutLine("✔ Test fast() passed after 0.001 seconds.");
+          onStdoutLine("◇ Test truncatedFinishLine() started.");
+          // The finish line for truncatedFinishLine() never arrives, as when the
+          // runner's stdio buffer is lost; the stall watchdog must fire.
+          await terminated;
+          return {
+            code: null,
+            signal: "SIGTERM",
+            timedOut: false,
+            terminationConfirmed: true,
+            durationMs: 150,
+            stdout: "",
+            stderr: "",
+          };
+        },
+      },
+    ),
+    /produced no output for 100ms; tests without a reported result: truncatedFinishLine\(\)/,
+  );
+  const stallReport = JSON.parse(readFileSync(reportPath, "utf8"));
+  assert.equal(stallReport.process.stalled, true);
+  assert.deepEqual(
+    stallReport.tests.map(({ name, status }) => ({ name, status })),
+    [
+      { name: "fast()", status: "passed" },
+      { name: "truncatedFinishLine()", status: "timeout" },
+      { name: "Swift test runner stall", status: "timeout" },
+    ],
+  );
+} finally {
+  rmSync(swiftStallRoot, { recursive: true, force: true });
+}
+
+// A stall after every test reported a result points at teardown/exit instead of
+// blaming any test.
+const swiftTeardownStallRoot = mkdtempSync(
+  path.join(os.tmpdir(), "lithe-test-stability-swift-teardown-stall-"),
+);
+try {
+  const reportPath = path.join(swiftTeardownStallRoot, "swift-teardown-stall.json");
+  await assert.rejects(
+    runSwiftTestsWithTiming(
+      {
+        warnMs: 50,
+        maxMs: 200,
+        stallTimeoutMs: 100,
+        suiteTimeoutMs: 5000,
+        report: reportPath,
+        command: "swift",
+        commandArguments: ["test"],
+      },
+      {
+        runProcessImpl: async ({ onStdoutLine, onSpawn }) => {
+          let resolveTerminated;
+          const terminated = new Promise((resolve) => {
+            resolveTerminated = resolve;
+          });
+          onSpawn({
+            terminate: async () => {
+              resolveTerminated();
+              return true;
+            },
+          });
+          onStdoutLine("◇ Test fast() started.");
+          onStdoutLine("✔ Test fast() passed after 0.001 seconds.");
+          await terminated;
+          return {
+            code: null,
+            signal: "SIGTERM",
+            timedOut: false,
+            terminationConfirmed: true,
+            durationMs: 150,
+            stdout: "",
+            stderr: "",
+          };
+        },
+      },
+    ),
+    /produced no output for 100ms; every parsed test had reported a result/,
+  );
+  const teardownReport = JSON.parse(readFileSync(reportPath, "utf8"));
+  assert.equal(teardownReport.process.stalled, true);
+  assert.deepEqual(
+    teardownReport.tests.map(({ name, status }) => ({ name, status })),
+    [
+      { name: "fast()", status: "passed" },
+      { name: "Swift test runner stall", status: "timeout" },
+    ],
+  );
+} finally {
+  rmSync(swiftTeardownStallRoot, { recursive: true, force: true });
+}
+
+// The per-test budget is enforced from the durations swift-testing reports: a
+// test that finishes over maxMs must fail the run even though the runner
+// exited cleanly and no watchdog fired.
+const swiftBudgetRoot = mkdtempSync(path.join(os.tmpdir(), "lithe-test-stability-swift-budget-"));
+try {
+  const reportPath = path.join(swiftBudgetRoot, "swift-budget.json");
+  await assert.rejects(
+    runSwiftTestsWithTiming(
+      {
+        warnMs: 50,
+        maxMs: 200,
+        stallTimeoutMs: 5000,
+        suiteTimeoutMs: 10000,
+        report: reportPath,
+        command: "swift",
+        commandArguments: ["test"],
+      },
+      {
+        runProcessImpl: async ({ onStdoutLine, onSpawn }) => {
+          onSpawn({ terminate: async () => true });
+          onStdoutLine("◇ Test overBudget() started.");
+          onStdoutLine("✔ Test overBudget() passed after 0.250 seconds.");
+          return {
+            code: 0,
+            signal: null,
+            timedOut: false,
+            terminationConfirmed: true,
+            durationMs: 300,
+            stdout: "",
+            stderr: "",
+          };
+        },
+      },
+    ),
+    /1 Swift test\(s\) exceeded the local budget/,
+  );
+  const budgetReport = JSON.parse(readFileSync(reportPath, "utf8"));
+  assert.deepEqual(
+    budgetReport.tests.map(({ name, status, durationMs }) => ({ name, status, durationMs })),
+    [{ name: "overBudget()", status: "passed", durationMs: 250 }],
+  );
+} finally {
+  rmSync(swiftBudgetRoot, { recursive: true, force: true });
+}
+
+// A spawn failure must reject promptly and clear the stall watchdog; a leaked
+// ref'd timer would keep the harness process alive for the full stall timeout.
+{
+  const spawnFailureRoot = mkdtempSync(
+    path.join(os.tmpdir(), "lithe-test-stability-swift-spawn-failure-"),
+  );
+  try {
+    await assert.rejects(
+      runSwiftTestsWithTiming(
+        {
+          warnMs: 50,
+          maxMs: 200,
+          stallTimeoutMs: 600000,
+          suiteTimeoutMs: 10000,
+          report: path.join(spawnFailureRoot, "swift-spawn-failure.json"),
+          command: "swift",
+          commandArguments: ["test"],
+        },
+        {
+          runProcessImpl: async () => {
+            throw new Error("spawn ENOENT");
+          },
+        },
+      ),
+      /spawn ENOENT/,
+    );
+    // If the watchdog leaked, the 600s timer would hold this test process open
+    // long past its CI budget; reaching this line with a cleared event loop is
+    // asserted implicitly by the suite finishing on time.
+  } finally {
+    rmSync(spawnFailureRoot, { recursive: true, force: true });
+  }
+}
+
 const rustCompileFailureRoot = mkdtempSync(
   path.join(
     os.tmpdir(),

--- a/macos/Sources/Lithe/Models/AppModel/AppModel+ExecutionModules.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+ExecutionModules.swift
@@ -22,6 +22,11 @@ extension AppModel {
     }
 
     func activateExecutionModule() async -> ExecutionFeatureAccess? {
+        // Run and Debug activate on demand, so they can arrive while the previous
+        // session's module graph is still being torn down. Activating first would
+        // hand back a run feature that teardown releases moments later, and the
+        // deferred action waiting on it would never be resumed.
+        await awaitModuleRuntimeShutdown()
         if let mavenFeature = mavenFeatureIfActive,
            let runFeature = runFeatureIfActive,
            let tests = languageTestServiceIfActive,
@@ -50,6 +55,7 @@ extension AppModel {
     }
 
     func activateDebugModule() async -> DebugFeatureAccess? {
+        await awaitModuleRuntimeShutdown()
         if let genericFeature = genericDebugFeatureIfActive {
             configureDebugHostHandlers(genericFeature)
             if let workspaceURL { genericFeature.openWorkspace(at: workspaceURL) }

--- a/macos/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -485,7 +485,7 @@ final class AppModel: ObservableObject, Identifiable {
             },
             reloadProjectServices: { [weak self] in
                 guard let self, let workspaceURL = self.workspaceURL else { return }
-                await self.loadProjectServices(at: workspaceURL, files: self.projectFiles)
+                await self.loadProjectServicesForAppliedSnapshot(at: workspaceURL)
             },
             refreshGit: { [weak self] in
                 guard let feature = self?.gitFeatureIfActive else { return }
@@ -496,9 +496,15 @@ final class AppModel: ObservableObject, Identifiable {
                 await feature.updateVisibilityRules(rules.localHistoryRules)
             },
             onSnapshotLoaded: { [weak self] snapshot, isInitialLoad in
-                guard let self, let workspaceURL = self.workspaceURL else { return }
-                // WorkspaceFeatureModel requests the single Git refresh after this callback.
-                await self.loadProjectServices(at: workspaceURL, files: snapshot.files)
+                guard let self else { return }
+                // The snapshot callback owns the transition from a provisional
+                // inventory to a ready run project and resumes any deferred action.
+                await self.loadProjectServices(
+                    at: snapshot.root.url,
+                    files: snapshot.files,
+                    snapshotID: snapshot.id,
+                    resumesDeferredRunAction: true
+                )
                 if isInitialLoad {
                     self.projectHistoryFeatureIfActive?.seed(files: snapshot.files)
                 }
@@ -696,9 +702,6 @@ final class AppModel: ObservableObject, Identifiable {
 
     func shutdownProjectSession() async {
         shortcutDetector?.stop()
-        Task { [weak self] in
-            await self?.services.moduleRuntime.shutdownAll()
-        }
         cancelJavaTestWorkflows()
         languageToolingSessionsIfActive?.stopAll()
         languageTestServiceIfActive?.stop()
@@ -711,22 +714,35 @@ final class AppModel: ObservableObject, Identifiable {
         await shutdownModuleRuntime()
     }
 
+    /// Records this session's module-graph teardown before it can yield, so an
+    /// on-demand activation that follows a project switch can join the same
+    /// operation instead of racing a capability release.
+    private func beginModuleRuntimeShutdown() {
+        guard moduleRuntimeShutdownTask == nil else { return }
+        let moduleRuntime = services.moduleRuntime
+        moduleRuntimeShutdownTask = Task { @MainActor [weak self] in
+            await moduleRuntime.shutdownAll()
+            guard let self else { return }
+            self.moduleRuntimeShutdownTask = nil
+            self.clearModuleBindings(for: .database)
+        }
+    }
+
     /// Shuts down this session's module graph once, even when multiple
     /// lifecycle paths request cleanup at the same time.
     private func shutdownModuleRuntime() async {
-        if let moduleRuntimeShutdownTask {
-            await moduleRuntimeShutdownTask.value
-            return
-        }
+        beginModuleRuntimeShutdown()
+        await moduleRuntimeShutdownTask?.value
+    }
 
-        let moduleRuntime = services.moduleRuntime
-        let shutdownTask = Task { @MainActor in
-            await moduleRuntime.shutdownAll()
+    /// Lets an on-demand activation resume after a session teardown finishes.
+    ///
+    /// A shutdown that starts while this wait is suspended is joined as well, so
+    /// activation never returns a capability the runtime is about to release.
+    func awaitModuleRuntimeShutdown() async {
+        while let shutdownTask = moduleRuntimeShutdownTask {
+            await shutdownTask.value
         }
-        moduleRuntimeShutdownTask = shutdownTask
-        await shutdownTask.value
-        moduleRuntimeShutdownTask = nil
-        clearModuleBindings(for: .database)
     }
 
     private func reloadJavaRuntimeServices() {
@@ -743,28 +759,9 @@ final class AppModel: ObservableObject, Identifiable {
             }
             Task { [weak self] in
                 guard let self else { return }
-                await self.loadProjectServices(at: workspaceURL, files: self.projectFiles)
+                await self.loadProjectServicesForAppliedSnapshot(at: workspaceURL)
             }
         }
-    }
-
-    /// Loads build-system and run state at the workspace boundary. The generic
-    /// run lifecycle is intentionally not owned by JavaFeatureModel.
-    func loadProjectServices(at workspaceURL: URL, files: [URL]) async {
-        prepareJavaLanguageServerForWorkspaceIfNeeded(
-            at: workspaceURL,
-            files: files
-        )
-        await springFeature.load(
-            workspaceURL: workspaceURL,
-            files: files,
-            textOverrides: Dictionary(uniqueKeysWithValues: openDocuments.map {
-                ($0.url.standardizedFileURL, $0.text)
-            })
-        )
-        guard let execution = await activateExecutionModule() else { return }
-        execution.tests.discover(workspaceURL: workspaceURL, files: files)
-        await execution.projectDevelopment.loadProject(at: workspaceURL, files: files)
     }
 
     var projectName: String {
@@ -909,10 +906,7 @@ final class AppModel: ObservableObject, Identifiable {
 
     func openProjectDirectly(_ url: URL) {
         let normalizedURL = url.standardizedFileURL
-        Task { [weak self] in
-            guard let self else { return }
-            await self.shutdownModuleRuntime()
-        }
+        beginModuleRuntimeShutdown()
         if let previousWorkspaceURL = workspaceURL {
             workspaceFeature.persistWorkspaceSession(for: previousWorkspaceURL)
         }
@@ -929,6 +923,8 @@ final class AppModel: ObservableObject, Identifiable {
         runtimeFeature.openProject(at: normalizedURL)
         mavenFeatureIfActive?.reset()
         runFeatureIfActive?.reset()
+        pendingRunAction = nil
+        scheduleObjectWillChangeRelay()
         genericDebugFeatureIfActive?.reset()
         debugBreakpointPresentation.reset()
         clearLanguageNavigationProjection()
@@ -963,13 +959,21 @@ final class AppModel: ObservableObject, Identifiable {
         pendingProjectItemDeletion = nil
         recentProjects = recentProjectsStore.record(normalizedURL, in: recentProjects)
 
+        // The rebuild belongs to this opening. Reopening the same path advances
+        // the generation, so a rebuild left over from the previous opening
+        // cannot publish its snapshot into this one.
+        let generation = workspaceFeature.workspaceGeneration
         Task {
             await restoreDebugBreakpoints(for: normalizedURL)
-            guard workspaceURL == normalizedURL else { return }
+            guard workspaceURL == normalizedURL,
+                  workspaceFeature.workspaceGeneration == generation else { return }
             _ = await workspaceFeature.rebuild(
                 at: normalizedURL,
                 rules: visibilityRules,
-                isCurrent: { [weak self] in self?.workspaceURL == normalizedURL }
+                isCurrent: { [weak self] in
+                    self?.workspaceURL == normalizedURL
+                        && self?.workspaceFeature.workspaceGeneration == generation
+                }
             )
         }
     }
@@ -996,10 +1000,7 @@ final class AppModel: ObservableObject, Identifiable {
 
     private func performCloseProject() {
         cancelJavaLanguageServerPreparation()
-        Task { [weak self] in
-            guard let self else { return }
-            await self.shutdownModuleRuntime()
-        }
+        beginModuleRuntimeShutdown()
         if let workspaceURL {
             workspaceFeature.persistWorkspaceSession(for: workspaceURL)
         }
@@ -1039,6 +1040,8 @@ final class AppModel: ObservableObject, Identifiable {
         runtimeFeature.closeProject()
         mavenFeatureIfActive?.reset()
         runFeatureIfActive?.reset()
+        pendingRunAction = nil
+        scheduleObjectWillChangeRelay()
         genericDebugFeatureIfActive?.reset()
         debugBreakpointPresentation.reset()
         javaFeature.stop()


### PR DESCRIPTION
## Purpose

Diagnostic-only combination of:

- PR #375 product fix for RunEntryPoint activation during module teardown
- PR #371 stall-aware Swift test watchdog and descendant sampling

This draft PR is intended to distinguish a real Swift test stall from the old per-test 15-second watchdog false positive. It must not be merged as-is; keep the product fix and CI harness changes in their separate PRs.

## Local verification

- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`
- `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh --suite-timeout-seconds 180 -- --filter RunEntryPointTests`
- Result: 12/12 passed.
