### PR TITLE
docs(release): prepare v0.4.3 notes

### DIFF
--- a/docs/releases/v0.4.3.md
+++ b/docs/releases/v0.4.3.md
@@ -1,0 +1,89 @@
+## 中文
+
+Lithe 0.4.3 聚焦于大型项目体验、编辑器响应速度以及 Maven 和 Git 工作流的稳定性。
+
+### 下载
+
+- **项目主页：** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.3/Lithe-0.4.3-arm64.dmg)
+- **macOS Intel：** [下载 DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.3/Lithe-0.4.3-x86_64.dmg)
+- **Windows x64：** [下载安装程序](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.3/Lithe-0.4.3-windows-x64.exe)
+- **全部下载：** [查看 Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.3)
+
+### 重点更新
+
+- 编辑器输入、语法高亮、语言服务和全文搜索减少了不必要的重复工作，大型文件和项目的交互响应更加稳定。
+- macOS 工作区的可调面板和 Git 视图得到完善，调整布局、查看历史和浏览工作树时更容易保持当前上下文。
+- Maven 工具窗口、依赖树和运行相关流程继续完善，Windows 端的 Maven 项目操作与 macOS 更加一致。
+- Windows 窗口交互、Markdown 预览和差异查看得到修复与调整，常见开发操作更加顺畅。
+- macOS 应用内部的功能模块边界和工作流组织得到整理，为后续稳定性改进提供更清晰的基础。
+
+### 升级说明
+
+- **macOS DMG：** 退出正在运行的 Lithe，打开对应架构的 DMG，然后将 Lithe 拖入“应用程序”并替换旧版本。
+- **Homebrew：** 运行 `brew update && brew upgrade --cask lithe`。
+- **Windows：** 退出正在运行的 Lithe，然后运行 Windows x64 安装程序并按提示完成安装。
+
+### 兼容性与已知问题
+
+- macOS 需要 macOS 13 或更高版本。
+- Java 项目功能需要 JDK 17 或更高版本，推荐使用 JDK 17 或 JDK 21。
+- macOS 和 Windows 正式安装包均包含 JDTLS，无需单独安装。
+- Windows 版本仍处于预览阶段，部分平台能力和界面细节可能与 macOS 不完全一致；未配置 Authenticode 证书时安装程序可能显示安全提示。
+- 如果 macOS 提示无法打开 Lithe.app，请在“应用程序”中按住 Control 点按应用并选择“打开”；如果仍被阻止，可在终端执行 `xattr -dr com.apple.quarantine /Applications/Lithe.app`。仅对可信来源的应用使用。
+
+查看 [v0.4.2 到 v0.4.3 的完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.4.2...v0.4.3)。
+
+---
+
+## English
+
+Lithe 0.4.3 focuses on large-project responsiveness, editor performance, and more reliable Maven and Git workflows.
+
+### Downloads
+
+- **Project homepage:** [Lithe IDEA](https://github.com/1lck/Lithe-IDEA)
+- **macOS Apple Silicon:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.3/Lithe-0.4.3-arm64.dmg)
+- **macOS Intel:** [Download DMG](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.3/Lithe-0.4.3-x86_64.dmg)
+- **Windows x64:** [Download installer](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.3/Lithe-0.4.3-windows-x64.exe)
+- **All downloads:** [View Release Assets](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.3)
+
+### Highlights
+
+- The editor, syntax highlighting, language service, and project search do less redundant work, making interactions more consistent for large files and projects.
+- macOS workbench panes and Git views are more polished, so layout adjustments, history browsing, and worktree navigation better preserve the active context.
+- The Maven tool window, dependency tree, and run workflows continue to improve, bringing Windows Maven operations closer to macOS.
+- Windows window interactions, Markdown preview, and diff viewing received fixes and refinements for smoother everyday development tasks.
+- macOS application modules and workflow ownership were reorganized to provide a clearer foundation for future stability improvements.
+
+### Upgrade instructions
+
+- **macOS DMG:** Quit Lithe, open the DMG for your Mac architecture, and replace the existing application in the Applications folder.
+- **Homebrew:** Run `brew update && brew upgrade --cask lithe`.
+- **Windows:** Quit Lithe, run the Windows x64 installer, and follow the installation prompts.
+
+### Compatibility and known issues
+
+- macOS requires macOS 13 or later.
+- Java project features require JDK 17 or newer. JDK 17 or JDK 21 is recommended.
+- Release packages for macOS and Windows include JDTLS, so it does not need to be installed separately.
+- The Windows build remains a preview, and some platform capabilities and interface details may differ from macOS. The installer may show a security warning when Authenticode signing is not configured.
+- If macOS says it cannot open Lithe.app, Control-click it in Applications and choose Open. If it is still blocked, run `xattr -dr com.apple.quarantine /Applications/Lithe.app` in Terminal. Use this only for an app from a source you trust.
+
+Review the [full changes from v0.4.2 to v0.4.3](https://github.com/1lck/Lithe-IDEA/compare/v0.4.2...v0.4.3).
+
+### 贡献者
+
+- [1lck](https://github.com/1lck)
+- [Xiaoyumuxi](https://github.com/xiaoyumuxi)
+- [arkleselect](https://github.com/arkleselect)
+- [Mucheen](https://github.com/Mucheen)
+- [Sir Chen](https://github.com/cg3940)
+
+### Contributors
+
+- [1lck](https://github.com/1lck)
+- [Xiaoyumuxi](https://github.com/xiaoyumuxi)
+- [arkleselect](https://github.com/arkleselect)
+- [Mucheen](https://github.com/Mucheen)
+- [Sir Chen](https://github.com/cg3940)


### PR DESCRIPTION
## Summary
- Add `docs/releases/v0.4.3.md` release notes (bilingual), following the release-lithe skill format.

## Test plan
- [x] Verified only `docs/releases/v0.4.3.md` changes vs main.
- [x] Checked release notes format matches previous stable releases (v0.4.2).