### PR TITLE
docs(release): add v0.4.1 release notes

### DIFF
--- a/docs/releases/v0.4.1.md
+++ b/docs/releases/v0.4.1.md
@@ -1,0 +1,87 @@
+## 中文
+
+Lithe 0.4.1 改进了工作区、媒体文件和 Git 工作流，让项目浏览、文件查看与仓库操作更加稳定、清晰。
+
+### 下载
+
+- **项目主页：** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.1/Lithe-0.4.1-arm64.dmg)
+- **macOS Intel：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.1/Lithe-0.4.1-x86_64.dmg)
+- **Windows x64：** [下载安装程序](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.1/Lithe-0.4.1-windows-x64.exe)
+- **全部下载：** [查看 Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.1)
+
+### 重点更新
+
+- 工作区和 Git 工作树视图更加稳定，刷新、删除和切换操作能够更准确地保持当前上下文。
+- Git 历史、分支、差异和推送相关界面得到完善，较大的提交历史可以分段加载，仓库状态变化也更不容易造成过期内容覆盖最新结果。
+- 编辑器现在可以在标签页中打开图片和其他媒体文件，并支持缩放和原生媒体查看体验。
+- macOS 与 Windows 的共享 Git 行为、边界处理和测试覆盖得到扩展，减少跨平台操作的不一致。
+- Issue 标签自动化现在区分 UI 与 UX 等不同领域，便于准确归类和筛选问题。
+
+### 升级说明
+
+- **macOS DMG：** 退出正在运行的 Lithe，打开对应架构的 DMG，然后将 Lithe 拖入“应用程序”并替换旧版本。
+- **Homebrew：** 运行 `brew update && brew upgrade --cask lithe`。
+- **Windows：** 退出正在运行的 Lithe，然后运行 Windows x64 安装程序并按提示完成安装。
+
+### 兼容性与已知问题
+
+- macOS 需要 macOS 13 或更高版本。
+- Java 项目功能需要 JDK 17 或更高版本，推荐使用 JDK 17 或 JDK 21。
+- macOS 和 Windows 正式安装包均包含 JDTLS，无需单独安装。
+- Windows 版本仍处于预览阶段，部分平台能力和界面细节可能与 macOS 不完全一致；未配置 Authenticode 证书时安装程序可能显示安全提示。
+- 如果 macOS 提示无法打开 Lithe.app，请在“应用程序”中按住 Control 点按应用并选择“打开”；如果仍被阻止，可在终端执行 `xattr -dr com.apple.quarantine /Applications/Lithe.app`。仅对可信来源的应用使用。
+
+查看 [v0.3.9 到 v0.4.1 的完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.3.9...v0.4.1)。
+
+---
+
+## English
+
+Lithe 0.4.1 improves workspace, media-file, and Git workflows so project navigation, file inspection, and repository operations stay clearer and more reliable.
+
+### Downloads
+
+- **Project homepage:** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.1/Lithe-0.4.1-arm64.dmg)
+- **macOS Intel:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.1/Lithe-0.4.1-x86_64.dmg)
+- **Windows x64:** [Download installer](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.1/Lithe-0.4.1-windows-x64.exe)
+- **All downloads:** [View Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.1)
+
+### Highlights
+
+- Workspace and Git worktree views now preserve the active context more reliably during refresh, removal, and switching operations.
+- Git history, branches, diffs, and push workflows are more complete; large histories load incrementally, and repository changes are less likely to let stale results replace current state.
+- The editor can open images and other media in tabs with zoom support and a native macOS viewing experience.
+- Shared Git behavior, boundary handling, and test coverage were expanded across macOS and Windows to reduce cross-platform inconsistencies.
+- Issue-label automation now distinguishes areas such as UI and UX, making issue triage and filtering more precise.
+
+### Upgrade instructions
+
+- **macOS DMG:** Quit Lithe, open the DMG for your Mac architecture, and replace the existing application in the Applications folder.
+- **Homebrew:** Run `brew update && brew upgrade --cask lithe`.
+- **Windows:** Quit Lithe, run the Windows x64 installer, and follow the installation prompts.
+
+### Compatibility and known issues
+
+- macOS requires macOS 13 or later.
+- Java project features require JDK 17 or newer. JDK 17 or JDK 21 is recommended.
+- Release packages for macOS and Windows include JDTLS, so it does not need to be installed separately.
+- The Windows build remains a preview, and some platform capabilities and interface details may differ from macOS. The installer may show a security warning when Authenticode signing is not configured.
+- If macOS says it cannot open Lithe.app, Control-click it in Applications and choose Open. If it is still blocked, run `xattr -dr com.apple.quarantine /Applications/Lithe.app` in Terminal. Use this only for an app from a source you trust.
+
+Review the [full changes from v0.3.9 to v0.4.1](https://github.com/1lck/Lithe-IDEA/compare/v0.3.9...v0.4.1).
+
+### 贡献者
+
+- [1lck](https://github.com/1lck)
+- [Wz58luck](https://github.com/Wz58luck)
+- [mirakyux](https://github.com/mirakyux)
+- [Rangsh](https://github.com/Rangsh)
+
+### Contributors
+
+- [1lck](https://github.com/1lck)
+- [Wz58luck](https://github.com/Wz58luck)
+- [mirakyux](https://github.com/mirakyux)
+- [Rangsh](https://github.com/Rangsh)


### PR DESCRIPTION
Add the v0.4.1 stable release notes. This PR adds the bilingual release artifact required by the stable macOS and Windows release workflows.