### PR TITLE
ci(macos): 诊断 DMG 打包的 Resource busy 失败

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -260,6 +260,10 @@ jobs:
           plutil -lint macos/Resources/Info.plist
 
       - name: Build and verify default universal package
+        env:
+          # Temporary: capture disk image state around create-dmg.sh while the
+          # intermittent "hdiutil: create failed - Resource busy" is diagnosed.
+          LITHE_DMG_DIAGNOSTICS: "1"
         run: ./scripts/verify-macos-package.sh
 
   gate:

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -33,11 +33,46 @@ fi
 cp -R "$APP_DIR" "$STAGING_DIR/Lithe.app"
 ln -s /Applications "$STAGING_DIR/Applications"
 
-hdiutil create \
-    -volname "Lithe" \
-    -srcfolder "$STAGING_DIR" \
-    -ov \
-    -format UDZO \
-    "$DMG_PATH"
+# Temporary diagnostics for the intermittent "hdiutil: create failed - Resource
+# busy" seen on macos-14 CI runners. hdiutil rejects the request within seconds
+# rather than timing out, which points at something holding the staging tree or
+# a stale attached device rather than at slow I/O. Capture that state on the
+# runner so a failure carries evidence instead of guesswork.
+#
+# Everything here writes to stderr: callers parse the last stdout line as the
+# produced disk image path.
+#
+# Remove this block once the root cause is identified.
+report_disk_image_state() {
+    local stage="$1"
+    print -u2 -- "--- dmg diagnostics ($stage): attached disk images ---"
+    /usr/bin/hdiutil info >&2 || true
+    print -u2 -- "--- dmg diagnostics ($stage): openers of the staging tree ---"
+    # lsof exits non-zero when nothing matches, which is the healthy case.
+    /usr/sbin/lsof +D "$STAGING_DIR" >&2 || true
+    print -u2 -- "--- dmg diagnostics ($stage): mounted volumes ---"
+    /bin/ls -1 /Volumes >&2 || true
+    print -u2 -- "--- dmg diagnostics ($stage): end ---"
+}
+
+hdiutil_options=(
+    -volname "Lithe"
+    -srcfolder "$STAGING_DIR"
+    -ov
+    -format UDZO
+)
+if [[ -n "${LITHE_DMG_DIAGNOSTICS:-}" ]]; then
+    report_disk_image_state "before create"
+    hdiutil_options+=(-debug)
+fi
+
+hdiutil_status=0
+hdiutil create "${hdiutil_options[@]}" "$DMG_PATH" || hdiutil_status=$?
+if (( hdiutil_status != 0 )); then
+    if [[ -n "${LITHE_DMG_DIAGNOSTICS:-}" ]]; then
+        report_disk_image_state "after failed create"
+    fi
+    exit $hdiutil_status
+fi
 
 print -r -- "$DMG_PATH"


### PR DESCRIPTION
## 背景

`macOS CI` 的 **Release package verification** 任务间歇性地在最后一步打包 DMG 时失败：

```
hdiutil: create failed - Resource busy
```

这个失败正在挡住 #515（`macOS CI gate` 是 `preview` 上唯一的必需检查，而它红是因为 `RELEASE_RESULT: failure`）。

## 已确认的事实

- 失败点唯一，前面的 lipo 校验、插件签名、`codesign --verify --deep --strict` 全部通过。
- **不是超时**：三次运行从 codesign 到 hdiutil 返回的耗时几乎一致（8.2s 成功 / 7.2s 失败 / 7.8s 失败），hdiutil 是很快主动拒绝的。
- Runner image 完全相同（`macos-14-arm64/20260831.0302`），排除镜像变更。
- 两次失败都残留了孤儿 `diskimages-help` 进程，成功那次没有 —— 但**无法从日志判断它是原因还是结果**。
- 与 #515 的代码改动无关：全绿的 `a67874c0` 与失败的 `945dae25` 之间，`macos/ scripts/ rust/ third_party/ Plugins/ .github/` 的 diff 为空。

## 尚不清楚的

**为什么同一份输入 07:58 能出 DMG，09:09 和 09:42 都不行。** 同一个 SHA 已经 2/2 失败，所以不能简单归结为随机 flake。

## 本 PR 做什么

只加诊断，不改行为：

- 在 `hdiutil create` 前后记录已挂载的磁盘镜像、占用 staging 目录的进程（`lsof`）、`/Volumes` 内容，并打开 hdiutil 自己的 `-debug`。
- 通过 `LITHE_DMG_DIAGNOSTICS` 开关控制，仅在 CI 打开。
- **全部输出到 stderr**，因为调用方 `verify-macos-package.sh` 依赖「stdout 最后一行是 DMG 路径」这个约定。

## 为什么不直接加重试

失败是随机还是确定性的目前未知。加重试会掩盖答案，而且如果是确定性问题，只会把失败时间拖长 3 倍。等这次拿到证据再决定怎么修。

## 验证

- `zsh -n scripts/create-dmg.sh` 通过；workflow YAML 解析通过。
- `./scripts/test-classify-ci-changes.sh` 通过（确认 `create-dmg.sh` 会触发 `macos_release`，即目标任务会真的跑起来）。
- 本地用假 app bundle 实跑了三种情况：
  - 诊断关闭：行为与改动前完全一致，stderr 为空，stdout 最后一行是 DMG 路径。
  - 诊断开启：stdout 最后一行仍是 DMG 路径（stdout 约定未被破坏），诊断进 stderr。
  - 失败路径：退出码正确传播为非 0，诊断正常输出，且不会有假路径污染 stdout。

> 注：本地无法复现 CI 上的 `Resource busy`，所以真正的证据要等这个 PR 在 CI 上跑一次。诊断代码在定位到根因后会移除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)