### PR TITLE
docs: prepare release notes for v0.4.0

### DIFF
--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,77 @@
+## 中文
+
+Lithe 0.4.0 将最新的跨平台 Git 工作流、工作树管理和提交历史体验带入稳定版，并继续提升 macOS 工作台与 Windows 运行流程的可靠性。
+
+### 下载
+
+- **项目主页：** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.0/Lithe-0.4.0-arm64.dmg)
+- **macOS Intel：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.0/Lithe-0.4.0-x86_64.dmg)
+- **Windows x64（预览版）：** [下载安装程序](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.0/Lithe-0.4.0-windows-x64.exe)
+- **全部下载：** [查看 Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.0)
+
+> Windows 版本仍处于预览阶段。若未配置 Authenticode 证书，安装程序可能没有数字签名，Windows 可能会显示安全提示。
+
+### 重点更新
+
+- 新增跨平台 Git Worktree 管理，包括创建、删除、路径查看、历史查看，以及从指定 revision 创建工作树。
+- 为 Git 提交历史增加 cursor 分页和增量加载，并在 macOS 与 Windows 统一共享协议、结果适配和测试 fixtures。
+- 改进 Git 分支、引用、状态、提交、差异和推送流程，提升大型变更集的浏览与操作体验。
+- 优化 macOS 工作台分栏、编辑器、Git 日志、缓存和渲染调度，减少异步刷新造成的界面抖动与过期结果问题。
+- 改进 Windows 多窗口运行输出隔离、项目显示别名、Maven 测试进程事件和运行窗口上下文处理。
+- 扩展 Rust Core、macOS 和 Windows 测试覆盖，并改进 CI 测试看门狗和构建诊断流程。
+
+### 升级说明
+
+- **macOS DMG：** 退出正在运行的 Lithe，打开对应架构的 DMG，然后将 Lithe 拖入“应用程序”并替换旧版本。
+- **Homebrew：** 运行 `brew update && brew upgrade --cask lithe`。
+- **Windows：** 退出正在运行的 Lithe，然后运行 Windows x64 安装程序并按提示完成安装。
+
+### 兼容性与已知问题
+
+- macOS 需要 macOS 13 或更高版本。
+- Java 项目功能需要 JDK 17 或更高版本，推荐使用 JDK 17 或 JDK 21。
+- macOS 和 Windows 正式安装包均包含 JDTLS，无需单独安装。
+- Windows 版本仍处于预览阶段，部分平台能力和界面细节可能与 macOS 不完全一致；未配置 Authenticode 证书时安装程序可能显示安全提示。
+
+查看 [v0.3.9 到 v0.4.0 的完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.3.9...v0.4.0)。
+
+---
+
+## English
+
+Lithe 0.4.0 brings the latest cross-platform Git workflows, worktree management, and commit history experience to the stable line while improving macOS workbench performance and Windows run reliability.
+
+### Downloads
+
+- **Project homepage:** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.0/Lithe-0.4.0-arm64.dmg)
+- **macOS Intel:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.0/Lithe-0.4.0-x86_64.dmg)
+- **Windows x64 preview:** [Download installer](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.0/Lithe-0.4.0-windows-x64.exe)
+- **All downloads:** [View Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.0)
+
+> The Windows build remains a preview. If an Authenticode certificate is not configured, the installer may be unsigned and Windows may show a security warning.
+
+### Highlights
+
+- Added cross-platform Git worktree management, including creation, deletion, path inspection, history viewing, and creating worktrees from a selected revision.
+- Added cursor-based pagination and incremental loading for Git commit history, with shared protocols, result adapters, and fixtures across macOS and Windows.
+- Improved Git branch, reference, status, commit, diff, and push workflows for reviewing and operating on large change sets.
+- Improved macOS workbench split panes, editor, Git log, caching, and render scheduling to reduce UI jitter and stale-result issues during asynchronous refreshes.
+- Improved Windows multi-window run-output isolation, project display aliases, Maven test process events, and run-window context handling.
+- Expanded Rust Core, macOS, and Windows test coverage, and improved CI test watchdog and build diagnostics.
+
+### Upgrade instructions
+
+- **macOS DMG:** Quit Lithe, open the DMG for your Mac architecture, and replace the existing application in the Applications folder.
+- **Homebrew:** Run `brew update && brew upgrade --cask lithe`.
+- **Windows:** Quit Lithe, run the Windows x64 installer, and follow the installation prompts.
+
+### Compatibility and known issues
+
+- macOS requires macOS 13 or later.
+- Java project features require JDK 17 or newer. JDK 17 or JDK 21 is recommended.
+- Release packages for macOS and Windows include JDTLS, so it does not need to be installed separately.
+- The Windows build remains a preview, and some platform capabilities and interface details may differ from macOS. The installer may show a security warning when Authenticode signing is not configured.
+
+Review the [full changes from v0.3.9 to v0.4.0](https://github.com/1lck/Lithe-IDEA/compare/v0.3.9...v0.4.0).


### PR DESCRIPTION
## Summary
- Add the required bilingual release notes for v0.4.0.
- Document the Git worktree, history pagination, cross-platform Git, macOS, and Windows updates already present on `main`.
- Include the v0.3.9 to v0.4.0 comparison and versioned asset links.

## Verification
- `node scripts/validate-stable-release-notes.mjs docs/releases/v0.4.0.md`
- `git diff --check`