### PR TITLE
perf(macos): send incremental LSP document changes

### DIFF
--- a/macos/Sources/Lithe/Core/Rust/RustCoreBridge.swift
+++ b/macos/Sources/Lithe/Core/Rust/RustCoreBridge.swift
@@ -9,7 +9,7 @@ import LitheRustCore
 /// The JSON request/response shape is also the contract that the future
 /// Windows Qt binding will consume. The bridge stays synchronous at this
 /// layer; callers move filesystem and Git work off the main actor.
-struct RustCoreBridge: Sendable {
+struct RustCoreBridge: Sendable, IncrementalLanguageServerRuntimeCore {
     private struct Request<Payload: Encodable>: Encodable {
         let id: String
         let operationId: String?
@@ -1669,10 +1669,23 @@ struct RustCoreBridge: Sendable {
     }
 
     private struct LspSyncDocumentRequest: Encodable {
+        struct Change: Encodable {
+            let range: Range
+            let text: String
+        }
+        struct Position: Encodable {
+            let line: Int
+            let character: Int
+        }
+        struct Range: Encodable {
+            let start: LspSyncDocumentRequest.Position
+            let end: LspSyncDocumentRequest.Position
+        }
         let sessionId: String
         let uri: String
         let languageId: String
         let text: String
+        let contentChanges: [Change]
     }
 
     private struct LspWorkspaceFilesChangedRequest: Encodable {
@@ -3403,7 +3416,8 @@ struct RustCoreBridge: Sendable {
         sessionID: String,
         fileURL: URL,
         languageID: String,
-        text: String
+        text: String,
+        changes: [LanguageServerDocumentChange] = []
     ) -> Result<LspSyncDocumentPayload, CoreCallError> {
         executeResult(
             command: "lsp.syncDocument",
@@ -3411,9 +3425,53 @@ struct RustCoreBridge: Sendable {
                 sessionId: sessionID,
                 uri: fileURL.standardizedFileURL.absoluteString,
                 languageId: languageID,
-                text: text
+                // Keep the full snapshot for the initial didOpen and as a
+                // recovery source; Rust emits range-based didChange when safe.
+                text: text,
+                contentChanges: changes.map { change in
+                    LspSyncDocumentRequest.Change(
+                        range: .init(
+                            start: LspSyncDocumentRequest.Position(
+                                line: change.start.line,
+                                character: change.start.utf16Column
+                            ),
+                            end: LspSyncDocumentRequest.Position(
+                                line: change.end.line,
+                                character: change.end.utf16Column
+                            )
+                        ),
+                        text: change.text
+                    )
+                }
             )
         )
+    }
+
+    func syncLanguageServerDocument(
+        sessionID: String,
+        fileURL: URL,
+        languageID: String,
+        text: String,
+        changes: [LanguageServerDocumentChange]
+    ) -> Result<LanguageServerDocumentSync, LanguageServerRuntimeFailure> {
+        lspSyncDocument(
+            sessionID: sessionID,
+            fileURL: fileURL,
+            languageID: languageID,
+            text: text,
+            changes: changes
+        ).map {
+            LanguageServerDocumentSync(
+                documentVersion: $0.documentVersion,
+                changed: $0.changed
+            )
+        }.mapError { error in
+            LanguageServerRuntimeFailure(
+                code: error.code,
+                message: error.message,
+                details: error.details
+            )
+        }
     }
 
     func lspWorkspaceFilesChanged(

--- a/macos/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -1395,7 +1395,8 @@ final class AppModel: ObservableObject, Identifiable {
             try languageToolingSessions.synchronizeLanguageServer(
                 for: document.url,
                 text: document.text,
-                rootURL: workspaceURL
+                rootURL: workspaceURL,
+                changes: document.takePendingLanguageServerChanges()
             )
             languageToolingFeature.markActivationSucceeded(providerID: descriptor.id)
             if let moduleID = services.pluginCatalog.languageSupport(for: document.url)?

--- a/macos/Sources/Lithe/Models/Editor/EditorDocument.swift
+++ b/macos/Sources/Lithe/Models/Editor/EditorDocument.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LitheCoreContracts
 
 @MainActor
 final class EditorDocument: ObservableObject, Identifiable, @unchecked Sendable {
@@ -25,6 +26,7 @@ final class EditorDocument: ObservableObject, Identifiable, @unchecked Sendable 
     @Published private(set) var savedText: String
     private(set) var lifecycleState: DocumentLifecycleState
     private(set) var lastKnownModificationDate: Date?
+    private var pendingLanguageServerChanges: [LanguageServerDocumentChange] = []
 
     init(
         url: URL,
@@ -71,8 +73,37 @@ final class EditorDocument: ObservableObject, Identifiable, @unchecked Sendable 
               replacedRange.length <= source.length - replacedRange.location else {
             return
         }
+        let start = Self.position(at: replacedRange.location, in: source)
+        let end = Self.position(at: NSMaxRange(replacedRange), in: source)
+        pendingLanguageServerChanges.append(
+            LanguageServerDocumentChange(
+                start: start,
+                end: end,
+                text: replacement
+            )
+        )
         let nextText = source.replacingCharacters(in: replacedRange, with: replacement)
         applyLiveEditorText(nextText)
+    }
+
+    func takePendingLanguageServerChanges() -> [LanguageServerDocumentChange] {
+        defer { pendingLanguageServerChanges.removeAll(keepingCapacity: true) }
+        return pendingLanguageServerChanges
+    }
+
+    private static func position(
+        at offset: Int,
+        in source: NSString
+    ) -> LanguageServerDocumentPosition {
+        let safeOffset = min(max(offset, 0), source.length)
+        let lineRange = source.lineRange(
+            for: NSRange(location: safeOffset, length: 0)
+        )
+        return LanguageServerDocumentPosition(
+            line: source.substring(with: NSRange(location: 0, length: lineRange.location))
+                .split(separator: "\n", omittingEmptySubsequences: false).count - 1,
+            utf16Column: safeOffset - lineRange.location
+        )
     }
 
     private func replaceText(_ newText: String, publish: Bool) {

--- a/macos/Sources/LitheCoreContracts/Language/LanguageServerRuntimeContracts.swift
+++ b/macos/Sources/LitheCoreContracts/Language/LanguageServerRuntimeContracts.swift
@@ -83,6 +83,42 @@ package struct LanguageServerDocumentSync: Equatable, Sendable {
     }
 }
 
+package struct LanguageServerDocumentPosition: Equatable, Sendable, Codable {
+    package let line: Int
+    package let utf16Column: Int
+
+    package init(line: Int, utf16Column: Int) {
+        self.line = line
+        self.utf16Column = utf16Column
+    }
+}
+
+package struct LanguageServerDocumentChange: Equatable, Sendable, Codable {
+    package let start: LanguageServerDocumentPosition
+    package let end: LanguageServerDocumentPosition
+    package let text: String
+
+    package init(
+        start: LanguageServerDocumentPosition,
+        end: LanguageServerDocumentPosition,
+        text: String
+    ) {
+        self.start = start
+        self.end = end
+        self.text = text
+    }
+}
+
+package protocol IncrementalLanguageServerRuntimeCore {
+    func syncLanguageServerDocument(
+        sessionID: String,
+        fileURL: URL,
+        languageID: String,
+        text: String,
+        changes: [LanguageServerDocumentChange]
+    ) -> Result<LanguageServerDocumentSync, LanguageServerRuntimeFailure>
+}
+
 package enum LanguageServerWorkspaceFileChangeKind: String, Equatable, Sendable {
     case created
     case changed

--- a/macos/Sources/LitheLanguageIntelligenceModule/Runtime/LanguageServerSession.swift
+++ b/macos/Sources/LitheLanguageIntelligenceModule/Runtime/LanguageServerSession.swift
@@ -168,6 +168,29 @@ package final class LanguageServerRuntimeSession: LanguageServerSession {
         }
     }
 
+    package func synchronize(
+        fileURL: URL,
+        text: String,
+        languageID: String,
+        changes: [LanguageServerDocumentChange]
+    ) throws {
+        guard let sessionID else { throw LanguageServerRuntimeSessionError.notReady }
+        guard let incrementalCore = core as? any IncrementalLanguageServerRuntimeCore else {
+            return try synchronize(fileURL: fileURL, text: text, languageID: languageID)
+        }
+        switch incrementalCore.syncLanguageServerDocument(
+            sessionID: sessionID,
+            fileURL: fileURL.standardizedFileURL,
+            languageID: languageID,
+            text: text,
+            changes: changes
+        ) {
+        case .success(let sync):
+            documentVersions[fileURL.standardizedFileURL] = sync.documentVersion
+        case .failure(let error):
+            throw LanguageServerRuntimeSessionError.documentSyncFailed(error.userMessage)
+        }
+    }
     package func notifyWorkspaceFilesChanged(
         _ changes: [LanguageServerWorkspaceFileChange]
     ) throws {

--- a/macos/Sources/LitheLanguageIntelligenceModule/Services/LanguageToolingSessionManager.swift
+++ b/macos/Sources/LitheLanguageIntelligenceModule/Services/LanguageToolingSessionManager.swift
@@ -235,7 +235,8 @@ package final class LanguageToolingSessionManager: ObservableObject,
     package func synchronizeLanguageServer(
         for fileURL: URL,
         text: String,
-        rootURL: URL
+        rootURL: URL,
+        changes: [LanguageServerDocumentChange] = []
     ) throws {
         guard let descriptor = catalog.provider(for: fileURL) else {
             throw LanguageToolingSessionError.noProvider(fileExtension: fileURL.pathExtension.lowercased())
@@ -249,12 +250,22 @@ package final class LanguageToolingSessionManager: ObservableObject,
             rootURL: normalizedRoot,
             operationID: nil
         )
-        try session.synchronize(
-            fileURL: fileURL,
-            text: text,
-            languageID: extensionLanguageIdentifiers[descriptor.id]
-                ?? descriptor.languageIdentifier(for: fileURL)
-        )
+        if let incremental = session as? LanguageServerRuntimeSession {
+            try incremental.synchronize(
+                fileURL: fileURL,
+                text: text,
+                languageID: extensionLanguageIdentifiers[descriptor.id]
+                    ?? descriptor.languageIdentifier(for: fileURL),
+                changes: changes
+            )
+        } else {
+            try session.synchronize(
+                fileURL: fileURL,
+                text: text,
+                languageID: extensionLanguageIdentifiers[descriptor.id]
+                    ?? descriptor.languageIdentifier(for: fileURL)
+            )
+        }
     }
 
     /// Starts one workspace-owned session without opening a document.

--- a/macos/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/macos/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -3266,6 +3266,31 @@ struct EditorDocumentTests {
 
     @Test
     @MainActor
+    func liveEditorEditsProduceOrderedLanguageServerChanges() {
+        let document = EditorDocument(
+            url: URL(fileURLWithPath: "/tmp/live-editor-lsp.txt"),
+            text: "one\ntwo",
+            modificationDate: nil
+        )
+
+        document.applyLiveEditorEdit(
+            replacedRange: NSRange(location: 4, length: 3),
+            replacement: "second"
+        )
+        document.applyLiveEditorEdit(
+            replacedRange: NSRange(location: 0, length: 0),
+            replacement: "A"
+        )
+
+        let changes = document.takePendingLanguageServerChanges()
+        #expect(changes.map(\.text) == ["second", "A"])
+        #expect(changes[0].start == LanguageServerDocumentPosition(line: 1, utf16Column: 0))
+        #expect(changes[0].end == LanguageServerDocumentPosition(line: 1, utf16Column: 3))
+        #expect(document.takePendingLanguageServerChanges().isEmpty)
+    }
+
+    @Test
+    @MainActor
     func liveEditorEditAppliesUTF16ReplacementWithoutFullEditorSnapshot() {
         let document = EditorDocument(
             url: URL(fileURLWithPath: "/tmp/live-editor-edit.txt"),


### PR DESCRIPTION
## Summary
- record ordered editor edits as UTF-16 LSP ranges
- pass incremental content changes through the macOS language-service bridge
- use the existing Rust Core fallback when incremental replay is unsafe or unsupported
- preserve full text for initial document open and recovery
- add regression coverage for ordered edit batches

## Validation
- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`
- `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh -- --filter liveEditorEditsProduceOrderedLanguageServerChanges`
- `./scripts/verify-service-boundaries.sh`
- `./scripts/verify-rust-core.sh`
- `./scripts/test-macos.sh`
- `git diff --check`

Closes #493