### PR TITLE
fix(macos): unblock in-app update install after download

### DIFF
--- a/macos/Sources/Lithe/LitheApp.swift
+++ b/macos/Sources/Lithe/LitheApp.swift
@@ -34,9 +34,17 @@ final class LitheAppDelegate: NSObject, NSApplicationDelegate {
         case approved
     }
 
+    /// Upper bound for module/session teardown during in-app update replacement.
+    /// A hung language server or plugin must not leave the installer spinner forever.
+    private static let updateTerminationCleanupTimeoutNanoseconds: UInt64 = 5_000_000_000
+    /// Hard ceiling after requesting update termination; the helper force-kills later.
+    private static let updateTerminationForceExitNanoseconds: UInt64 = 8_000_000_000
+
     private var pendingFileURLs: [URL] = []
     private var terminationCleanupTask: Task<Void, Never>?
     private var terminationCleanupState: TerminationCleanupState = .idle
+    private var isUpdateInstallTermination = false
+    private var updateForceExitTask: Task<Void, Never>?
     weak var projectSessions: ProjectSessionManager? {
         didSet {
             guard let projectSessions else { return }
@@ -63,6 +71,31 @@ final class LitheAppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
+    /// Confirms unsaved work before an update download starts so termination
+    /// during replacement cannot be cancelled mid-install.
+    func prepareForUpdateInstall() -> Bool {
+        guard let projectSessions else { return true }
+        return Self.confirmUnsavedDocuments(
+            for: projectSessions,
+            context: .applicationTermination
+        )
+    }
+
+    /// Starts the post-helper quit path used by the in-app updater.
+    /// Skips cancelable prompts and bounds cleanup so replacement can proceed.
+    func requestTerminationForUpdateInstall() {
+        isUpdateInstallTermination = true
+        updateForceExitTask?.cancel()
+        updateForceExitTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: Self.updateTerminationForceExitNanoseconds)
+            guard let self, self.isUpdateInstallTermination, !Task.isCancelled else { return }
+            // Soft AppKit termination can stall on module shutdown; the staged
+            // helper is already waiting and will replace the bundle after exit.
+            Foundation.exit(EXIT_SUCCESS)
+        }
+        NSApp.terminate(nil)
+    }
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         guard let projectSessions else { return .terminateNow }
 
@@ -78,6 +111,15 @@ final class LitheAppDelegate: NSObject, NSApplicationDelegate {
         case .idle:
             break
         }
+
+        if isUpdateInstallTermination {
+            return beginTerminationCleanup(
+                for: projectSessions,
+                sender: sender,
+                timeoutNanoseconds: Self.updateTerminationCleanupTimeoutNanoseconds
+            )
+        }
+
         return Self.confirmUnsavedDocuments(
             for: projectSessions,
             context: .applicationTermination
@@ -86,11 +128,19 @@ final class LitheAppDelegate: NSObject, NSApplicationDelegate {
 
     private func beginTerminationCleanup(
         for projectSessions: ProjectSessionManager,
-        sender: NSApplication
+        sender: NSApplication,
+        timeoutNanoseconds: UInt64? = nil
     ) -> NSApplication.TerminateReply {
         terminationCleanupState = .cleaning
         terminationCleanupTask = Task { @MainActor [weak self, projectSessions, sender] in
-            await projectSessions.stopAllSessions()
+            if let timeoutNanoseconds {
+                await Self.stopSessions(
+                    projectSessions,
+                    timingOutAfterNanoseconds: timeoutNanoseconds
+                )
+            } else {
+                await projectSessions.stopAllSessions()
+            }
             guard let self, self.terminationCleanupState == .cleaning else { return }
             self.terminationCleanupTask = nil
             self.terminationCleanupState = .approved
@@ -99,7 +149,26 @@ final class LitheAppDelegate: NSObject, NSApplicationDelegate {
         return .terminateLater
     }
 
+    private static func stopSessions(
+        _ projectSessions: ProjectSessionManager,
+        timingOutAfterNanoseconds timeoutNanoseconds: UInt64
+    ) async {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { @MainActor in
+                await projectSessions.stopAllSessions()
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+            }
+            await group.next()
+            group.cancelAll()
+        }
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
+        isUpdateInstallTermination = false
+        updateForceExitTask?.cancel()
+        updateForceExitTask = nil
         NSAppleEventManager.shared().removeEventHandler(
             forEventClass: AEEventClass(kCoreEventClass),
             andEventID: AEEventID(kAEOpenDocuments)
@@ -196,7 +265,7 @@ struct LitheApp: App {
     @StateObject private var projectSessions: ProjectSessionManager
     @StateObject private var memoryUsageMonitor: MemoryUsageMonitor
     @StateObject private var frameRateMonitor = FrameRateMonitor()
-    @StateObject private var updateChecker = UpdateChecker()
+    @StateObject private var updateChecker: UpdateChecker
     private let applicationLogWriter: MacApplicationLogWriter
 
     init() {
@@ -261,10 +330,19 @@ struct LitheApp: App {
             processRegistry: processRegistry,
             memorySampler: MacProcessMemorySampler()
         ))
+        let updateChecker = UpdateChecker()
+        _updateChecker = StateObject(wrappedValue: updateChecker)
         appDelegate.projectSessions = projectSessions
         appDelegate.authorizationCallbackRouter = authorizationCallbackRouter
         appDelegate.recordCleanPluginShutdown = {
             pluginRuntimeRecovery.recordCleanShutdown(using: moduleStore)
+        }
+        let appDelegate = appDelegate
+        updateChecker.prepareForInstall = { [weak appDelegate] in
+            appDelegate?.prepareForUpdateInstall() ?? true
+        }
+        updateChecker.requestTerminationForInstall = { [weak appDelegate] in
+            appDelegate?.requestTerminationForUpdateInstall()
         }
     }
 

--- a/macos/Sources/Lithe/Platform/MacOS/Updates/UpdateChecker.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/Updates/UpdateChecker.swift
@@ -105,6 +105,11 @@ final class UpdateChecker: ObservableObject {
     let currentVersion: String
     var isBusy: Bool { isChecking || isInstalling }
 
+    /// Returns `false` when the user cancels unsaved-document handling before install.
+    var prepareForInstall: (() -> Bool)?
+    /// Invoked after the replacement helper is running so the app can quit for swap-in.
+    var requestTerminationForInstall: (() -> Void)?
+
     private let transport: any UpdateNetworkTransport
     private let preferences: UserDefaults
     private let now: () -> Date
@@ -205,6 +210,12 @@ final class UpdateChecker: ObservableObject {
               let manifest = availableManifest,
               let asset = availableAsset,
               case .available(let version, _) = status else { return }
+
+        // Confirm unsaved work before download so quit-for-replace cannot be cancelled
+        // after the helper is already waiting on this process.
+        if let prepareForInstall, !prepareForInstall() {
+            return
+        }
 
         isInstalling = true
         status = .downloading(version: version, progress: .initial)
@@ -369,11 +380,24 @@ final class UpdateChecker: ObservableObject {
         temporary_root="$5"
         old_app="${target_app}.lithe-old"
 
-        install_without_privileges() {
+        wait_for_app_exit() {
+            attempts=0
             while /bin/kill -0 "$app_pid" 2>/dev/null; do
+                if [ "$attempts" -ge 150 ]; then
+                    # A stale termination request must not leave updates stuck forever.
+                    /bin/kill -TERM "$app_pid" 2>/dev/null || true
+                    /bin/sleep 2
+                    /bin/kill -KILL "$app_pid" 2>/dev/null || true
+                    break
+                fi
                 /bin/sleep 0.2
+                attempts=$((attempts + 1))
             done
             /bin/sleep 0.5
+        }
+
+        install_without_privileges() {
+            wait_for_app_exit
             /bin/rm -rf "$old_app"
             /bin/mv "$target_app" "$old_app"
             if ! /bin/mv "$staged_app" "$target_app"; then
@@ -397,7 +421,8 @@ final class UpdateChecker: ObservableObject {
             set mountPoint to item 4 of argv
             set temporaryRoot to item 5 of argv
             set oldApp to targetApp & ".lithe-old"
-            set installScript to "/bin/sh -c " & quoted form of ("while /bin/kill -0 " & quoted form of appPID & " 2>/dev/null; do /bin/sleep 0.2; done; /bin/sleep 0.5; /bin/rm -rf " & quoted form of oldApp & "; if ! /bin/mv " & quoted form of targetApp & " " & quoted form of oldApp & "; then exit 1; fi; if ! /bin/mv " & quoted form of stagedApp & " " & quoted form of targetApp & "; then /bin/mv " & quoted form of oldApp & " " & quoted form of targetApp & " || true; exit 1; fi; /usr/bin/hdiutil detach " & quoted form of mountPoint & " -force >/dev/null 2>&1 || true; /bin/rm -rf " & quoted form of oldApp & " " & quoted form of temporaryRoot)
+            set waitScript to "attempts=0; while /bin/kill -0 " & quoted form of appPID & " 2>/dev/null; do if [ \"$attempts\" -ge 150 ]; then /bin/kill -TERM " & quoted form of appPID & " 2>/dev/null || true; /bin/sleep 2; /bin/kill -KILL " & quoted form of appPID & " 2>/dev/null || true; break; fi; /bin/sleep 0.2; attempts=$((attempts + 1)); done; /bin/sleep 0.5; "
+            set installScript to "/bin/sh -c " & quoted form of (waitScript & "/bin/rm -rf " & quoted form of oldApp & "; if ! /bin/mv " & quoted form of targetApp & " " & quoted form of oldApp & "; then exit 1; fi; if ! /bin/mv " & quoted form of stagedApp & " " & quoted form of targetApp & "; then /bin/mv " & quoted form of oldApp & " " & quoted form of targetApp & " || true; exit 1; fi; /usr/bin/hdiutil detach " & quoted form of mountPoint & " -force >/dev/null 2>&1 || true; /bin/rm -rf " & quoted form of oldApp & " " & quoted form of temporaryRoot)
             try
                 do shell script installScript with administrator privileges
             on error
@@ -416,9 +441,12 @@ final class UpdateChecker: ObservableObject {
             ofItemAtPath: helperURL.path
         )
 
+        // Detach via nohup so module/process teardown cannot reap the installer
+        // before it replaces the bundle. Redirect I/O so the helper outlives Lithe.
         let helper = Process()
-        helper.executableURL = URL(fileURLWithPath: "/bin/sh")
+        helper.executableURL = URL(fileURLWithPath: "/usr/bin/nohup")
         helper.arguments = [
+            "/bin/sh",
             helperURL.path,
             String(ProcessInfo.processInfo.processIdentifier),
             stagedAppURL.path,
@@ -426,8 +454,15 @@ final class UpdateChecker: ObservableObject {
             mountPoint.path,
             temporaryRoot.path
         ]
+        helper.standardInput = FileHandle.nullDevice
+        helper.standardOutput = FileHandle.nullDevice
+        helper.standardError = FileHandle.nullDevice
         try helper.run()
-        NSApp.terminate(nil)
+        if let requestTerminationForInstall {
+            requestTerminationForInstall()
+        } else {
+            NSApp.terminate(nil)
+        }
     }
 
     private func runProcess(_ executablePath: String, arguments: [String]) throws {

--- a/macos/Tests/LitheTests/UpdateCheckerTests.swift
+++ b/macos/Tests/LitheTests/UpdateCheckerTests.swift
@@ -256,6 +256,54 @@ struct UpdateCheckerTests {
         #expect(!FileManager.default.fileExists(atPath: downloadedFile.path))
     }
 
+    @Test
+    func cancelledInstallPreparationDoesNotStartDownload() async {
+        let downloadStarted = TestGate()
+        let transport = StubUpdateNetworkTransport(
+            fetch: { _ in
+                UpdateHTTPResponse(statusCode: 200, headers: [:], body: manifestData())
+            },
+            download: { _, _ in
+                downloadStarted.open()
+                throw UpdateCheckError.downloadFailed
+            }
+        )
+        let preferences = makePreferences()
+        defer { clear(preferences) }
+        let checker = UpdateChecker(
+            currentVersion: "0.3.0",
+            transport: transport,
+            preferences: preferences,
+            architecture: .arm64
+        )
+        checker.prepareForInstall = { false }
+
+        await checker.checkForUpdates(manual: true)
+        await checker.installAvailableUpdate()
+
+        #expect(checker.status == .available(
+            version: "0.3.1",
+            url: URL(string: "https://github.com/1lck/Lithe-IDEA/releases/tag/v0.3.1")!
+        ))
+        #expect(!downloadStarted.isOpen)
+        #expect(!checker.isBusy)
+    }
+
+    @Test
+    func replacementHelperSurvivesParentExitAndBoundsWait() throws {
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Lithe/Platform/MacOS/Updates/UpdateChecker.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        #expect(source.contains("/usr/bin/nohup"))
+        #expect(source.contains("requestTerminationForInstall"))
+        #expect(source.contains("attempts\" -ge 150"))
+        #expect(source.contains("/bin/kill -KILL"))
+    }
+
     private func makePreferences() -> UserDefaults {
         let suiteName = "lithe.update-tests.\(UUID().uuidString)"
         return UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
## Summary
- macOS in-app updates could hang on **Installing update…** after the DMG finished downloading: the replacement helper waited forever for Lithe to exit, while `NSApp.terminate` could stall on unsaved-document prompts or module/session shutdown.
- Confirm unsaved work **before** download/install, then quit through a dedicated update termination path with bounded cleanup and a hard exit fallback.
- Detach the install helper with `nohup`, bound the wait-for-exit loop (~30s then TERM/KILL), and keep the UI from staying stuck when soft quit does not complete.

## Test plan
- [x] `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`
- [x] `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh -- --filter 'UpdateChecker|UpdateManifest|cancelledInstall|replacementHelper'`
- [ ] Manual: on a build that includes this fix, check for updates, install, confirm app quits and relaunches on the new version (not stuck on installing)
- [ ] Manual: with an unsaved editor tab, start install and confirm the save prompt appears **before** download, and Cancel leaves status as available