### PR TITLE
perf(macos): eliminate per-keystroke full-text synchronization

### DIFF
--- a/macos/Sources/Lithe/Models/Editor/EditorDocument.swift
+++ b/macos/Sources/Lithe/Models/Editor/EditorDocument.swift
@@ -59,6 +59,22 @@ final class EditorDocument: ObservableObject, Identifiable, @unchecked Sendable 
         replaceText(newText, publish: isDirty != remainsUnpersisted)
     }
 
+    /// Applies the editor's latest change without asking the NSTextView for a
+    /// full document snapshot. The editor and document model stay in lockstep
+    /// through the same UTF-16 range used by NSTextView.
+    func applyLiveEditorEdit(replacedRange: NSRange, replacement: String) {
+        let source = storedText as NSString
+        guard replacedRange.location != NSNotFound,
+              replacedRange.location >= 0,
+              replacedRange.length >= 0,
+              replacedRange.location <= source.length,
+              replacedRange.length <= source.length - replacedRange.location else {
+            return
+        }
+        let nextText = source.replacingCharacters(in: replacedRange, with: replacement)
+        applyLiveEditorText(nextText)
+    }
+
     private func replaceText(_ newText: String, publish: Bool) {
         guard storedText != newText else { return }
         let nextRevision = lifecycleState.revision + 1

--- a/macos/Sources/Lithe/Views/Editor/CodeEditorView.swift
+++ b/macos/Sources/Lithe/Views/Editor/CodeEditorView.swift
@@ -1300,7 +1300,18 @@ struct CodeEditorView: NSViewRepresentable {
             }
             gutter?.refreshLineNumberLayout()
             isApplyingEditorChange = true
-            document?.applyLiveEditorText(textView.string)
+            if let document,
+               let replacedRange = pendingReplacedRange,
+               let replacement = pendingReplacement {
+                document.applyLiveEditorEdit(
+                    replacedRange: replacedRange,
+                    replacement: replacement
+                )
+            } else {
+                // Programmatic edits may not provide shouldChangeTextIn
+                // metadata. Keep this recovery path for those edits only.
+                document?.applyLiveEditorText(textView.string)
+            }
             if let document,
                let previousSource,
                let replacedRange = pendingReplacedRange,

--- a/macos/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/macos/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -3238,6 +3238,30 @@ struct EditorDocumentTests {
     }
 
     @Test
+    @MainActor
+    func liveEditorEditAppliesUTF16ReplacementWithoutFullEditorSnapshot() {
+        let document = EditorDocument(
+            url: URL(fileURLWithPath: "/tmp/live-editor-edit.txt"),
+            text: "before\nvalue",
+            modificationDate: nil
+        )
+
+        document.applyLiveEditorEdit(
+            replacedRange: NSRange(location: 7, length: 5),
+            replacement: "updated"
+        )
+
+        #expect(document.text == "before\nupdated")
+        #expect(document.isDirty)
+
+        document.applyLiveEditorEdit(
+            replacedRange: NSRange(location: 0, length: 0),
+            replacement: "A"
+        )
+        #expect(document.text == "Abefore\nupdated")
+    }
+
+    @Test
     func rustDocumentLifecyclePreservesDirtyEditorTextOnExternalChange() throws {
         let core = RustCoreBridge()
         guard core.isAvailable else { return }


### PR DESCRIPTION
## Summary
- apply normal editor edits through the NSTextView UTF-16 replacement range
- avoid reading the full editor buffer on every keystroke
- retain a full-text fallback for programmatic edits without range metadata
- add regression coverage for incremental document edits

## Validation
- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`
- `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh -- --filter liveEditorEditAppliesUTF16ReplacementWithoutFullEditorSnapshot`
- `./scripts/verify-service-boundaries.sh`
- `./scripts/test-macos.sh`
- `git diff --check`

Closes #488