### PR TITLE
fix(issue): split UI and UX area labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,7 +43,8 @@ body:
         - Docker
         - Remote and WSL / 远程与 WSL
         - AI
-        - UI and layout / 界面与布局
+        - UI / 界面
+        - UX / 用户体验
         - Other / 其他
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -64,7 +64,8 @@ body:
         - Docker
         - Remote and WSL / 远程与 WSL
         - AI
-        - UI and layout / 界面与布局
+        - UI / 界面
+        - UX / 用户体验
         - Other / 其他
     validations:
       required: true

--- a/.github/workflows/lithe-issue-priority.yml
+++ b/.github/workflows/lithe-issue-priority.yml
@@ -29,13 +29,13 @@ jobs:
               const match = body.match(new RegExp(`###\\s+${heading}\\s*\\r?\\n+([^\\r\\n]+)`, 'i'));
               return match?.[1]?.trim() || '';
             };
-            const priority = field('Priority \/ 优先级').match(/^(P[012])\b/i)?.[1]?.toUpperCase() || null;
+            const priority = field('Priority / 优先级').match(/^(P[012])\b/i)?.[1]?.toUpperCase() || null;
             const platform = {
               'macOS': 'platform:macos',
               'Windows': 'platform:windows',
               'Cross-platform / 跨平台': 'platform:cross-platform',
               'Other / 其他': 'platform:other',
-            }[field('Platform \/ 平台') || field('Target platform \/ 目标平台')] || null;
+            }[field('Platform / 平台') || field('Target platform / 目标平台')] || null;
             const area = {
               'Editor / 编辑器': 'area:editor',
               'Language support / 语言服务': 'area:language',
@@ -54,9 +54,10 @@ jobs:
               'Docker': 'area:docker',
               'Remote and WSL / 远程与 WSL': 'area:remote',
               'AI': 'area:ai',
-              'UI and layout / 界面与布局': 'area:ui',
+              'UI / 界面': 'area:ui',
+              'UX / 用户体验': 'area:ux',
               'Other / 其他': 'area:other',
-            }[field('Area \/ 模块')] || null;
+            }[field('Area / 模块')] || null;
             const type = /^\[(Bug|Feature)\]\s*/i.exec(issue.title || '')?.[1]?.toLowerCase();
             const managedLabels = [
               'bug', 'enhancement', 'P0', 'P1', 'P2',
@@ -64,7 +65,7 @@ jobs:
               'area:editor', 'area:language', 'area:maven', 'area:run', 'area:debug', 'area:test',
               'area:terminal', 'area:git', 'area:github', 'area:project', 'area:search',
               'area:extensions', 'area:settings', 'area:database', 'area:docker', 'area:remote',
-              'area:ai', 'area:ui', 'area:other',
+              'area:ai', 'area:ui', 'area:ux', 'area:other',
             ];
             const selectedLabels = [type === 'bug' ? 'bug' : type === 'feature' ? 'enhancement' : null, platform, area, priority].filter(Boolean);
             const currentLabels = issue.labels


### PR DESCRIPTION
## Summary
- split the Area field into `UI / 界面` and `UX / 用户体验`
- map the two choices to `area:ui` and `area:ux`
- keep the legacy `UI/UX` label available for historical issues

## Verification
- parsed both issue templates and the workflow as YAML
- validated the embedded workflow JavaScript syntax
- exercised UI and UX mapping with a mocked GitHub API flow
- ran `git diff --check`