### PR TITLE
docs(release): add v0.4.2 release notes

### DIFF
--- a/docs/releases/v0.4.2.md
+++ b/docs/releases/v0.4.2.md
@@ -1,0 +1,95 @@
+## 中文
+
+Lithe 0.4.2 改进了 Maven 运行与调试、Windows 调试与差异查看，以及 macOS 编辑器和亮色工作区体验，让日常开发更顺手、更稳定。
+
+### 下载
+
+- **项目主页：** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.2/Lithe-0.4.2-arm64.dmg)
+- **macOS Intel：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.2/Lithe-0.4.2-x86_64.dmg)
+- **Windows x64：** [下载安装程序](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.2/Lithe-0.4.2-windows-x64.exe)
+- **全部下载：** [查看 Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.2)
+
+### 重点更新
+
+- Maven 多模块项目运行或调试子模块时，会一并构建所需依赖模块，避免本地模块被当成远程依赖导致启动失败。
+- 可在设置中指定 Maven 本地仓库路径；本机已安装较新 Maven 时，不再因 wrapper 声明的旧版本而无法运行。
+- Maven 项目能更准确识别源码根、资源根和生成源码目录，并在项目树中区分展示。
+- Windows 调试链路接通原生调试适配，可更完整地使用断点、步进和变量查看等调试能力。
+- Windows 运行配置列表支持左右拖拽调整宽度，长应用名不再容易被截断，宽度会在重启后保留。
+- Windows 查看 `pom.xml` 等差异时，不再因高亮重叠出现文字错乱或重影。
+- macOS 编辑器可把光标稳定移到最后一行末尾和文档末尾，键盘与鼠标定位更准确。
+- macOS 亮色主题下的工作区分隔、目录图标和“标记为源码/资源/排除”等目录标记更清晰，也更接近熟悉的 IDE 习惯。
+
+### 升级说明
+
+- **macOS DMG：** 退出正在运行的 Lithe，打开对应架构的 DMG，然后将 Lithe 拖入“应用程序”并替换旧版本。
+- **Homebrew：** 运行 `brew update && brew upgrade --cask lithe`。
+- **Windows：** 退出正在运行的 Lithe，然后运行 Windows x64 安装程序并按提示完成安装。
+
+### 兼容性与已知问题
+
+- macOS 需要 macOS 13 或更高版本。
+- Java 项目功能需要 JDK 17 或更高版本，推荐使用 JDK 17 或 JDK 21。
+- macOS 和 Windows 正式安装包均包含 JDTLS，无需单独安装。
+- Windows 版本仍处于预览阶段，部分平台能力和界面细节可能与 macOS 不完全一致；未配置 Authenticode 证书时安装程序可能显示安全提示。
+- 如果 macOS 提示无法打开 Lithe.app，请在“应用程序”中按住 Control 点按应用并选择“打开”；如果仍被阻止，可在终端执行 `xattr -dr com.apple.quarantine /Applications/Lithe.app`。仅对可信来源的应用使用。
+
+查看 [v0.4.1 到 v0.4.2 的完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.4.1...v0.4.2)。
+
+---
+
+## English
+
+Lithe 0.4.2 improves Maven run and debug flows, Windows debugging and diff viewing, and the macOS editor and light-theme workspace so everyday development stays smoother and more reliable.
+
+### Downloads
+
+- **Project homepage:** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.2/Lithe-0.4.2-arm64.dmg)
+- **macOS Intel:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.2/Lithe-0.4.2-x86_64.dmg)
+- **Windows x64:** [Download installer](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.2/Lithe-0.4.2-windows-x64.exe)
+- **All downloads:** [View Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.2)
+
+### Highlights
+
+- Running or debugging a Maven reactor submodule now also builds the modules it depends on, so local modules are less likely to be treated as remote dependencies and fail to start.
+- You can set a custom Maven local repository path; a newer locally installed Maven is no longer blocked just because the wrapper declares an older version.
+- Maven projects recognize source, resource, and generated source roots more accurately and show them more clearly in the project tree.
+- Windows debugging now uses a native debug adapter path, so breakpoints, stepping, and variable inspection work more completely.
+- The Windows Run configuration list can be resized horizontally, so long application names are easier to read and the chosen width is kept after restart.
+- Windows diffs for files such as `pom.xml` no longer scramble or ghost text because of overlapping highlights.
+- The macOS editor can place the caret reliably at the end of the last line and at the end of the document with both keyboard and mouse.
+- The macOS light theme improves workbench separation, directory icons, and “mark as source/resource/excluded” directory marks so the workspace feels clearer and more familiar.
+
+### Upgrade instructions
+
+- **macOS DMG:** Quit Lithe, open the DMG for your Mac architecture, and replace the existing application in the Applications folder.
+- **Homebrew:** Run `brew update && brew upgrade --cask lithe`.
+- **Windows:** Quit Lithe, run the Windows x64 installer, and follow the installation prompts.
+
+### Compatibility and known issues
+
+- macOS requires macOS 13 or later.
+- Java project features require JDK 17 or newer. JDK 17 or JDK 21 is recommended.
+- Release packages for macOS and Windows include JDTLS, so it does not need to be installed separately.
+- The Windows build remains a preview, and some platform capabilities and interface details may differ from macOS. The installer may show a security warning when Authenticode signing is not configured.
+- If macOS says it cannot open Lithe.app, Control-click it in Applications and choose Open. If it is still blocked, run `xattr -dr com.apple.quarantine /Applications/Lithe.app` in Terminal. Use this only for an app from a source you trust.
+
+Review the [full changes from v0.4.1 to v0.4.2](https://github.com/1lck/Lithe-IDEA/compare/v0.4.1...v0.4.2).
+
+### 贡献者
+
+- [1lck](https://github.com/1lck)
+- [Rangsh](https://github.com/Rangsh)
+- [Mucheen](https://github.com/Mucheen)
+- [puppyben1](https://github.com/puppyben1)
+- [xiaoyumuxi](https://github.com/xiaoyumuxi)
+
+### Contributors
+
+- [1lck](https://github.com/1lck)
+- [Rangsh](https://github.com/Rangsh)
+- [Mucheen](https://github.com/Mucheen)
+- [puppyben1](https://github.com/puppyben1)
+- [xiaoyumuxi](https://github.com/xiaoyumuxi)


### PR DESCRIPTION
## Summary
- Add bilingual stable release notes for **v0.4.2**
- Notes cover user-facing changes since v0.4.1 (Maven run/debug, Windows debug/diffs, macOS editor and light-theme workspace)
- Validated with `node scripts/validate-stable-release-notes.mjs docs/releases/v0.4.2.md`

## Release plan
After merge to `main`:
1. Tag `v0.4.2` on the merge commit
2. Tag push triggers `Release macOS` and `Release Windows`
3. Homebrew cask update PR is opened by the macOS release workflow