### PR TITLE
perf(macos): 降低搜索热路径开销

### DIFF
--- a/macos/Sources/Lithe/Models/AppModel/AppModel+FeatureState.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+FeatureState.swift
@@ -310,8 +310,8 @@ extension AppModel {
     var searchEverywhereResults: SearchEverywhereResults {
         searchFeatureIfActive?.searchEverywhereResults ?? SearchEverywhereResults()
     }
-    var searchEverywhereActionMatches: [LitheAction] {
-        LitheActionRegistry.actions(for: self).filter { $0.matches(searchEverywhereQuery) }
+    func searchEverywhereActionMatches(query: String) -> [LitheAction] {
+        LitheActionRegistry.actions(for: self).filter { $0.matches(query) }
     }
     var isSearchingEverywhere: Bool { searchFeatureIfActive?.isSearchingEverywhere ?? false }
     var projectReplacementFiles: [ProjectReplacementFile] {

--- a/macos/Sources/Lithe/Models/AppModel/AppModel+SearchModule.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+SearchModule.swift
@@ -42,6 +42,7 @@ extension AppModel {
     func toggleSearchEverywhere() {
         guard workspaceURL != nil, !isSearchEverywhereVisible else { return }
         isSearchEverywhereVisible = true
+        Task { _ = await activateSearchModule() }
     }
 
     func dismissSearchEverywhere() {
@@ -50,16 +51,20 @@ extension AppModel {
         searchFeatureIfActive?.clearSearchEverywhere()
     }
 
-    func searchEverywhere(options: ProjectSearchOptions = .default) async {
+    func searchEverywhere(
+        query: String,
+        options: ProjectSearchOptions = .default
+    ) async {
         let signpost = LitheSignpost.begin("search.everywhere")
         defer { LitheSignpost.end("search.everywhere", signpost) }
         guard let searchFeature = await activateSearchModule() else { return }
         guard let workspaceURL else { searchFeature.clearSearchEverywhere(); return }
-        let query = searchEverywhereQuery
         await searchFeature.searchEverywhere(
             at: workspaceURL, query: query, options: options,
             visibilityRules: settings.fileVisibilityRules.searchRules,
-            isCurrent: { [weak self] in self?.workspaceURL == workspaceURL && self?.searchEverywhereQuery == query }
+            isCurrent: { [weak self] in
+                self?.workspaceURL == workspaceURL && self?.isSearchEverywhereVisible == true
+            }
         )
         try? services.moduleRuntime.markIdle(.search)
     }
@@ -86,19 +91,22 @@ extension AppModel {
         isProjectReplaceVisible = true
     }
 
-    func previewProjectReplacement() async {
+    func previewProjectReplacement(
+        query: String,
+        replacement: String,
+        options: ProjectSearchOptions
+    ) async {
         guard let rootURL = workspaceURL, let searchFeature = await activateSearchModule() else { return }
-        let query = projectReplaceQuery
         let overrides = openDocumentTextOverrides(rootURL: rootURL)
         await searchFeature.previewProjectReplacement(
-            at: rootURL, query: query, replacement: projectReplaceText,
+            at: rootURL, query: query, replacement: replacement,
             paths: projectFiles.compactMap { workspaceRelativePath(for: $0, root: rootURL) },
-            textOverrides: overrides, options: projectReplaceOptions,
+            textOverrides: overrides, options: options,
             visibilityRules: settings.fileVisibilityRules.searchRules,
-            isCurrent: { [weak self] in self?.workspaceURL == rootURL && self?.projectReplaceQuery == query }
+            isCurrent: { [weak self] in self?.workspaceURL == rootURL && self?.isProjectReplaceVisible == true }
         )
         try? services.moduleRuntime.markIdle(.search)
-        guard projectReplaceQuery == query else { return }
+        guard isProjectReplaceVisible else { return }
         selectedProjectReplacementPaths = Set(projectReplacementFiles.map(\.relativePath))
     }
 

--- a/macos/Sources/Lithe/Models/AppModel/AppModel+SearchModule.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+SearchModule.swift
@@ -110,9 +110,9 @@ extension AppModel {
         selectedProjectReplacementPaths = Set(projectReplacementFiles.map(\.relativePath))
     }
 
-    func applyProjectReplacement() async {
+    func applyProjectReplacement(query: String) async {
         guard let rootURL = workspaceURL,
-              !projectReplaceQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               let searchFeature = await activateSearchModule() else { return }
         let result = await searchFeature.applyProjectReplacement(
             at: rootURL, selectedPaths: selectedProjectReplacementPaths,

--- a/macos/Sources/Lithe/Models/AppModel/AppModel.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel.swift
@@ -46,7 +46,9 @@ final class AppModel: ObservableObject, Identifiable {
     @Published private(set) var recentProjects: [RecentProject]
     @Published var searchQuery = ""
     @Published var isSearchEverywhereVisible = false
-    @Published var searchEverywhereQuery = ""
+    // Search Everywhere owns its transient query so typing does not publish a
+    // change through the whole workbench.
+    var searchEverywhereQuery = ""
     @Published var isProjectReplaceVisible = false
     @Published var projectReplaceQuery = ""
     @Published var projectReplaceText = ""

--- a/macos/Sources/Lithe/Views/Search/ProjectReplaceView.swift
+++ b/macos/Sources/Lithe/Views/Search/ProjectReplaceView.swift
@@ -140,7 +140,7 @@ struct ProjectReplaceView: View {
                     .font(.system(size: 11.5))
                     .foregroundStyle(LitheTheme.secondaryText)
                 Button("Apply") {
-                    Task { await model.applyProjectReplacement() }
+                    Task { await model.applyProjectReplacement(query: query) }
                 }
                 .buttonStyle(.borderedProminent)
                 .lithePointer()

--- a/macos/Sources/Lithe/Views/Search/ProjectReplaceView.swift
+++ b/macos/Sources/Lithe/Views/Search/ProjectReplaceView.swift
@@ -4,6 +4,9 @@ import LitheSearchModule
 struct ProjectReplaceView: View {
     @EnvironmentObject private var model: AppModel
     @State private var expandedPaths: Set<String> = []
+    @State private var query = ""
+    @State private var replacement = ""
+    @State private var options = ProjectSearchOptions.default
 
     private var selectedFiles: [ProjectReplacementFile] {
         model.projectReplacementFiles.filter {
@@ -25,13 +28,18 @@ struct ProjectReplaceView: View {
         }
         .frame(minWidth: 780, minHeight: 560)
         .background(LitheTheme.window)
-        .onChange(of: model.projectReplaceQuery) { _ in
+        .onAppear {
+            query = model.projectReplaceQuery
+            replacement = model.projectReplaceText
+            options = model.projectReplaceOptions
+        }
+        .onChange(of: query) { _ in
             clearPreview()
         }
-        .onChange(of: model.projectReplaceText) { _ in
+        .onChange(of: replacement) { _ in
             clearPreview()
         }
-        .onChange(of: model.projectReplaceOptions) { _ in
+        .onChange(of: options) { _ in
             clearPreview()
         }
     }
@@ -60,29 +68,29 @@ struct ProjectReplaceView: View {
     private var controls: some View {
         VStack(spacing: 9) {
             HStack(spacing: 9) {
-                TextField("Find", text: $model.projectReplaceQuery)
+                TextField("Find", text: $query)
                     .textFieldStyle(.plain)
                     .litheSearchField()
                 Image(systemName: "arrow.right")
                     .foregroundStyle(LitheTheme.secondaryText)
-                TextField("Replace with", text: $model.projectReplaceText)
+                TextField("Replace with", text: $replacement)
                     .textFieldStyle(.plain)
                     .litheSearchField()
             }
 
             HStack(spacing: 14) {
-                Toggle("Match Case", isOn: $model.projectReplaceOptions.caseSensitive)
+                Toggle("Match Case", isOn: $options.caseSensitive)
                     .lithePointer()
-                Toggle("Whole Words", isOn: $model.projectReplaceOptions.wholeWords)
+                Toggle("Whole Words", isOn: $options.wholeWords)
                     .lithePointer()
-                Toggle("Regex", isOn: $model.projectReplaceOptions.regularExpression)
+                Toggle("Regex", isOn: $options.regularExpression)
                     .lithePointer()
-                Toggle("Preserve Case", isOn: $model.projectReplaceOptions.preserveCase)
+                Toggle("Preserve Case", isOn: $options.preserveCase)
                     .lithePointer()
-                    .disabled(model.projectReplaceOptions.caseSensitive)
+                    .disabled(options.caseSensitive)
                     .help("Match the original casing of each hit: fooBar → bazQux, FooBar → BazQux, FOOBAR → BAZQUX.")
 
-                TextField("File mask", text: $model.projectReplaceOptions.fileMask)
+                TextField("File mask", text: $options.fileMask)
                     .textFieldStyle(.plain)
                     .litheSearchField()
                     .frame(maxWidth: 190)
@@ -93,14 +101,20 @@ struct ProjectReplaceView: View {
 
             HStack(spacing: 8) {
                 Button {
-                    Task { await model.previewProjectReplacement() }
+                    Task {
+                        await model.previewProjectReplacement(
+                            query: query,
+                            replacement: replacement,
+                            options: options
+                        )
+                    }
                 } label: {
                     Label("Preview", systemImage: "eye")
                 }
                 .buttonStyle(.borderedProminent)
                 .lithePointer()
                 .tint(LitheTheme.accent)
-                .disabled(model.projectReplaceQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || model.isLoadingProjectReplacement)
+                .disabled(query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || model.isLoadingProjectReplacement)
 
                 Button {
                     let allSelected = model.selectedProjectReplacementPaths.count == model.projectReplacementFiles.count
@@ -144,7 +158,7 @@ struct ProjectReplaceView: View {
             VStack(spacing: 8) {
                 Image(systemName: "doc.text.magnifyingglass")
                     .font(.system(size: 28, weight: .light))
-                Text(model.projectReplaceQuery.isEmpty
+                Text(query.isEmpty
                     ? "Enter text to preview project changes"
                     : "No replacement matches")
             }

--- a/macos/Sources/Lithe/Views/Search/SearchEverywhereView.swift
+++ b/macos/Sources/Lithe/Views/Search/SearchEverywhereView.swift
@@ -17,6 +17,7 @@ enum SearchEverywhereScope: String, CaseIterable, Identifiable {
 struct SearchEverywhereView: View {
     @EnvironmentObject private var model: AppModel
     @FocusState private var searchFocused: Bool
+    @State private var query = ""
     @State private var selectedIndex = 0
     @State private var scope: SearchEverywhereScope = .all
     @State private var searchOptions = ProjectSearchOptions.default
@@ -37,7 +38,7 @@ struct SearchEverywhereView: View {
                 + model.searchEverywhereResults.classMatches
                 + model.searchEverywhereResults.symbolMatches
             return rankedResults(nameMatches)
-                + model.searchEverywhereActionMatches.map(SearchItem.action)
+                + model.searchEverywhereActionMatches(query: query).map(SearchItem.action)
         case .classes:
             return results(in: model.searchEverywhereResults.classMatches)
         case .files:
@@ -47,7 +48,7 @@ struct SearchEverywhereView: View {
         case .text:
             return results(in: model.searchEverywhereResults.contentMatches)
         case .actions:
-            return model.searchEverywhereActionMatches.map(SearchItem.action)
+            return model.searchEverywhereActionMatches(query: query).map(SearchItem.action)
         }
     }
 
@@ -59,7 +60,6 @@ struct SearchEverywhereView: View {
 
     /// 按相关度降序。同分保持原顺序，避免逐字输入时行位置来回跳动。
     private func rankedResults(_ results: [FileSearchResult]) -> [SearchItem] {
-        let query = model.searchEverywhereQuery
         var ranked: [RankedResult] = []
         ranked.reserveCapacity(results.count)
         for (index, value) in results.enumerated() {
@@ -74,7 +74,7 @@ struct SearchEverywhereView: View {
     }
 
     private var hasQuery: Bool {
-        !model.searchEverywhereQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     var body: some View {
@@ -102,15 +102,16 @@ struct SearchEverywhereView: View {
         .onAppear {
             searchFocused = true
             selectedIndex = 0
+            query = model.searchEverywhereQuery
             installKeyMonitor()
         }
         .onDisappear { removeKeyMonitor() }
-        .onChange(of: model.searchEverywhereQuery) { _ in selectedIndex = 0 }
+        .onChange(of: query) { _ in selectedIndex = 0 }
         .onChange(of: scope) { _ in selectedIndex = 0 }
-        .task(id: "\(model.searchEverywhereQuery)|\(searchOptions.cacheKey)") {
+        .task(id: "\(query)|\(searchOptions.cacheKey)") {
             try? await Task.sleep(for: .milliseconds(180))
             guard !Task.isCancelled else { return }
-            await model.searchEverywhere(options: searchOptions)
+            await model.searchEverywhere(query: query, options: searchOptions)
         }
     }
 
@@ -171,18 +172,18 @@ struct SearchEverywhereView: View {
         HStack(spacing: 8) {
             LitheSystemIcon(systemImage: "magnifyingglass")
                 .foregroundStyle(LitheTheme.secondaryText)
-            TextField("", text: $model.searchEverywhereQuery)
+            TextField("", text: $query)
                 .textFieldStyle(.plain)
                 .font(.system(size: 15))
                 .focused($searchFocused)
-            if model.searchEverywhereQuery.isEmpty {
+            if query.isEmpty {
                 Text("Type / to see commands")
                     .font(.system(size: 12))
                     .foregroundStyle(LitheTheme.tertiaryText)
                     .allowsHitTesting(false)
             } else {
                 Button {
-                    model.searchEverywhereQuery = ""
+                    query = ""
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                 }

--- a/macos/Sources/LitheSearchModule/Application/SearchFeatureModel.swift
+++ b/macos/Sources/LitheSearchModule/Application/SearchFeatureModel.swift
@@ -23,6 +23,8 @@ public final class SearchFeatureModel: ObservableObject {
     private let operations: any SearchOperations
     private var indexTask: Task<Void, Never>?
     private var indexTaskGeneration = 0
+    private var everywhereSearchGeneration = 0
+    private var replacementPreviewGeneration = 0
 
     public var hasActiveModuleWork: Bool {
         isSearching || isSearchingEverywhere || isLoadingProjectReplacement || indexTask != nil
@@ -140,6 +142,7 @@ public final class SearchFeatureModel: ObservableObject {
     }
 
     public func clearSearchEverywhere() {
+        everywhereSearchGeneration += 1
         searchEverywhereResults = SearchEverywhereResults(fileMatches: [], contentMatches: [])
         isSearchingEverywhere = false
     }
@@ -151,6 +154,8 @@ public final class SearchFeatureModel: ObservableObject {
         visibilityRules: SearchVisibilityRules,
         isCurrent: @escaping @MainActor () -> Bool
     ) async {
+        everywhereSearchGeneration += 1
+        let generation = everywhereSearchGeneration
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             clearSearchEverywhere()
             return
@@ -167,7 +172,7 @@ public final class SearchFeatureModel: ObservableObject {
             ) ?? SearchEverywhereResults()
         }.value
 
-        guard isCurrent() else {
+        guard generation == everywhereSearchGeneration, isCurrent() else {
             isSearchingEverywhere = false
             return
         }
@@ -181,6 +186,7 @@ public final class SearchFeatureModel: ObservableObject {
     }
 
     public func clearProjectReplacementPreview() {
+        replacementPreviewGeneration += 1
         projectReplacementFiles = []
         isLoadingProjectReplacement = false
     }
@@ -247,6 +253,8 @@ public final class SearchFeatureModel: ObservableObject {
         visibilityRules: SearchVisibilityRules,
         isCurrent: @escaping @MainActor () -> Bool
     ) async {
+        replacementPreviewGeneration += 1
+        let generation = replacementPreviewGeneration
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             clearProjectReplacementPreview()
             return
@@ -266,7 +274,7 @@ public final class SearchFeatureModel: ObservableObject {
             ) ?? []
         }.value
 
-        guard isCurrent() else {
+        guard generation == replacementPreviewGeneration, isCurrent() else {
             isLoadingProjectReplacement = false
             return
         }


### PR DESCRIPTION
## Summary
- 将 Search Everywhere 的查询状态下沉到弹窗本地，避免每次输入触发 Workbench 重建
- 打开 Search Everywhere 时预热并复用搜索模块
- 将 Replace in Project 的查询、替换文本和选项下沉到弹窗本地
- 为 Search Everywhere 和 Replace 预览增加旧请求保护，避免过期结果覆盖新结果

## Validation
- `./scripts/test-macos.sh`
- `./scripts/verify-service-boundaries.sh`
- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`
- `git diff --check`

Closes #491