### PR TITLE
perf(macos): 统一可调分栏布局

### DIFF
--- a/macos/Sources/Lithe/Views/Diff/DiffSplitPaneView.swift
+++ b/macos/Sources/Lithe/Views/Diff/DiffSplitPaneView.swift
@@ -20,6 +20,8 @@ struct DiffSplitPaneView<RowOverlay: View>: View {
 
     @State private var horizontalOffset: CGFloat = 0
     @State private var wheelScheduler = LitheDragUpdateScheduler()
+    @State private var leftPaneWidth: CGFloat?
+    @State private var paneDragStart: CGFloat = 0
 
     init(
         displayRows: [DiffDisplayRow],
@@ -52,7 +54,12 @@ struct DiffSplitPaneView<RowOverlay: View>: View {
     var body: some View {
         let layout = DiffSplitLayout.plan(displayRows: displayRows, kinds: kinds)
         let gutterWidth = DiffLayoutMetrics.centerGutterWidth
-        let paneViewportWidth = max(0, (viewportWidth - gutterWidth) / 2)
+        let availablePaneWidth = max(0, viewportWidth - gutterWidth)
+        let paneViewportWidth = max(
+            0,
+            min(availablePaneWidth, leftPaneWidth ?? availablePaneWidth / 2)
+        )
+        let rightPaneViewportWidth = max(0, availablePaneWidth - paneViewportWidth)
         let paneContentWidth = max(
             paneViewportWidth,
             (contentWidth - gutterWidth) / 2
@@ -75,8 +82,11 @@ struct DiffSplitPaneView<RowOverlay: View>: View {
                         sideViewport(
                             layout.rightItems,
                             side: .right,
-                            viewportWidth: paneViewportWidth,
-                            contentWidth: paneContentWidth,
+                            viewportWidth: rightPaneViewportWidth,
+                            contentWidth: max(
+                                rightPaneViewportWidth,
+                                contentWidth - gutterWidth - paneViewportWidth
+                            ),
                             height: height
                         )
                     }
@@ -97,6 +107,29 @@ struct DiffSplitPaneView<RowOverlay: View>: View {
                 viewportWidth: paneViewportWidth,
                 contentWidth: paneContentWidth
             )
+        }
+        .overlay(alignment: .topLeading) {
+            SplitHandleView(
+                axis: .horizontal,
+                showsIdleDivider: false,
+                onDragStarted: {
+                    paneDragStart = paneViewportWidth
+                },
+                onDragChanged: { translation in
+                    leftPaneWidth = min(
+                        max(paneDragStart + translation, 220),
+                        max(220, availablePaneWidth - 220)
+                    )
+                },
+                onDragEnded: { translation in
+                    leftPaneWidth = min(
+                        max(paneDragStart + translation, 220),
+                        max(220, availablePaneWidth - 220)
+                    )
+                }
+            )
+            .offset(x: paneViewportWidth + gutterWidth / 2 - SplitHandleView.thickness / 2)
+            .frame(height: minimumHeight)
         }
         .frame(width: viewportWidth, height: minimumHeight, alignment: .topLeading)
         .background {

--- a/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
+++ b/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
@@ -1698,17 +1698,25 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
                 maximum: maximumTopPaneHeight
             )
 
-            ZStack(alignment: .topLeading) {
-                VStack(spacing: isBottomToolVisible ? WorkbenchWorkspaceMetrics.paneSpacing : 0) {
-                    HStack(spacing: WorkbenchWorkspaceMetrics.paneSpacing) {
+            let topContent: AnyView = AnyView(
+                LitheSplitPaneView(
+                    axis: .horizontal,
+                    placement: .leading,
+                    defaultSize: resolvedSidebarWidth,
+                    minimum: minimumSidebarWidth,
+                    maximum: maximumSidebarWidth,
+                    showsIdleDivider: false,
+                    onCommit: actions.onSidebarWidthCommitted,
+                    sized: {
                         sidebar
-                            .frame(width: resolvedSidebarWidth)
                             .frame(maxHeight: .infinity)
                             .workbenchPaneChrome(
                                 background: hasWorkbenchBackground ? Color.clear : LitheTheme.editor,
                                 surrounding: hasWorkbenchBackground ? Color.clear : LitheTheme.titlebar,
                                 roundsCorners: !hasWorkbenchBackground
                             )
+                    },
+                    flexible: {
                         editor
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                             .workbenchPaneChrome(
@@ -1717,67 +1725,40 @@ private struct WorkbenchWorkspaceSplitView<Sidebar: View, Editor: View, BottomTo
                                 roundsCorners: !hasWorkbenchBackground
                             )
                     }
-                    .padding(.horizontal, WorkbenchWorkspaceMetrics.paneInset)
-                    .padding(.top, WorkbenchWorkspaceMetrics.paneInset)
-                    .padding(
-                        .bottom,
-                        isBottomToolVisible ? 0 : WorkbenchWorkspaceMetrics.paneInset
-                    )
-                    .overlay(alignment: .topLeading) {
-                        sidebarResizeHandle(
-                            resolvedSidebarWidth: resolvedSidebarWidth,
-                            minimumSidebarWidth: minimumSidebarWidth,
-                            maximumSidebarWidth: maximumSidebarWidth,
-                            bottomInset: isBottomToolVisible ? 0 : WorkbenchWorkspaceMetrics.paneInset
-                        )
-                    }
-                    .frame(height: isBottomToolVisible ? resolvedTopPaneHeight : geometry.size.height)
+                )
+            )
 
-                    if isBottomToolVisible {
-                        bottomTool
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .workbenchPaneChrome(
-                                background: hasWorkbenchBackground ? Color.clear : LitheTheme.editor,
-                                surrounding: hasWorkbenchBackground ? Color.clear : LitheTheme.titlebar,
-                                roundsCorners: !hasWorkbenchBackground
-                            )
-                            .padding(.horizontal, WorkbenchWorkspaceMetrics.paneInset)
-                            .padding(.bottom, WorkbenchWorkspaceMetrics.paneInset)
-                            .frame(maxHeight: .infinity)
-                    }
-                }
-
+            Group {
                 if isBottomToolVisible {
-                    Rectangle()
-                        .fill(LitheTheme.titlebar)
-                        .frame(height: WorkbenchWorkspaceMetrics.paneSpacing)
-                        .position(
-                            x: geometry.size.width / 2,
-                            y: resolvedTopPaneHeight
-                                + WorkbenchWorkspaceMetrics.paneSpacing / 2
-                        )
-                        .allowsHitTesting(false)
-                        .accessibilityHidden(true)
-
-                    topPaneResizeHandle(
-                        resolvedTopPaneHeight: resolvedTopPaneHeight,
-                        minimumTopPaneHeight: minimumTopPaneHeight,
-                        maximumTopPaneHeight: maximumTopPaneHeight
+                    LitheSplitPaneView(
+                        axis: .vertical,
+                        placement: .leading,
+                        defaultSize: resolvedTopPaneHeight,
+                        minimum: minimumTopPaneHeight,
+                        maximum: maximumTopPaneHeight,
+                        showsIdleDivider: false,
+                        onCommit: actions.onTopPaneHeightCommitted,
+                        sized: {
+                            topContent
+                                .padding(.horizontal, WorkbenchWorkspaceMetrics.paneInset)
+                                .padding(.top, WorkbenchWorkspaceMetrics.paneInset)
+                        },
+                        flexible: {
+                            bottomTool
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .workbenchPaneChrome(
+                                    background: hasWorkbenchBackground ? Color.clear : LitheTheme.editor,
+                                    surrounding: hasWorkbenchBackground ? Color.clear : LitheTheme.titlebar,
+                                    roundsCorners: !hasWorkbenchBackground
+                                )
+                                .padding(.horizontal, WorkbenchWorkspaceMetrics.paneInset)
+                                .padding(.bottom, WorkbenchWorkspaceMetrics.paneInset)
+                        }
                     )
-                }
-
-                if isBottomToolVisible, showsBottomToolMinimize {
-                    Button(action: actions.onBottomToolMinimize) {
-                        Image(systemName: "chevron.down")
-                            .font(.system(size: 12, weight: .semibold))
-                    }
-                    .litheIconButton()
-                    .help("Collapse tool window")
-                    .accessibilityLabel("Collapse tool window")
-                    .position(
-                        x: geometry.size.width - ActivityBarMetrics.rightWidth - 20,
-                        y: resolvedTopPaneHeight + WorkbenchWorkspaceMetrics.paneSpacing + 16
-                    )
+                } else {
+                    topContent
+                        .padding(.horizontal, WorkbenchWorkspaceMetrics.paneInset)
+                        .padding(.vertical, WorkbenchWorkspaceMetrics.paneInset)
                 }
             }
             .frame(


### PR DESCRIPTION
## Summary
- 将 Workbench 侧栏和底部工具区迁移到 `LitheSplitPaneView`
- 为 Diff 双栏增加稳定坐标拖动、边界限制和合帧更新
- 保留现有 Diff 行对齐、中心 gutter 和滚动行为

## Validation
- `./scripts/test-macos.sh`
- `./scripts/verify-service-boundaries.sh`
- `git diff --check`

Closes #494