### PR TITLE
fix(macos): 修复编辑器最后一行末尾光标无法到位

### DIFF
--- a/macos/Sources/Lithe/Views/Editor/CodeEditorView.swift
+++ b/macos/Sources/Lithe/Views/Editor/CodeEditorView.swift
@@ -105,6 +105,210 @@ enum EditorLayoutMetrics {
     }
 }
 
+/// Container-local caret geometry for the custom `CodeTextView` insertion point.
+///
+/// AppKit's default insertion-point drawing is disabled so blink width stays
+/// stable; this helper must still match NSTextView's end-of-line and
+/// end-of-document placement, including the extra line fragment after a
+/// trailing newline.
+enum EditorCaretGeometry {
+    static func rect(
+        at location: Int,
+        sourceLength: Int,
+        layoutManager: NSLayoutManager,
+        textContainer: NSTextContainer,
+        caretWidth: CGFloat = EditorLayoutMetrics.caretWidth,
+        fallbackLineHeight: CGFloat
+    ) -> NSRect {
+        let safeLocation = min(max(0, location), max(0, sourceLength))
+
+        if layoutManager.numberOfGlyphs == 0 {
+            return emptyDocumentRect(
+                layoutManager: layoutManager,
+                textContainer: textContainer,
+                caretWidth: caretWidth,
+                fallbackLineHeight: fallbackLineHeight
+            )
+        }
+
+        layoutManager.ensureLayout(for: textContainer)
+
+        if safeLocation >= sourceLength {
+            return documentEndRect(
+                sourceLength: sourceLength,
+                layoutManager: layoutManager,
+                textContainer: textContainer,
+                caretWidth: caretWidth,
+                fallbackLineHeight: fallbackLineHeight
+            )
+        }
+
+        let source = (layoutManager.textStorage?.string as NSString?) ?? ("" as NSString)
+        if source.length > safeLocation {
+            let character = source.character(at: safeLocation)
+            if character == 10 || character == 13 {
+                return lineEndingRect(
+                    at: safeLocation,
+                    source: source,
+                    layoutManager: layoutManager,
+                    textContainer: textContainer,
+                    caretWidth: caretWidth,
+                    fallbackLineHeight: fallbackLineHeight
+                )
+            }
+        }
+
+        return leadingEdgeRect(
+            at: safeLocation,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            caretWidth: caretWidth,
+            fallbackLineHeight: fallbackLineHeight
+        )
+    }
+
+    private static func emptyDocumentRect(
+        layoutManager: NSLayoutManager,
+        textContainer: NSTextContainer,
+        caretWidth: CGFloat,
+        fallbackLineHeight: CGFloat
+    ) -> NSRect {
+        if layoutManager.extraLineFragmentTextContainer === textContainer {
+            let extra = layoutManager.extraLineFragmentUsedRect
+            if extra.height > 0 {
+                return NSRect(
+                    x: extra.minX,
+                    y: extra.minY,
+                    width: caretWidth,
+                    height: max(extra.height, fallbackLineHeight)
+                )
+            }
+        }
+        return NSRect(x: 0, y: 0, width: caretWidth, height: fallbackLineHeight)
+    }
+
+    private static func documentEndRect(
+        sourceLength: Int,
+        layoutManager: NSLayoutManager,
+        textContainer: NSTextContainer,
+        caretWidth: CGFloat,
+        fallbackLineHeight: CGFloat
+    ) -> NSRect {
+        if layoutManager.extraLineFragmentTextContainer === textContainer {
+            let extra = layoutManager.extraLineFragmentUsedRect
+            if extra.height > 0 {
+                return NSRect(
+                    x: extra.minX,
+                    y: extra.minY,
+                    width: caretWidth,
+                    height: max(extra.height, fallbackLineHeight)
+                )
+            }
+        }
+
+        guard sourceLength > 0, layoutManager.numberOfGlyphs > 0 else {
+            return emptyDocumentRect(
+                layoutManager: layoutManager,
+                textContainer: textContainer,
+                caretWidth: caretWidth,
+                fallbackLineHeight: fallbackLineHeight
+            )
+        }
+
+        let lastCharacter = sourceLength - 1
+        let glyphIndex = layoutManager.glyphIndexForCharacter(at: lastCharacter)
+        let glyphRect = layoutManager.boundingRect(
+            forGlyphRange: NSRange(location: glyphIndex, length: 1),
+            in: textContainer
+        )
+        let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+        return NSRect(
+            x: glyphRect.maxX,
+            y: lineRect.minY,
+            width: caretWidth,
+            height: max(lineRect.height, fallbackLineHeight)
+        )
+    }
+
+    private static func lineEndingRect(
+        at location: Int,
+        source: NSString,
+        layoutManager: NSLayoutManager,
+        textContainer: NSTextContainer,
+        caretWidth: CGFloat,
+        fallbackLineHeight: CGFloat
+    ) -> NSRect {
+        // Prefer the trailing edge of the last visible character on this line so
+        // the caret sits after the content rather than on the newline glyph.
+        if let contentIndex = lastVisibleCharacterIndexBeforeLineEnding(
+            at: location,
+            in: source
+        ) {
+            let glyphIndex = layoutManager.glyphIndexForCharacter(at: contentIndex)
+            let glyphRect = layoutManager.boundingRect(
+                forGlyphRange: NSRange(location: glyphIndex, length: 1),
+                in: textContainer
+            )
+            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+            return NSRect(
+                x: glyphRect.maxX,
+                y: lineRect.minY,
+                width: caretWidth,
+                height: max(lineRect.height, fallbackLineHeight)
+            )
+        }
+
+        let glyphIndex = layoutManager.glyphIndexForCharacter(at: location)
+        let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+        let usedRect = layoutManager.lineFragmentUsedRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+        let x = usedRect.height > 0 ? usedRect.minX : lineRect.minX
+        return NSRect(
+            x: x,
+            y: lineRect.minY,
+            width: caretWidth,
+            height: max(lineRect.height, fallbackLineHeight)
+        )
+    }
+
+    /// Walks back over CR/LF so CRLF line ends still anchor to the last glyph.
+    private static func lastVisibleCharacterIndexBeforeLineEnding(
+        at location: Int,
+        in source: NSString
+    ) -> Int? {
+        var index = location - 1
+        while index >= 0 {
+            let character = source.character(at: index)
+            if character == 10 || character == 13 {
+                index -= 1
+                continue
+            }
+            return index
+        }
+        return nil
+    }
+
+    private static func leadingEdgeRect(
+        at location: Int,
+        layoutManager: NSLayoutManager,
+        textContainer: NSTextContainer,
+        caretWidth: CGFloat,
+        fallbackLineHeight: CGFloat
+    ) -> NSRect {
+        let glyphIndex = layoutManager.glyphIndexForCharacter(at: location)
+        let glyphRect = layoutManager.boundingRect(
+            forGlyphRange: NSRange(location: glyphIndex, length: 1),
+            in: textContainer
+        )
+        let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+        return NSRect(
+            x: glyphRect.minX,
+            y: lineRect.minY,
+            width: caretWidth,
+            height: max(lineRect.height, fallbackLineHeight)
+        )
+    }
+}
+
 enum EditorGutterHitTarget: Equatable {
     case breakpoint
     case implementation
@@ -2838,37 +3042,26 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
     private func drawCaret() {
         guard caretVisible,
               window?.firstResponder === self,
+              selectedRange().length == 0,
               let layoutManager,
               let textContainer else { return }
 
         let sourceLength = string.utf16.count
         let location = min(selectedRange().location, sourceLength)
-        let caretRect: NSRect
-        if layoutManager.numberOfGlyphs == 0 {
-            let lineHeight = layoutManager.defaultLineHeight(for: font ?? .systemFont(ofSize: 13))
-            caretRect = NSRect(
-                x: textContainerOrigin.x,
-                y: textContainerOrigin.y,
-                width: EditorLayoutMetrics.caretWidth,
-                height: lineHeight
-            )
-        } else {
-            let isAtDocumentEnd = location == sourceLength
-            let glyphIndex = layoutManager.glyphIndexForCharacter(
-                at: min(location, sourceLength - 1)
-            )
-            let glyphRect = layoutManager.boundingRect(
-                forGlyphRange: NSRange(location: glyphIndex, length: 1),
-                in: textContainer
-            )
-            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
-            caretRect = NSRect(
-                x: textContainerOrigin.x + (isAtDocumentEnd ? glyphRect.maxX : glyphRect.minX),
-                y: textContainerOrigin.y + lineRect.minY,
-                width: EditorLayoutMetrics.caretWidth,
-                height: lineRect.height
-            )
-        }
+        let fallbackLineHeight = layoutManager.defaultLineHeight(
+            for: font ?? .monospacedSystemFont(ofSize: 13, weight: .regular)
+        )
+        let containerRect = EditorCaretGeometry.rect(
+            at: location,
+            sourceLength: sourceLength,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallbackLineHeight
+        )
+        let caretRect = containerRect.offsetBy(
+            dx: textContainerOrigin.x,
+            dy: textContainerOrigin.y
+        )
 
         insertionPointColor.setFill()
         caretRect.fill()
@@ -3650,15 +3843,21 @@ final class CodeTextView: NSTextView, NSLayoutManagerDelegate {
             return NSRect(x: textContainerInset.width, y: textContainerInset.height, width: 1, height: 18)
         }
         let length = string.utf16.count
-        let location = length == 0 ? 0 : min(selectedRange().location, length - 1)
-        let glyph = length == 0 ? 0 : layoutManager.glyphIndexForCharacter(at: location)
-        var rect = layoutManager.boundingRect(
-            forGlyphRange: NSRange(location: glyph, length: 0),
-            in: textContainer
+        let location = min(selectedRange().location, length)
+        let fallbackLineHeight = layoutManager.defaultLineHeight(
+            for: font ?? .monospacedSystemFont(ofSize: 13, weight: .regular)
+        )
+        var rect = EditorCaretGeometry.rect(
+            at: location,
+            sourceLength: length,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            caretWidth: max(1, EditorLayoutMetrics.caretWidth),
+            fallbackLineHeight: fallbackLineHeight
         )
         rect.origin.x += textContainerOrigin.x
         rect.origin.y += textContainerOrigin.y
-        rect.size = NSSize(width: max(1, rect.width), height: max(18, rect.height))
+        rect.size.height = max(18, rect.height)
         return rect
     }
 

--- a/macos/Tests/LitheTests/EditorCaretGeometryTests.swift
+++ b/macos/Tests/LitheTests/EditorCaretGeometryTests.swift
@@ -1,0 +1,176 @@
+import AppKit
+import Testing
+@testable import Lithe
+
+/// Regression coverage for #385: custom caret drawing must reach the true end
+/// of the last line and the extra line after a trailing newline.
+@Suite("Editor caret geometry")
+struct EditorCaretGeometryTests {
+    @MainActor
+    @Test
+    func caretAfterLastCharacterSitsPastTheFinalGlyphWhenFileHasNoTrailingNewline() throws {
+        let textView = makeLaidOutEditor(text: "DP_LOAD_BALANCE_PORT=18081")
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        let length = textView.string.utf16.count
+        let fallback = layoutManager.defaultLineHeight(for: textView.font!)
+
+        let onLastCharacter = EditorCaretGeometry.rect(
+            at: length - 1,
+            sourceLength: length,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallback
+        )
+        let atDocumentEnd = EditorCaretGeometry.rect(
+            at: length,
+            sourceLength: length,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallback
+        )
+
+        #expect(atDocumentEnd.minX > onLastCharacter.minX)
+        #expect(abs(atDocumentEnd.minY - onLastCharacter.minY) < 0.5)
+        #expect(atDocumentEnd.width == EditorLayoutMetrics.caretWidth)
+    }
+
+    @MainActor
+    @Test
+    func caretOnLineEndingSitsAfterVisibleLineContent() throws {
+        let textView = makeLaidOutEditor(text: "first\nsecond\n")
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        let source = textView.string as NSString
+        let fallback = layoutManager.defaultLineHeight(for: textView.font!)
+
+        // Index of the newline after "first"
+        let firstNewline = source.range(of: "\n").location
+        let caretOnNewline = EditorCaretGeometry.rect(
+            at: firstNewline,
+            sourceLength: source.length,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallback
+        )
+        let caretOnLastLetter = EditorCaretGeometry.rect(
+            at: firstNewline - 1,
+            sourceLength: source.length,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallback
+        )
+
+        #expect(caretOnNewline.minX > caretOnLastLetter.minX)
+        #expect(abs(caretOnNewline.minY - caretOnLastLetter.minY) < 0.5)
+    }
+
+    @MainActor
+    @Test
+    func caretAtDocumentEndAfterTrailingNewlineUsesExtraLineFragment() throws {
+        let textView = makeLaidOutEditor(text: "only\n")
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        let length = textView.string.utf16.count
+        let fallback = layoutManager.defaultLineHeight(for: textView.font!)
+
+        let endCaret = EditorCaretGeometry.rect(
+            at: length,
+            sourceLength: length,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallback
+        )
+        let contentCaret = EditorCaretGeometry.rect(
+            at: 0,
+            sourceLength: length,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallback
+        )
+
+        #expect(endCaret.minY > contentCaret.minY)
+        #expect(layoutManager.extraLineFragmentUsedRect.height > 0)
+    }
+
+    @MainActor
+    @Test
+    func caretOnCRLFLineEndingStillSitsAfterVisibleContent() throws {
+        let textView = makeLaidOutEditor(text: "alpha\r\nbeta")
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        let source = textView.string as NSString
+        let fallback = layoutManager.defaultLineHeight(for: textView.font!)
+        let crIndex = source.range(of: "\r").location
+
+        let caretOnCR = EditorCaretGeometry.rect(
+            at: crIndex,
+            sourceLength: source.length,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallback
+        )
+        let caretOnLastLetter = EditorCaretGeometry.rect(
+            at: crIndex - 1,
+            sourceLength: source.length,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallback
+        )
+        let caretOnLF = EditorCaretGeometry.rect(
+            at: crIndex + 1,
+            sourceLength: source.length,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallback
+        )
+
+        #expect(caretOnCR.minX > caretOnLastLetter.minX)
+        #expect(abs(caretOnLF.minX - caretOnCR.minX) < 0.5)
+        #expect(abs(caretOnLF.minY - caretOnCR.minY) < 0.5)
+    }
+
+    @MainActor
+    @Test
+    func emptyDocumentCaretUsesFallbackLineHeight() throws {
+        let textView = makeLaidOutEditor(text: "")
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        let fallback = layoutManager.defaultLineHeight(for: textView.font!)
+
+        let caret = EditorCaretGeometry.rect(
+            at: 0,
+            sourceLength: 0,
+            layoutManager: layoutManager,
+            textContainer: textContainer,
+            fallbackLineHeight: fallback
+        )
+
+        #expect(caret.height >= fallback)
+        #expect(caret.width == EditorLayoutMetrics.caretWidth)
+    }
+
+    @MainActor
+    private func makeLaidOutEditor(text: String) -> CodeTextView {
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 640, height: 240))
+        textView.font = LitheTheme.editorFont(size: 13)
+        textView.defaultParagraphStyle = LitheTheme.editorParagraphStyle
+        textView.string = text
+        textView.textContainerInset = NSSize(width: EditorLayoutMetrics.leadingInset, height: 0)
+        textView.textContainer?.lineFragmentPadding = EditorLayoutMetrics.lineFragmentPadding
+        if let textStorage = textView.textStorage, textStorage.length > 0 {
+            textStorage.addAttributes(
+                [
+                    .font: textView.font as Any,
+                    .paragraphStyle: textView.defaultParagraphStyle as Any
+                ],
+                range: NSRange(location: 0, length: textStorage.length)
+            )
+        }
+        textView.layoutManager?.delegate = textView
+        if let layoutManager = textView.layoutManager, let textContainer = textView.textContainer {
+            layoutManager.ensureLayout(for: textContainer)
+        }
+        return textView
+    }
+}


### PR DESCRIPTION
## 摘要

- 修复 macOS 编辑器自绘 caret 在**最后一行行尾 / 文档末尾**画偏或看起来“点不过去”的问题（#385）
- 抽出 `EditorCaretGeometry`，按 NSTextView 语义处理：行尾换行、无尾换行文档末、有尾换行的 extra line fragment、CRLF
- 有选区时不再绘制 insertion point；补全/菜单锚点 `caretAnchorRect` 同步同一套几何
- 新增 `EditorCaretGeometryTests` 回归覆盖

## 原因

`CodeTextView` 关闭了系统 `drawInsertionPoint`，旧逻辑仅用 `location == length ? maxX : minX`，无法正确表达：

1. 光标落在 `\n`/`\r` 上的行尾
2. 文档以换行结束时的空最后一行（extra line fragment）
3. 无尾换行时文档真正末尾

## 验证

- [x] `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`
- [x] `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh -- --filter EditorCaretGeometry`（5/5）
- [x] 本地预览包实机测试：最后一行末尾键盘/鼠标均可到位（报告人确认已修复）

## 相关 Issue

Closes #385