### PR TITLE
fix(windows): restore Maven pane typecheck

### DIFF
--- a/windows/tauri/src/features/maven/components/maven-pane.tsx
+++ b/windows/tauri/src/features/maven/components/maven-pane.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
+import { useFileSystemStore } from "@/features/file-system/stores/file-system.store";
 import { workspaceRuntimeRegistry } from "@/features/workspace/runtime/workspace-runtime-registry";
 import { useActiveWorkspaceId } from "@/features/workspace/stores/create-workspace-scoped-store";
 import { workspaceScopeMatchesRoot } from "@/features/workspace/types/workspace-launch-scope";
@@ -30,6 +31,7 @@ import { ScrollArea } from "@/ui/scroll-area";
 import { Spinner } from "@/ui/spinner";
 import Tooltip from "@/ui/tooltip";
 import { cn } from "@/utils/cn";
+import { joinPath } from "@/utils/path-helpers";
 import { openMavenRunPane } from "../actions/maven-tool-window-actions";
 import { ensureMavenProcessListeners } from "../hooks/use-maven-process-events";
 import { availableMavenProfiles, useMavenStore } from "../stores/maven.store";
@@ -257,12 +259,12 @@ export default function MavenPane({ onClose }: MavenPaneProps) {
   const reloadRequired = useMavenStore((state) => state.reloadRequired);
   const taskStatus = useMavenStore((state) => state.taskStatus);
   const taskError = useMavenStore((state) => state.taskError);
-  const runningTitle = useMavenStore((state) => state.runningTitle);
   const output = useMavenStore((state) => state.output);
   const issues = useMavenStore((state) => state.issues);
   const lastExitCode = useMavenStore((state) => state.lastExitCode);
   const dependencyLoads = useMavenStore((state) => state.dependencyLoads);
   const actions = useMavenStore((state) => state.actions);
+  const handleFileSelect = useFileSystemStore((state) => state.handleFileSelect);
   const [selectedModule, setSelectedModule] = useState<string | null>(null);
   const [selectedPhase, setSelectedPhase] = useState<MavenLifecyclePhase>("compile");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());


### PR DESCRIPTION
## Summary

- restore the Maven pane's `joinPath` and file-system store imports
- remove the stale `runningTitle` selector from `MavenPane`
- fix the Windows frontend typecheck failures on the `preview` baseline

This is an independent Windows CI fix and is separate from the macOS AppModel refactor in #515.

## Verification

- `bun run typecheck` in `windows/tauri`
- `bun run lint -- src/features/maven/components/maven-pane.tsx` in `windows/tauri`
- `./scripts/verify-windows-boundaries.sh`
- `git diff --check`
