### PR TITLE
fix(windows): keep run test within tauri boundary

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -252,7 +252,10 @@ jobs:
         run: ./.agents/skills/write-stable-tests/scripts/test-stability-windows.ps1 -Scope WindowsRust -SuiteTimeoutSeconds 1080
 
       - name: Generate combined Windows test report
-        if: always()
+        if: >-
+          always() &&
+          (needs.changes.outputs.rust_core == 'true' ||
+          needs.changes.outputs.windows_rust == 'true')
         shell: pwsh
         run: node .agents/skills/write-stable-tests/scripts/generate-test-report.mjs
 

--- a/windows/tauri/src/features/run/api/run-host-api.test.ts
+++ b/windows/tauri/src/features/run/api/run-host-api.test.ts
@@ -1,11 +1,10 @@
-import { Channel } from "@tauri-apps/api/core";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const invoke = mock(async () => undefined);
 
 mock.module("@/platform/tauri-core", () => ({
   invoke,
-  Channel,
+  Channel: class {},
   convertFileSrc: (path: string) => path,
 }));
 mock.module("../utils/run-window-context", () => ({


### PR DESCRIPTION
修复 Windows 运行 API 测试直接导入 `@tauri-apps/api/core` 的问题。

测试通过 `@/platform/tauri-core` mock 提供 `Channel`，避免绕过平台封装边界。

验证：
- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`
- `cd windows/tauri && bun test src/features/run/api/run-host-api.test.ts`