### PR TITLE
修复 Windows 窗口拖拽卡顿问题

### DIFF
--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -166,8 +166,8 @@ if (-not $profileRoot.StartsWith($targetPrefix, [System.StringComparison]::Ordin
     throw "Windows Cargo target profile must stay inside $cargoTargetRoot"
 }
 $bundleDirectory = Join-Path $profileRoot "bundle/nsis"
-$bundle = Get-ChildItem -LiteralPath $bundleDirectory -Filter "*.exe" -File |
-    Select-Object -First 1
+$bundleName = "Lithe_${Version}_x64-setup.exe"
+$bundle = Get-Item -LiteralPath (Join-Path $bundleDirectory $bundleName) -ErrorAction SilentlyContinue
 if ($null -eq $bundle) { throw "Tauri NSIS installer was not found in $bundleDirectory" }
 
 New-Item -ItemType Directory -Force -Path $output | Out-Null

--- a/windows/tauri/src/App.tsx
+++ b/windows/tauri/src/App.tsx
@@ -45,11 +45,7 @@ function InitialWindowShell() {
 
   return (
     <div className="h-dvh w-dvw overflow-hidden bg-surface">
-      <div
-        className="h-10 w-full bg-surface/70"
-        data-tauri-drag-region
-        onMouseDown={handleMouseDown}
-      />
+      <div className="h-10 w-full bg-surface/70" onMouseDown={handleMouseDown} />
       <div className="h-[calc(100dvh-2.5rem)] w-full bg-background" />
     </div>
   );

--- a/windows/tauri/src/features/window/components/title-bar/title-bar.tsx
+++ b/windows/tauri/src/features/window/components/title-bar/title-bar.tsx
@@ -279,7 +279,6 @@ const TitleBar = ({ showMinimal = false, onOpenProjectPicker }: TitleBarProps) =
     return (
       <ChromeBar
         region="title"
-        data-tauri-drag-region
         onMouseDown={handleTitleBarMouseDown}
         className="lithe-title-bar relative z-50 justify-between select-none"
       >
@@ -305,7 +304,6 @@ const TitleBar = ({ showMinimal = false, onOpenProjectPicker }: TitleBarProps) =
             "lithe-title-bar font-sans ui-text-chrome relative z-50 flex h-(--lithe-title-bar-height) items-center justify-between gap-(--lithe-chrome-gap) bg-transparent pr-(--lithe-chrome-padding-inline) text-subtle-foreground",
             isFullscreen ? "pl-2" : "pl-23.5",
           )}
-          data-tauri-drag-region
           onMouseDown={handleTitleBarMouseDown}
         >
           <ChromeGroup className="pointer-events-auto h-full">
@@ -325,12 +323,11 @@ const TitleBar = ({ showMinimal = false, onOpenProjectPicker }: TitleBarProps) =
   return (
     <ContextMenu>
       <ContextMenuTrigger
-        data-tauri-drag-region
         onMouseDown={handleTitleBarMouseDown}
         onContextMenu={handleTitleBarContextMenu}
         className="lithe-title-bar font-sans ui-text-chrome relative z-50 flex h-(--lithe-title-bar-height) items-center justify-between gap-(--lithe-chrome-gap) bg-surface px-(--lithe-chrome-padding-inline) text-muted-foreground"
       >
-        <ChromeGroup data-tauri-drag-region grow className="min-w-0">
+        <ChromeGroup grow className="min-w-0">
           <ChromeGroup className="pointer-events-auto min-w-0">
             {menuItem}
             {projectControls}


### PR DESCRIPTION
## 问题

Windows 客户端窗口拖动时存在明显卡顿和延迟。

## 修复内容

- 移除 Windows 标题栏上的 data-tauri-drag-region 自动拖动机制
- 改用手动 startDragging() 拖动路径
- 保留按钮、输入框等交互控件的排除逻辑
- 修复 Windows 打包脚本可能选中旧安装包的问题

## 验证

- bun test src/features/window/utils/title-bar-drag.test.ts：3 个测试通过
- bun run typecheck：通过
- 已构建并安装 0.4.1-dragfix.2
- 已实际验证窗口拖拽恢复正常

该分支已 rebase 到上游最新 main，当前无冲突。
 #484 
