### PR TITLE
fix(macos): 优化新建文件和文件夹弹窗样式

### DIFF
--- a/macos/Sources/Lithe/Theme/LitheTheme.swift
+++ b/macos/Sources/Lithe/Theme/LitheTheme.swift
@@ -418,6 +418,7 @@ enum LitheTheme {
         static let statusBarHeight: CGFloat = 24
         static let cornerRadius: CGFloat = 5
         static let popupCornerRadius: CGFloat = 10
+        static let contextMenuCornerRadius: CGFloat = 9
         static let controlCornerRadius: CGFloat = 6
     }
 }
@@ -630,6 +631,20 @@ extension View {
             RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(color)
         }
+    }
+
+    func litheContextMenuSurface(
+        cornerRadius: CGFloat = LitheTheme.Metrics.contextMenuCornerRadius
+    ) -> some View {
+        self
+            .litheRoundedControlBackground(
+                LitheTheme.contextMenuBackground,
+                cornerRadius: cornerRadius
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .stroke(LitheTheme.panelBorder, lineWidth: 1)
+            }
     }
 
     /// 浮层统一外观：圆角、背景、1pt 边框和投影。

--- a/macos/Sources/Lithe/Views/Workspace/ProjectSidebarView.swift
+++ b/macos/Sources/Lithe/Views/Workspace/ProjectSidebarView.swift
@@ -1,5 +1,6 @@
 import LitheCoreContracts
 import LitheGitModule
+import AppKit
 import SwiftUI
 
 struct ProjectSidebarView: View {
@@ -119,12 +120,17 @@ struct ProjectSidebarView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .sheet(item: $model.projectItemEditRequest) { request in
+        .sheet(item: renameRequest) { request in
             ProjectItemNameDialog(request: request) { name in
                 Task { await model.performProjectItemEdit(named: name) }
             } onCancel: {
                 model.cancelProjectItemEdit()
             }
+        }
+        .overlay {
+            ProjectItemNameDialogPresenter()
+                .frame(width: 0, height: 0)
+                .allowsHitTesting(false)
         }
         .confirmationDialog(
             "Move '\(model.pendingProjectItemDeletion?.url.lastPathComponent ?? "")' to Trash?",
@@ -174,6 +180,20 @@ struct ProjectSidebarView: View {
         }
         .padding(.horizontal, 12)
         .frame(height: 39)
+    }
+
+    private var renameRequest: Binding<ProjectItemEditRequest?> {
+        Binding(
+            get: {
+                guard let request = model.projectItemEditRequest,
+                      request.kind == .rename else { return nil }
+                return request
+            },
+            set: { request in
+                guard request == nil, model.projectItemEditRequest?.kind == .rename else { return }
+                model.cancelProjectItemEdit()
+            }
+        )
     }
 }
 
@@ -647,6 +667,174 @@ private struct FileNodeRow: View {
 
 }
 
+private struct ProjectItemNameDialogPresenter: NSViewRepresentable {
+    @EnvironmentObject private var model: AppModel
+
+    func makeCoordinator() -> ProjectItemNameDialogPanelCoordinator {
+        ProjectItemNameDialogPanelCoordinator(model: model)
+    }
+
+    func makeNSView(context: Context) -> NSView { NSView() }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        // Wait for the anchor to join its owning window, without nesting AppKit's event loop.
+        DispatchQueue.main.async { [weak view, weak coordinator = context.coordinator] in
+            guard let view else { return }
+            coordinator?.update(parent: view.window)
+        }
+    }
+
+    static func dismantleNSView(_ view: NSView, coordinator: ProjectItemNameDialogPanelCoordinator) {
+        coordinator.close()
+    }
+}
+
+private final class ProjectItemNameDialogPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
+@MainActor
+private final class ProjectItemNameDialogPanelCoordinator: NSObject, NSWindowDelegate {
+    private let model: AppModel
+    private var panel: NSPanel?
+    private var requestID: UUID?
+    private var parentObservers: [NSObjectProtocol] = []
+
+    init(model: AppModel) {
+        self.model = model
+    }
+
+    func update(parent: NSWindow?) {
+        guard let request = model.projectItemEditRequest, request.kind != .rename,
+              let parent else {
+            close()
+            return
+        }
+        guard requestID != request.id else { return }
+        close()
+        requestID = request.id
+        let panel = ProjectItemNameDialogPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 340, height: 78),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        self.panel = panel
+        panel.isReleasedWhenClosed = false
+        panel.level = .modalPanel
+        panel.appearance = model.settings.themePreference.windowAppearance
+        panel.animationBehavior = .none
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.delegate = self
+        panel.contentViewController = NSHostingController(
+            rootView: ProjectItemNameDialogContent(request: request, coordinator: self)
+        )
+        parent.addChildWindow(panel, ordered: .above)
+        center()
+        for notification in [NSWindow.didResizeNotification, NSWindow.didMoveNotification] {
+            parentObservers.append(NotificationCenter.default.addObserver(
+                forName: notification, object: parent, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.center() }
+            })
+        }
+        parentObservers.append(NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification, object: parent, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.cancel() }
+        })
+        panel.makeKeyAndOrderFront(nil)
+        center()
+    }
+
+    private func center() {
+        guard let panel, let parent = panel.parent else { return }
+        panel.setFrameOrigin(NSPoint(
+            x: parent.frame.midX - panel.frame.width / 2,
+            y: parent.frame.midY - panel.frame.height / 2
+        ))
+    }
+
+    func close() {
+        parentObservers.forEach(NotificationCenter.default.removeObserver)
+        parentObservers.removeAll()
+        let previousPanel = panel
+        panel = nil
+        requestID = nil
+        previousPanel?.delegate = nil
+        if let previousPanel {
+            previousPanel.parent?.removeChildWindow(previousPanel)
+            previousPanel.close()
+        }
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        cancel()
+    }
+
+    func windowDidResize(_ notification: Notification) {
+        // Hosting content can settle its size after the first placement.
+        // Keep the final panel frame centered on the whole owning window.
+        center()
+    }
+
+    func submit(_ name: String) {
+        guard let requestID, model.projectItemEditRequest?.id == requestID,
+              !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        Task { @MainActor in
+            guard model.projectItemEditRequest?.id == requestID else { return }
+            await model.performProjectItemEdit(named: name)
+            update(parent: panel?.parent)
+        }
+    }
+
+    func cancel() {
+        if model.projectItemEditRequest?.id == requestID {
+            model.cancelProjectItemEdit()
+        }
+        close()
+    }
+}
+
+private struct ProjectItemNameDialogContent: View {
+    let request: ProjectItemEditRequest
+    let coordinator: ProjectItemNameDialogPanelCoordinator
+    @State private var name = ""
+    @FocusState private var nameFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text(LocalizedStringKey(title))
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(LitheTheme.primaryText)
+
+            TextField("Name", text: $name)
+                .textFieldStyle(.plain)
+                .font(.system(size: 13))
+                .padding(.horizontal, 8)
+                .frame(height: 30)
+                .foregroundStyle(LitheTheme.primaryText)
+                .focused($nameFocused)
+                .onSubmit { coordinator.submit(name) }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 11)
+        .frame(width: 340, height: 78)
+        .litheContextMenuSurface()
+        .task {
+            await Task.yield()
+            nameFocused = true
+        }
+        .onExitCommand { coordinator.cancel() }
+    }
+
+    private var title: String {
+        request.kind == .createDirectory ? "New Directory" : "New File"
+    }
+}
+
 private struct ProjectItemNameDialog: View {
     @Environment(\.dismiss) private var dismiss
     let request: ProjectItemEditRequest
@@ -668,6 +856,10 @@ private struct ProjectItemNameDialog: View {
     }
 
     var body: some View {
+        standardNameDialog
+    }
+
+    private var standardNameDialog: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 5) {
                 Text(LocalizedStringKey(title))

--- a/macos/Tests/LitheTests/WorkbenchRenderingSafetyTests.swift
+++ b/macos/Tests/LitheTests/WorkbenchRenderingSafetyTests.swift
@@ -5,6 +5,20 @@ import Testing
 @Suite("Workbench rendering safety")
 struct WorkbenchRenderingSafetyTests {
     @Test
+    func projectNamePopupDoesNotNestTheApplicationEventLoop() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(contentsOf: repositoryRoot.appendingPathComponent(
+            "Sources/Lithe/Views/Workspace/ProjectSidebarView.swift"
+        ), encoding: .utf8)
+
+        // A nested modal loop can starve the SwiftUI focus task and freeze the workbench.
+        #expect(source.range(of: #"\brunModal\s*\("#, options: .regularExpression) == nil)
+    }
+
+    @Test
     func workspaceReservesTheRightActivityBar() {
         #expect(WorkbenchLayoutMetrics.workspaceTrailingInset == WorkbenchLayoutMetrics.rightActivityBarWidth)
     }


### PR DESCRIPTION
## 修改内容

- 新建文件和新建文件夹共用紧凑弹窗，保留外框，输入框无边框并自动聚焦。
- 弹窗以整个 App 窗口为基准居中，并在显示和尺寸变化后重新定位。
- 使用非阻塞窗口交互，取消打开动画，保留回车创建及 Esc 取消。
- 不包含右键菜单宽度、主窗口切换动画等其他样式改动。

## 验证情况

- [x] 编译、服务边界及 diff 检查通过。
- [x] WorkbenchRenderingSafetyTests：4 项检查通过。
- 全量测试最近一次运行：969 项测试中存在 Git 状态观察相关失败，尚未确认原因，不标记为全量通过。

## 待人工验收

- [ ] 两种弹窗均位于整个 App 窗口中央，而非编辑区中央。
- [ ] 打开后显示闪烁光标，直接输入，输入框无边框。
- [ ] 回车正确创建，Esc 关闭，反复打开无卡顿。
- [ ] 移动、缩放窗口后仍居中，外框样式符合预期。