### PR TITLE
feat(macos): 支持单实例多项目窗口，避免 Dock 出现重复图标

### DIFF
--- a/macos/Sources/Lithe/Application/Workspace/ProjectWindowSessionHandlers.swift
+++ b/macos/Sources/Lithe/Application/Workspace/ProjectWindowSessionHandlers.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+@MainActor
+final class PrimaryProjectWindowSessions: ProjectWindowSessionHandling {
+    private let manager: ProjectSessionManager
+
+    init(manager: ProjectSessionManager) {
+        self.manager = manager
+    }
+
+    var hasUnsavedDocuments: Bool {
+        manager.primarySessions.contains(where: \.hasUnsavedDocuments)
+    }
+
+    var unsavedDocumentNames: [String] {
+        manager.primarySessions.flatMap { model in
+            model.openDocuments
+                .filter(\.isDirty)
+                .map { "\(model.projectName)/\($0.displayName)" }
+        }
+    }
+
+    var hasActiveProject: Bool {
+        manager.activeModel(in: .primary).workspaceURL != nil
+    }
+
+    var hasActiveStandaloneFile: Bool {
+        manager.activeModel(in: .primary).standaloneFileURL != nil
+    }
+
+    var shouldDismissWindowWhenClosingActiveSession: Bool {
+        manager.shouldDismissPrimaryWindowWhenClosingActiveSession
+    }
+
+    var windowScope: ProjectWindowScope { .primary }
+
+    func closeActiveProject() {
+        manager.activeModel(in: .primary).closeProject()
+    }
+
+    func requestCloseActiveWorkbenchItem() -> Bool {
+        manager.activeModel(in: .primary).requestCloseActiveWorkbenchItem()
+    }
+
+    func requestCloseActiveSession() -> Bool {
+        let model = manager.activeModel(in: .primary)
+        if model.workspaceURL != nil {
+            model.closeProject()
+            return false
+        }
+        if model.standaloneFileURL != nil {
+            if model.hasUnsavedDocuments {
+                model.closeStandaloneFile()
+                return false
+            }
+            return true
+        }
+        return true
+    }
+
+    func saveAllDocuments() -> Bool {
+        var savedAll = true
+        for model in manager.primarySessions where !model.saveAllDocuments() {
+            savedAll = false
+        }
+        return savedAll
+    }
+
+    func resetForProjectWindowClose() async {
+        await manager.resetPrimaryWindowSessions()
+    }
+
+    func noteWindowBecameKey() {
+        manager.noteWindowBecameKey(.primary)
+    }
+}
+
+@MainActor
+final class DedicatedProjectWindowSessions: ProjectWindowSessionHandling {
+    private let manager: ProjectSessionManager
+    private let windowID: UUID
+
+    init(manager: ProjectSessionManager, windowID: UUID) {
+        self.manager = manager
+        self.windowID = windowID
+    }
+
+    private var scope: ProjectWindowScope { .dedicated(windowID) }
+
+    private var scopedSessions: [AppModel] {
+        manager.sessions(in: scope)
+    }
+
+    private var activeModel: AppModel {
+        manager.activeModel(in: scope)
+    }
+
+    var hasUnsavedDocuments: Bool {
+        scopedSessions.contains(where: \.hasUnsavedDocuments)
+    }
+
+    var unsavedDocumentNames: [String] {
+        scopedSessions.flatMap { model in
+            model.openDocuments
+                .filter(\.isDirty)
+                .map { "\(model.projectName)/\($0.displayName)" }
+        }
+    }
+
+    var hasActiveProject: Bool {
+        activeModel.workspaceURL != nil
+    }
+
+    var hasActiveStandaloneFile: Bool {
+        activeModel.standaloneFileURL != nil
+    }
+
+    var shouldDismissWindowWhenClosingActiveSession: Bool { true }
+
+    var windowScope: ProjectWindowScope { scope }
+
+    func closeActiveProject() {
+        activeModel.closeProject()
+    }
+
+    func requestCloseActiveWorkbenchItem() -> Bool {
+        activeModel.requestCloseActiveWorkbenchItem()
+    }
+
+    func requestCloseActiveSession() -> Bool {
+        // Dedicated windows always dismiss instead of becoming welcome.
+        false
+    }
+
+    func saveAllDocuments() -> Bool {
+        var savedAll = true
+        for model in scopedSessions where !model.saveAllDocuments() {
+            savedAll = false
+        }
+        return savedAll
+    }
+
+    func resetForProjectWindowClose() async {
+        await manager.resetDedicatedWindowSession(windowID: windowID)
+    }
+
+    func noteWindowBecameKey() {
+        manager.noteWindowBecameKey(scope)
+    }
+}

--- a/macos/Sources/Lithe/LitheApp.swift
+++ b/macos/Sources/Lithe/LitheApp.swift
@@ -263,6 +263,7 @@ struct LitheApp: App {
     @NSApplicationDelegateAdaptor(LitheAppDelegate.self) private var appDelegate
     @StateObject private var settings: AppSettings
     @StateObject private var projectSessions: ProjectSessionManager
+    @StateObject private var projectWindowLauncher: ProjectWindowLauncher
     @StateObject private var memoryUsageMonitor: MemoryUsageMonitor
     @StateObject private var frameRateMonitor = FrameRateMonitor()
     @StateObject private var updateChecker: UpdateChecker
@@ -301,6 +302,8 @@ struct LitheApp: App {
         let authorizationCallbackRouter = MacExternalAuthorizationCallbackRouter()
         pluginRuntimeRecovery.recoverPreviousSession(using: moduleStore)
         _settings = StateObject(wrappedValue: settings)
+        let projectWindowLauncher = ProjectWindowLauncher()
+        _projectWindowLauncher = StateObject(wrappedValue: projectWindowLauncher)
         let projectSessions = ProjectSessionManager(
             settings: settings,
             modelFactory: {
@@ -320,7 +323,9 @@ struct LitheApp: App {
                     ).services
                 )
             },
-            newWindowOpener: Self.openProjectInNewWindow
+            projectWindowPresenter: { [weak projectWindowLauncher] sessionID in
+                projectWindowLauncher?.present(sessionID)
+            }
         )
         if let startupProjectURL = Self.startupProjectURL {
             projectSessions.openStartupProject(startupProjectURL)
@@ -394,9 +399,10 @@ struct LitheApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootView()
+            RootView(scope: .primary)
                 .environmentObject(model)
                 .environmentObject(projectSessions)
+                .environmentObject(projectWindowLauncher)
                 .environmentObject(settings)
                 .environmentObject(memoryUsageMonitor)
                 .environmentObject(frameRateMonitor)
@@ -572,6 +578,27 @@ struct LitheApp: App {
             }
         }
 
+        WindowGroup(id: LitheWindowID.project, for: UUID.self) { $sessionID in
+            if let sessionID {
+                RootView(scope: .dedicated(sessionID))
+                    .environmentObject(projectSessions.session(for: sessionID) ?? model)
+                    .environmentObject(projectSessions)
+                    .environmentObject(projectWindowLauncher)
+                    .environmentObject(settings)
+                    .environmentObject(memoryUsageMonitor)
+                    .environmentObject(frameRateMonitor)
+                    .environmentObject(updateChecker)
+                    .environment(\.locale, settings.language.locale)
+                    .id("\(sessionID.uuidString)-\(settings.language)")
+                    .preferredColorScheme(settings.themePreference.preferredColorScheme)
+            }
+        }
+        .defaultSize(
+            width: LitheWindowLayout.workspaceContentSize.width,
+            height: LitheWindowLayout.workspaceContentSize.height
+        )
+        .windowStyle(.hiddenTitleBar)
+
         Window(settingsWindowTitle(for: settings.language), id: LitheWindowID.settings) {
             SettingsWindow(
                 model: model,
@@ -593,16 +620,6 @@ struct LitheApp: App {
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
               isDirectory.boolValue else { return nil }
         return url
-    }
-
-    private static func openProjectInNewWindow(_ url: URL) {
-        let configuration = NSWorkspace.OpenConfiguration()
-        configuration.createsNewApplicationInstance = true
-        configuration.arguments = ["--open-project", url.path]
-        NSWorkspace.shared.openApplication(
-            at: Bundle.main.bundleURL,
-            configuration: configuration
-        )
     }
 }
 

--- a/macos/Sources/Lithe/LitheApp.swift
+++ b/macos/Sources/Lithe/LitheApp.swift
@@ -323,8 +323,11 @@ struct LitheApp: App {
                     ).services
                 )
             },
-            projectWindowPresenter: { [weak projectWindowLauncher] sessionID in
-                projectWindowLauncher?.present(sessionID)
+            projectWindowPresenter: { [weak projectWindowLauncher] windowID in
+                projectWindowLauncher?.present(windowID)
+            },
+            projectWindowDismisser: { [weak projectWindowLauncher] windowID in
+                projectWindowLauncher?.dismiss(windowID)
             }
         )
         if let startupProjectURL = Self.startupProjectURL {
@@ -398,7 +401,7 @@ struct LitheApp: App {
     private var model: AppModel { projectSessions.activeModel }
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: LitheWindowID.welcome) {
             RootView(scope: .primary)
                 .environmentObject(model)
                 .environmentObject(projectSessions)
@@ -432,6 +435,11 @@ struct LitheApp: App {
                     model.chooseProject()
                 }
                 .litheKeyboardShortcut(model.keyboardShortcutFeature.primaryKeyPress(for: "open-project"))
+
+                Button("New Window") {
+                    projectSessions.ensurePrimaryWindowAvailable()
+                    projectWindowLauncher.presentPrimary()
+                }
             }
 
             CommandGroup(after: .saveItem) {
@@ -578,19 +586,25 @@ struct LitheApp: App {
             }
         }
 
-        WindowGroup(id: LitheWindowID.project, for: UUID.self) { $sessionID in
-            if let sessionID {
-                RootView(scope: .dedicated(sessionID))
-                    .environmentObject(projectSessions.session(for: sessionID) ?? model)
-                    .environmentObject(projectSessions)
-                    .environmentObject(projectWindowLauncher)
-                    .environmentObject(settings)
-                    .environmentObject(memoryUsageMonitor)
-                    .environmentObject(frameRateMonitor)
-                    .environmentObject(updateChecker)
-                    .environment(\.locale, settings.language.locale)
-                    .id("\(sessionID.uuidString)-\(settings.language)")
-                    .preferredColorScheme(settings.themePreference.preferredColorScheme)
+        WindowGroup(id: LitheWindowID.project, for: UUID.self) { $windowID in
+            if let windowID {
+                let scopedSessions = projectSessions.sessions(in: .dedicated(windowID))
+                if scopedSessions.isEmpty {
+                    ProjectWindowMissingSessionView(windowID: windowID)
+                        .environmentObject(projectWindowLauncher)
+                } else {
+                    RootView(scope: .dedicated(windowID))
+                        .environmentObject(projectSessions.activeModel(in: .dedicated(windowID)))
+                        .environmentObject(projectSessions)
+                        .environmentObject(projectWindowLauncher)
+                        .environmentObject(settings)
+                        .environmentObject(memoryUsageMonitor)
+                        .environmentObject(frameRateMonitor)
+                        .environmentObject(updateChecker)
+                        .environment(\.locale, settings.language.locale)
+                        .id("\(windowID.uuidString)-\(settings.language)")
+                        .preferredColorScheme(settings.themePreference.preferredColorScheme)
+                }
             }
         }
         .defaultSize(
@@ -620,6 +634,33 @@ struct LitheApp: App {
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
               isDirectory.boolValue else { return nil }
         return url
+    }
+}
+
+private struct ProjectWindowMissingSessionView: View {
+    let windowID: UUID
+    @EnvironmentObject private var projectWindowLauncher: ProjectWindowLauncher
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("This project window is no longer available.")
+                .font(.system(size: 15, weight: .medium))
+            Text("Its session was closed or could not be restored.")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            Button("Close Window") {
+                ProjectWindowAppKitDismisser.dismiss(windowID: windowID)
+                projectWindowLauncher.dismiss(windowID)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(24)
+        .onAppear {
+            let message = "Lithe project window \(windowID.uuidString) has no matching session.\n"
+            if let data = message.data(using: .utf8) {
+                FileHandle.standardError.write(data)
+            }
+        }
     }
 }
 

--- a/macos/Sources/Lithe/Models/Workspace/ProjectSessionManager.swift
+++ b/macos/Sources/Lithe/Models/Workspace/ProjectSessionManager.swift
@@ -129,6 +129,13 @@ final class ProjectSessionManager: ObservableObject {
         sessions(in: scope).filter { $0.workspaceURL != nil }
     }
 
+    /// Returns the pending open prompt only when it originated in `scope`.
+    /// Multi-window RootViews must use this so Ask sheets do not present twice.
+    func pendingProjectOpen(in scope: ProjectWindowScope) -> PendingProjectOpen? {
+        guard let pending = pendingProjectOpen else { return nil }
+        return self.scope(for: pending.sourceSessionID) == scope ? pending : nil
+    }
+
     func activeSessionID(in scope: ProjectWindowScope) -> UUID {
         if let id = activeSessionIDs[scope], sessions.contains(where: { $0.id == id }) {
             return id

--- a/macos/Sources/Lithe/Models/Workspace/ProjectSessionManager.swift
+++ b/macos/Sources/Lithe/Models/Workspace/ProjectSessionManager.swift
@@ -14,23 +14,31 @@ struct PendingProjectOpen: Identifiable, Equatable {
     var projectName: String { url.lastPathComponent }
 }
 
-/// Identifies which top-level window hosts a project session.
-enum ProjectWindowScope: Equatable, Sendable {
+/// Identifies which top-level window hosts project sessions.
+enum ProjectWindowScope: Hashable, Equatable, Sendable {
     case primary
     case dedicated(UUID)
+
+    var dedicatedWindowID: UUID? {
+        if case .dedicated(let id) = self { return id }
+        return nil
+    }
 }
 
 @MainActor
 final class ProjectSessionManager: ObservableObject {
     @Published private(set) var sessions: [AppModel]
-    @Published private(set) var activeSessionID: UUID
+    /// Active session inside each top-level window.
+    @Published private(set) var activeSessionIDs: [ProjectWindowScope: UUID] = [:]
+    /// Window that currently owns menu-bar commands and focus-driven actions.
+    @Published private(set) var focusedScope: ProjectWindowScope = .primary
     @Published var pendingProjectOpen: PendingProjectOpen?
 
     private let settings: AppSettings
     private let modelFactory: () -> AppModel
-    /// Presents or focuses the dedicated SwiftUI window for a session ID.
     private let projectWindowPresenter: (UUID) -> Void
-    private var dedicatedWindowSessionIDs: Set<UUID> = []
+    private let projectWindowDismisser: (UUID) -> Void
+    private var sessionScopes: [UUID: ProjectWindowScope] = [:]
     private var modelObservations: [UUID: AnyCancellable] = [:]
     // A closed model can disappear from `sessions` before its asynchronous
     // module teardown finishes. Keep the task here so the manager remains the
@@ -40,16 +48,25 @@ final class ProjectSessionManager: ObservableObject {
     init(
         settings: AppSettings,
         modelFactory: @escaping () -> AppModel,
-        projectWindowPresenter: @escaping (UUID) -> Void = { _ in }
+        projectWindowPresenter: @escaping (UUID) -> Void = { _ in },
+        projectWindowDismisser: @escaping (UUID) -> Void = { _ in }
     ) {
         self.settings = settings
         self.modelFactory = modelFactory
         self.projectWindowPresenter = projectWindowPresenter
+        self.projectWindowDismisser = projectWindowDismisser
 
         let initialModel = modelFactory()
         sessions = [initialModel]
-        activeSessionID = initialModel.id
+        sessionScopes[initialModel.id] = .primary
+        activeSessionIDs[.primary] = initialModel.id
+        focusedScope = .primary
         configure(initialModel)
+    }
+
+    /// Focused window's active session. Menu commands and app-level chrome use this.
+    var activeSessionID: UUID {
+        activeSessionID(in: focusedScope)
     }
 
     var activeModel: AppModel {
@@ -61,11 +78,11 @@ final class ProjectSessionManager: ObservableObject {
     }
 
     var primarySessions: [AppModel] {
-        sessions.filter { !dedicatedWindowSessionIDs.contains($0.id) }
+        sessions(in: .primary)
     }
 
     var primaryOpenProjects: [AppModel] {
-        primarySessions.filter { $0.workspaceURL != nil }
+        openProjects(in: .primary)
     }
 
     var hasUnsavedDocuments: Bool {
@@ -89,44 +106,102 @@ final class ProjectSessionManager: ObservableObject {
         return savedAll
     }
 
+    func scope(for sessionID: UUID) -> ProjectWindowScope {
+        sessionScopes[sessionID] ?? .primary
+    }
+
     func isDedicatedWindowSession(_ id: UUID) -> Bool {
-        dedicatedWindowSessionIDs.contains(id)
+        if case .dedicated = scope(for: id) {
+            return true
+        }
+        return false
     }
 
     func session(for id: UUID) -> AppModel? {
         sessions.first(where: { $0.id == id })
     }
 
+    func sessions(in scope: ProjectWindowScope) -> [AppModel] {
+        sessions.filter { sessionScopes[$0.id] == scope }
+    }
+
     func openProjects(in scope: ProjectWindowScope) -> [AppModel] {
-        switch scope {
-        case .primary:
-            return primaryOpenProjects
-        case .dedicated(let sessionID):
-            return openProjects.filter { $0.id == sessionID }
+        sessions(in: scope).filter { $0.workspaceURL != nil }
+    }
+
+    func activeSessionID(in scope: ProjectWindowScope) -> UUID {
+        if let id = activeSessionIDs[scope], sessions.contains(where: { $0.id == id }) {
+            return id
         }
+        return sessions(in: scope).first?.id
+            ?? sessions.first?.id
+            ?? UUID()
+    }
+
+    func activeModel(in scope: ProjectWindowScope) -> AppModel {
+        let id = activeSessionID(in: scope)
+        return sessions.first(where: { $0.id == id })
+            ?? sessions(in: scope).first
+            ?? sessions[0]
+    }
+
+    func noteWindowBecameKey(_ scope: ProjectWindowScope) {
+        guard focusedScope != scope else {
+            syncProjectSessionActivation(for: scope)
+            return
+        }
+        let previous = activeModel
+        focusedScope = scope
+        previous.setProjectSessionActive(false)
+        syncProjectSessionActivation(for: scope)
+        activeModel(in: scope).refreshRecentProjects()
+        objectWillChange.send()
+    }
+
+    func ensurePrimaryWindowAvailable() {
+        if sessions(in: .primary).isEmpty {
+            let replacement = modelFactory()
+            sessions.append(replacement)
+            sessionScopes[replacement.id] = .primary
+            activeSessionIDs[.primary] = replacement.id
+            configure(replacement)
+        }
+        focusedScope = .primary
+        syncProjectSessionActivation(for: .primary)
+        // Re-presenting the primary WindowGroup is handled by the app scene;
+        // dedicated windows keep using their own presentation values.
+        objectWillChange.send()
     }
 
     func openStartupProject(_ url: URL) {
-        activeModel.openProjectDirectly(url.standardizedFileURL)
+        let model = activeModel(in: .primary)
+        setActiveSession(model.id, in: .primary)
+        focusedScope = .primary
+        model.openProjectDirectly(url.standardizedFileURL)
         refreshRecentProjects()
     }
 
     func openStandaloneFile(_ url: URL) {
+        let scope = focusedScope
+        let active = activeModel(in: scope)
         let model: AppModel
-        if activeModel.workspaceURL == nil && activeModel.standaloneFileURL == nil {
-            model = activeModel
+        if active.workspaceURL == nil && active.standaloneFileURL == nil {
+            model = active
         } else {
-            activeModel.setProjectSessionActive(false)
+            active.setProjectSessionActive(false)
             model = modelFactory()
             sessions.append(model)
+            sessionScopes[model.id] = scope
             configure(model)
-            activeSessionID = model.id
+            setActiveSession(model.id, in: scope)
         }
         model.openStandaloneFile(url.standardizedFileURL)
+        syncProjectSessionActivation(for: scope)
     }
 
     func requestOpenProject(_ url: URL, from sourceSessionID: UUID) {
         let normalizedURL = url.standardizedFileURL
+        let sourceScope = scope(for: sourceSessionID)
         if let existing = openProjects.first(where: {
             $0.workspaceURL?.standardizedFileURL == normalizedURL
         }) {
@@ -135,7 +210,7 @@ final class ProjectSessionManager: ObservableObject {
         }
 
         if openProjects.isEmpty {
-            openInThisWindow(normalizedURL)
+            openInThisWindow(normalizedURL, scope: sourceScope)
             return
         }
 
@@ -146,7 +221,7 @@ final class ProjectSessionManager: ObservableObject {
                 sourceSessionID: sourceSessionID
             )
         case .thisWindow:
-            openInThisWindow(normalizedURL)
+            openInThisWindow(normalizedURL, scope: sourceScope)
         case .newWindow:
             openInNewWindow(normalizedURL)
         }
@@ -164,9 +239,10 @@ final class ProjectSessionManager: ObservableObject {
             settings.projectOpenBehavior = placement == .thisWindow ? .thisWindow : .newWindow
         }
 
+        let sourceScope = scope(for: request.sourceSessionID)
         switch placement {
         case .thisWindow:
-            openInThisWindow(request.url)
+            openInThisWindow(request.url, scope: sourceScope)
         case .newWindow:
             openInNewWindow(request.url)
         }
@@ -177,15 +253,24 @@ final class ProjectSessionManager: ObservableObject {
     }
 
     func activateSession(_ id: UUID) {
-        guard let nextModel = sessions.first(where: { $0.id == id }) else { return }
-        if id != activeSessionID {
-            activeModel.setProjectSessionActive(false)
-            activeSessionID = id
-            nextModel.setProjectSessionActive(true)
-            nextModel.refreshRecentProjects()
+        guard sessions.contains(where: { $0.id == id }) else { return }
+        let scope = scope(for: id)
+        let previousFocused = focusedScope
+        let previousActive = activeModel(in: scope)
+
+        if previousFocused != scope {
+            activeModel(in: previousFocused).setProjectSessionActive(false)
+            focusedScope = scope
         }
-        if dedicatedWindowSessionIDs.contains(id) {
-            projectWindowPresenter(id)
+        if previousActive.id != id {
+            previousActive.setProjectSessionActive(false)
+            setActiveSession(id, in: scope)
+        }
+        syncProjectSessionActivation(for: scope)
+        activeModel(in: scope).refreshRecentProjects()
+
+        if case .dedicated(let windowID) = scope {
+            projectWindowPresenter(windowID)
         }
     }
 
@@ -199,13 +284,14 @@ final class ProjectSessionManager: ObservableObject {
     }
 
     func requestCloseActiveSession() -> Bool {
-        if activeModel.workspaceURL != nil {
-            closeActiveProject()
+        let model = activeModel
+        if model.workspaceURL != nil {
+            model.closeProject()
             return false
         }
-        if activeModel.standaloneFileURL != nil {
-            if activeModel.hasUnsavedDocuments {
-                activeModel.closeStandaloneFile()
+        if model.standaloneFileURL != nil {
+            if model.hasUnsavedDocuments {
+                model.closeStandaloneFile()
                 return false
             }
             return true
@@ -216,91 +302,110 @@ final class ProjectSessionManager: ObservableObject {
     /// Primary window: dismiss instead of showing welcome when other project
     /// windows still hold open workspaces.
     var shouldDismissPrimaryWindowWhenClosingActiveSession: Bool {
-        primaryOpenProjects.count <= 1 && openProjects.contains(where: {
-            dedicatedWindowSessionIDs.contains($0.id)
-        })
+        primaryOpenProjects.count <= 1 && openProjects.contains(where: { isDedicatedWindowSession($0.id) })
     }
 
+    /// Legacy name kept for existing window handlers. Only resets primary-window
+    /// sessions so dedicated project windows stay alive.
     func resetForProjectWindowClose() async {
-        let previousSessions = sessions
-
-        pendingProjectOpen = nil
-        dedicatedWindowSessionIDs.removeAll()
-        modelObservations.removeAll()
-        for model in previousSessions {
-            await scheduleSessionShutdown(for: model).value
-        }
-        await waitForPendingSessionShutdowns()
-
-        let replacement = modelFactory()
-        configure(replacement)
-        sessions = [replacement]
-        activeSessionID = replacement.id
+        await resetPrimaryWindowSessions()
     }
 
     /// Tears down only the primary-window sessions so dedicated project windows
     /// can keep running after the welcome/host window is dismissed.
     func resetPrimaryWindowSessions() async {
-        let primary = primarySessions
+        let primary = sessions(in: .primary)
         pendingProjectOpen = nil
         for model in primary {
             modelObservations[model.id] = nil
+            sessionScopes[model.id] = nil
             await scheduleSessionShutdown(for: model).value
             sessions.removeAll { $0.id == model.id }
         }
-        await waitForPendingSessionShutdowns()
-
-        if let next = sessions.first(where: { $0.workspaceURL != nil })
-            ?? sessions.first {
-            activeSessionID = next.id
-            next.setProjectSessionActive(true)
-        } else {
-            let replacement = modelFactory()
-            configure(replacement)
-            sessions = [replacement]
-            activeSessionID = replacement.id
-        }
-    }
-
-    /// Tears down one dedicated project window without creating a welcome shell
-    /// in that window. Restores a primary welcome session only when nothing remains.
-    func resetDedicatedWindowSession(_ id: UUID) async {
-        guard let model = sessions.first(where: { $0.id == id }) else { return }
-        dedicatedWindowSessionIDs.remove(id)
-        modelObservations[id] = nil
-        let wasActive = activeSessionID == id
-        await scheduleSessionShutdown(for: model).value
-        sessions.removeAll { $0.id == id }
+        activeSessionIDs[.primary] = nil
         await waitForPendingSessionShutdowns()
 
         if sessions.isEmpty {
             let replacement = modelFactory()
-            configure(replacement)
             sessions = [replacement]
-            activeSessionID = replacement.id
+            sessionScopes = [replacement.id: .primary]
+            activeSessionIDs = [.primary: replacement.id]
+            focusedScope = .primary
+            configure(replacement)
+            syncProjectSessionActivation(for: .primary)
+            objectWillChange.send()
             return
         }
 
-        if wasActive {
-            if let primaryProject = primaryOpenProjects.first {
-                activeSessionID = primaryProject.id
-                primaryProject.setProjectSessionActive(true)
-            } else if let primary = primarySessions.first {
-                activeSessionID = primary.id
-                primary.setProjectSessionActive(true)
-            } else if let next = sessions.first {
-                activeSessionID = next.id
-                next.setProjectSessionActive(true)
+        if focusedScope == .primary {
+            if let dedicatedProject = openProjects.first(where: { isDedicatedWindowSession($0.id) }) {
+                focusedScope = scope(for: dedicatedProject.id)
+                setActiveSession(dedicatedProject.id, in: focusedScope)
+                syncProjectSessionActivation(for: focusedScope)
+            } else if let any = sessions.first {
+                focusedScope = scope(for: any.id)
+                setActiveSession(any.id, in: focusedScope)
+                syncProjectSessionActivation(for: focusedScope)
             }
         }
+
+        objectWillChange.send()
+    }
+
+    /// Tears down one dedicated project window without creating a welcome shell
+    /// in that window. Restores a primary welcome session only when nothing remains.
+    func resetDedicatedWindowSession(windowID: UUID) async {
+        let scope = ProjectWindowScope.dedicated(windowID)
+        let scopedSessions = sessions(in: scope)
+        guard !scopedSessions.isEmpty else {
+            projectWindowDismisser(windowID)
+            return
+        }
+
+        pendingProjectOpen = nil
+        for model in scopedSessions {
+            modelObservations[model.id] = nil
+            sessionScopes[model.id] = nil
+            await scheduleSessionShutdown(for: model).value
+            sessions.removeAll { $0.id == model.id }
+        }
+        activeSessionIDs[scope] = nil
+        await waitForPendingSessionShutdowns()
+        projectWindowDismisser(windowID)
+
+        if sessions.isEmpty {
+            let replacement = modelFactory()
+            sessions = [replacement]
+            sessionScopes[replacement.id] = .primary
+            activeSessionIDs = [.primary: replacement.id]
+            focusedScope = .primary
+            configure(replacement)
+            syncProjectSessionActivation(for: .primary)
+            objectWillChange.send()
+            return
+        }
+
+        if focusedScope == scope {
+            if let primaryProject = primaryOpenProjects.first {
+                focusedScope = .primary
+                setActiveSession(primaryProject.id, in: .primary)
+            } else if let primary = primarySessions.first {
+                focusedScope = .primary
+                setActiveSession(primary.id, in: .primary)
+            } else if let next = sessions.first {
+                focusedScope = self.scope(for: next.id)
+                setActiveSession(next.id, in: focusedScope)
+            }
+            syncProjectSessionActivation(for: focusedScope)
+        }
+
+        objectWillChange.send()
     }
 
     func closeProject(_ id: UUID) {
         guard sessions.contains(where: { $0.id == id }) else { return }
-        if id != activeSessionID {
-            activateSession(id)
-        }
-        activeModel.closeProject()
+        activateSession(id)
+        activeModel(in: scope(for: id)).closeProject()
     }
 
     func stopAllSessions() async {
@@ -316,41 +421,62 @@ final class ProjectSessionManager: ObservableObject {
         }
     }
 
-    private func openInThisWindow(_ url: URL) {
+    private func openInThisWindow(_ url: URL, scope: ProjectWindowScope) {
+        let scoped = sessions(in: scope)
         let model: AppModel
-        if let emptyPrimary = primarySessions.first(where: {
+        if let empty = scoped.first(where: {
             $0.workspaceURL == nil && $0.standaloneFileURL == nil
         }) {
-            model = emptyPrimary
-            if model.id != activeSessionID {
-                activeModel.setProjectSessionActive(false)
-                activeSessionID = model.id
-                model.setProjectSessionActive(true)
-            }
-        } else if activeModel.workspaceURL == nil && !isDedicatedWindowSession(activeModel.id) {
-            model = activeModel
+            model = empty
+        } else if let active = scoped.first(where: { $0.id == activeSessionID(in: scope) }),
+                  active.workspaceURL == nil {
+            model = active
         } else {
-            activeModel.setProjectSessionActive(false)
+            activeModel(in: scope).setProjectSessionActive(false)
             model = modelFactory()
             sessions.append(model)
+            sessionScopes[model.id] = scope
             configure(model)
-            activeSessionID = model.id
         }
+
+        setActiveSession(model.id, in: scope)
+        focusedScope = scope
+        model.setProjectSessionActive(true)
         model.openProjectDirectly(url)
         refreshRecentProjects()
+
+        if case .dedicated(let windowID) = scope {
+            projectWindowPresenter(windowID)
+        }
+        objectWillChange.send()
     }
 
     private func openInNewWindow(_ url: URL) {
         activeModel.setProjectSessionActive(false)
         let model = modelFactory()
+        let windowID = model.id
+        let scope = ProjectWindowScope.dedicated(windowID)
         sessions.append(model)
-        dedicatedWindowSessionIDs.insert(model.id)
+        sessionScopes[model.id] = scope
         configure(model)
-        activeSessionID = model.id
+        setActiveSession(model.id, in: scope)
+        focusedScope = scope
         model.setProjectSessionActive(true)
         model.openProjectDirectly(url)
         refreshRecentProjects()
-        projectWindowPresenter(model.id)
+        projectWindowPresenter(windowID)
+        objectWillChange.send()
+    }
+
+    private func setActiveSession(_ id: UUID, in scope: ProjectWindowScope) {
+        activeSessionIDs[scope] = id
+    }
+
+    private func syncProjectSessionActivation(for scope: ProjectWindowScope) {
+        let activeID = activeSessionID(in: scope)
+        for model in sessions {
+            model.setProjectSessionActive(model.id == activeID && focusedScope == scope)
+        }
     }
 
     private func configure(_ model: AppModel) {
@@ -378,39 +504,53 @@ final class ProjectSessionManager: ObservableObject {
         guard model.workspaceURL == nil,
               let removedIndex = sessions.firstIndex(where: { $0.id == model.id }) else { return }
 
-        let wasDedicated = dedicatedWindowSessionIDs.remove(model.id) != nil
-        let wasActive = model.id == activeSessionID
+        let scope = scope(for: model.id)
+        let wasActiveInScope = activeSessionID(in: scope) == model.id
         _ = scheduleSessionShutdown(for: model)
         modelObservations[model.id] = nil
+        sessionScopes[model.id] = nil
         sessions.remove(at: removedIndex)
+
+        let remainingInScope = sessions(in: scope)
+        if remainingInScope.isEmpty {
+            activeSessionIDs[scope] = nil
+            if case .dedicated(let windowID) = scope {
+                projectWindowDismisser(windowID)
+            }
+        }
 
         if sessions.isEmpty {
             let replacement = modelFactory()
             sessions = [replacement]
-            activeSessionID = replacement.id
+            sessionScopes = [replacement.id: .primary]
+            activeSessionIDs = [.primary: replacement.id]
+            focusedScope = .primary
             configure(replacement)
+            syncProjectSessionActivation(for: .primary)
+            objectWillChange.send()
             return
         }
 
-        if wasActive {
-            let preferred: AppModel?
-            if wasDedicated {
-                preferred = primaryOpenProjects.first ?? primarySessions.first ?? sessions.first
-            } else {
-                let primary = primarySessions
-                if let nextPrimaryProject = primary.first(where: { $0.workspaceURL != nil }) {
-                    preferred = nextPrimaryProject
-                } else if let nextPrimary = primary.first {
-                    preferred = nextPrimary
-                } else {
-                    preferred = sessions.first
-                }
+        if wasActiveInScope, let next = remainingInScope.first {
+            setActiveSession(next.id, in: scope)
+            if focusedScope == scope {
+                next.setProjectSessionActive(true)
             }
-            if let preferred {
-                activeSessionID = preferred.id
-                preferred.setProjectSessionActive(true)
+        } else if remainingInScope.isEmpty, focusedScope == scope {
+            if let primaryProject = primaryOpenProjects.first {
+                focusedScope = .primary
+                setActiveSession(primaryProject.id, in: .primary)
+            } else if let primary = primarySessions.first {
+                focusedScope = .primary
+                setActiveSession(primary.id, in: .primary)
+            } else if let next = sessions.first {
+                focusedScope = self.scope(for: next.id)
+                setActiveSession(next.id, in: focusedScope)
             }
+            syncProjectSessionActivation(for: focusedScope)
         }
+
+        objectWillChange.send()
     }
 
     private func refreshRecentProjects() {
@@ -444,12 +584,3 @@ final class ProjectSessionManager: ObservableObject {
 }
 
 extension ProjectSessionManager: UnsavedDocumentHandling {}
-
-@MainActor
-final class ProjectWindowLauncher: ObservableObject {
-    var presentProjectWindow: ((UUID) -> Void)?
-
-    func present(_ sessionID: UUID) {
-        presentProjectWindow?(sessionID)
-    }
-}

--- a/macos/Sources/Lithe/Models/Workspace/ProjectSessionManager.swift
+++ b/macos/Sources/Lithe/Models/Workspace/ProjectSessionManager.swift
@@ -14,6 +14,12 @@ struct PendingProjectOpen: Identifiable, Equatable {
     var projectName: String { url.lastPathComponent }
 }
 
+/// Identifies which top-level window hosts a project session.
+enum ProjectWindowScope: Equatable, Sendable {
+    case primary
+    case dedicated(UUID)
+}
+
 @MainActor
 final class ProjectSessionManager: ObservableObject {
     @Published private(set) var sessions: [AppModel]
@@ -22,7 +28,9 @@ final class ProjectSessionManager: ObservableObject {
 
     private let settings: AppSettings
     private let modelFactory: () -> AppModel
-    private let newWindowOpener: (URL) -> Void
+    /// Presents or focuses the dedicated SwiftUI window for a session ID.
+    private let projectWindowPresenter: (UUID) -> Void
+    private var dedicatedWindowSessionIDs: Set<UUID> = []
     private var modelObservations: [UUID: AnyCancellable] = [:]
     // A closed model can disappear from `sessions` before its asynchronous
     // module teardown finishes. Keep the task here so the manager remains the
@@ -32,11 +40,11 @@ final class ProjectSessionManager: ObservableObject {
     init(
         settings: AppSettings,
         modelFactory: @escaping () -> AppModel,
-        newWindowOpener: @escaping (URL) -> Void
+        projectWindowPresenter: @escaping (UUID) -> Void = { _ in }
     ) {
         self.settings = settings
         self.modelFactory = modelFactory
-        self.newWindowOpener = newWindowOpener
+        self.projectWindowPresenter = projectWindowPresenter
 
         let initialModel = modelFactory()
         sessions = [initialModel]
@@ -52,6 +60,14 @@ final class ProjectSessionManager: ObservableObject {
         sessions.filter { $0.workspaceURL != nil }
     }
 
+    var primarySessions: [AppModel] {
+        sessions.filter { !dedicatedWindowSessionIDs.contains($0.id) }
+    }
+
+    var primaryOpenProjects: [AppModel] {
+        primarySessions.filter { $0.workspaceURL != nil }
+    }
+
     var hasUnsavedDocuments: Bool {
         sessions.contains(where: \.hasUnsavedDocuments)
     }
@@ -61,6 +77,32 @@ final class ProjectSessionManager: ObservableObject {
             model.openDocuments
                 .filter(\.isDirty)
                 .map { "\(model.projectName)/\($0.displayName)" }
+        }
+    }
+
+    @discardableResult
+    func saveAllDocuments() -> Bool {
+        var savedAll = true
+        for model in sessions where !model.saveAllDocuments() {
+            savedAll = false
+        }
+        return savedAll
+    }
+
+    func isDedicatedWindowSession(_ id: UUID) -> Bool {
+        dedicatedWindowSessionIDs.contains(id)
+    }
+
+    func session(for id: UUID) -> AppModel? {
+        sessions.first(where: { $0.id == id })
+    }
+
+    func openProjects(in scope: ProjectWindowScope) -> [AppModel] {
+        switch scope {
+        case .primary:
+            return primaryOpenProjects
+        case .dedicated(let sessionID):
+            return openProjects.filter { $0.id == sessionID }
         }
     }
 
@@ -93,8 +135,7 @@ final class ProjectSessionManager: ObservableObject {
         }
 
         if openProjects.isEmpty {
-            activeModel.openProjectDirectly(normalizedURL)
-            refreshRecentProjects()
+            openInThisWindow(normalizedURL)
             return
         }
 
@@ -107,7 +148,7 @@ final class ProjectSessionManager: ObservableObject {
         case .thisWindow:
             openInThisWindow(normalizedURL)
         case .newWindow:
-            newWindowOpener(normalizedURL)
+            openInNewWindow(normalizedURL)
         }
     }
 
@@ -127,7 +168,7 @@ final class ProjectSessionManager: ObservableObject {
         case .thisWindow:
             openInThisWindow(request.url)
         case .newWindow:
-            newWindowOpener(request.url)
+            openInNewWindow(request.url)
         }
     }
 
@@ -136,12 +177,16 @@ final class ProjectSessionManager: ObservableObject {
     }
 
     func activateSession(_ id: UUID) {
-        guard id != activeSessionID,
-              let nextModel = sessions.first(where: { $0.id == id }) else { return }
-        activeModel.setProjectSessionActive(false)
-        activeSessionID = id
-        nextModel.setProjectSessionActive(true)
-        nextModel.refreshRecentProjects()
+        guard let nextModel = sessions.first(where: { $0.id == id }) else { return }
+        if id != activeSessionID {
+            activeModel.setProjectSessionActive(false)
+            activeSessionID = id
+            nextModel.setProjectSessionActive(true)
+            nextModel.refreshRecentProjects()
+        }
+        if dedicatedWindowSessionIDs.contains(id) {
+            projectWindowPresenter(id)
+        }
     }
 
     func closeActiveProject() {
@@ -168,10 +213,19 @@ final class ProjectSessionManager: ObservableObject {
         return true
     }
 
+    /// Primary window: dismiss instead of showing welcome when other project
+    /// windows still hold open workspaces.
+    var shouldDismissPrimaryWindowWhenClosingActiveSession: Bool {
+        primaryOpenProjects.count <= 1 && openProjects.contains(where: {
+            dedicatedWindowSessionIDs.contains($0.id)
+        })
+    }
+
     func resetForProjectWindowClose() async {
         let previousSessions = sessions
 
         pendingProjectOpen = nil
+        dedicatedWindowSessionIDs.removeAll()
         modelObservations.removeAll()
         for model in previousSessions {
             await scheduleSessionShutdown(for: model).value
@@ -184,21 +238,69 @@ final class ProjectSessionManager: ObservableObject {
         activeSessionID = replacement.id
     }
 
+    /// Tears down only the primary-window sessions so dedicated project windows
+    /// can keep running after the welcome/host window is dismissed.
+    func resetPrimaryWindowSessions() async {
+        let primary = primarySessions
+        pendingProjectOpen = nil
+        for model in primary {
+            modelObservations[model.id] = nil
+            await scheduleSessionShutdown(for: model).value
+            sessions.removeAll { $0.id == model.id }
+        }
+        await waitForPendingSessionShutdowns()
+
+        if let next = sessions.first(where: { $0.workspaceURL != nil })
+            ?? sessions.first {
+            activeSessionID = next.id
+            next.setProjectSessionActive(true)
+        } else {
+            let replacement = modelFactory()
+            configure(replacement)
+            sessions = [replacement]
+            activeSessionID = replacement.id
+        }
+    }
+
+    /// Tears down one dedicated project window without creating a welcome shell
+    /// in that window. Restores a primary welcome session only when nothing remains.
+    func resetDedicatedWindowSession(_ id: UUID) async {
+        guard let model = sessions.first(where: { $0.id == id }) else { return }
+        dedicatedWindowSessionIDs.remove(id)
+        modelObservations[id] = nil
+        let wasActive = activeSessionID == id
+        await scheduleSessionShutdown(for: model).value
+        sessions.removeAll { $0.id == id }
+        await waitForPendingSessionShutdowns()
+
+        if sessions.isEmpty {
+            let replacement = modelFactory()
+            configure(replacement)
+            sessions = [replacement]
+            activeSessionID = replacement.id
+            return
+        }
+
+        if wasActive {
+            if let primaryProject = primaryOpenProjects.first {
+                activeSessionID = primaryProject.id
+                primaryProject.setProjectSessionActive(true)
+            } else if let primary = primarySessions.first {
+                activeSessionID = primary.id
+                primary.setProjectSessionActive(true)
+            } else if let next = sessions.first {
+                activeSessionID = next.id
+                next.setProjectSessionActive(true)
+            }
+        }
+    }
+
     func closeProject(_ id: UUID) {
         guard sessions.contains(where: { $0.id == id }) else { return }
         if id != activeSessionID {
             activateSession(id)
         }
         activeModel.closeProject()
-    }
-
-    @discardableResult
-    func saveAllDocuments() -> Bool {
-        var savedAll = true
-        for model in sessions where !model.saveAllDocuments() {
-            savedAll = false
-        }
-        return savedAll
     }
 
     func stopAllSessions() async {
@@ -216,7 +318,16 @@ final class ProjectSessionManager: ObservableObject {
 
     private func openInThisWindow(_ url: URL) {
         let model: AppModel
-        if activeModel.workspaceURL == nil {
+        if let emptyPrimary = primarySessions.first(where: {
+            $0.workspaceURL == nil && $0.standaloneFileURL == nil
+        }) {
+            model = emptyPrimary
+            if model.id != activeSessionID {
+                activeModel.setProjectSessionActive(false)
+                activeSessionID = model.id
+                model.setProjectSessionActive(true)
+            }
+        } else if activeModel.workspaceURL == nil && !isDedicatedWindowSession(activeModel.id) {
             model = activeModel
         } else {
             activeModel.setProjectSessionActive(false)
@@ -227,6 +338,19 @@ final class ProjectSessionManager: ObservableObject {
         }
         model.openProjectDirectly(url)
         refreshRecentProjects()
+    }
+
+    private func openInNewWindow(_ url: URL) {
+        activeModel.setProjectSessionActive(false)
+        let model = modelFactory()
+        sessions.append(model)
+        dedicatedWindowSessionIDs.insert(model.id)
+        configure(model)
+        activeSessionID = model.id
+        model.setProjectSessionActive(true)
+        model.openProjectDirectly(url)
+        refreshRecentProjects()
+        projectWindowPresenter(model.id)
     }
 
     private func configure(_ model: AppModel) {
@@ -254,6 +378,7 @@ final class ProjectSessionManager: ObservableObject {
         guard model.workspaceURL == nil,
               let removedIndex = sessions.firstIndex(where: { $0.id == model.id }) else { return }
 
+        let wasDedicated = dedicatedWindowSessionIDs.remove(model.id) != nil
         let wasActive = model.id == activeSessionID
         _ = scheduleSessionShutdown(for: model)
         modelObservations[model.id] = nil
@@ -268,9 +393,23 @@ final class ProjectSessionManager: ObservableObject {
         }
 
         if wasActive {
-            let nextIndex = min(removedIndex, sessions.count - 1)
-            activeSessionID = sessions[nextIndex].id
-            sessions[nextIndex].setProjectSessionActive(true)
+            let preferred: AppModel?
+            if wasDedicated {
+                preferred = primaryOpenProjects.first ?? primarySessions.first ?? sessions.first
+            } else {
+                let primary = primarySessions
+                if let nextPrimaryProject = primary.first(where: { $0.workspaceURL != nil }) {
+                    preferred = nextPrimaryProject
+                } else if let nextPrimary = primary.first {
+                    preferred = nextPrimary
+                } else {
+                    preferred = sessions.first
+                }
+            }
+            if let preferred {
+                activeSessionID = preferred.id
+                preferred.setProjectSessionActive(true)
+            }
         }
     }
 
@@ -301,5 +440,16 @@ final class ProjectSessionManager: ObservableObject {
                 await task.value
             }
         }
+    }
+}
+
+extension ProjectSessionManager: UnsavedDocumentHandling {}
+
+@MainActor
+final class ProjectWindowLauncher: ObservableObject {
+    var presentProjectWindow: ((UUID) -> Void)?
+
+    func present(_ sessionID: UUID) {
+        presentProjectWindow?(sessionID)
     }
 }

--- a/macos/Sources/Lithe/Platform/MacOS/UI/ProjectWindowLauncher.swift
+++ b/macos/Sources/Lithe/Platform/MacOS/UI/ProjectWindowLauncher.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+@MainActor
+final class ProjectWindowLauncher: ObservableObject {
+    var presentProjectWindow: ((UUID) -> Void)?
+    var dismissProjectWindow: ((UUID) -> Void)?
+    var presentPrimaryWindow: (() -> Void)?
+
+    func present(_ windowID: UUID) {
+        presentProjectWindow?(windowID)
+    }
+
+    func dismiss(_ windowID: UUID) {
+        dismissProjectWindow?(windowID)
+    }
+
+    func presentPrimary() {
+        presentPrimaryWindow?()
+    }
+}

--- a/macos/Sources/Lithe/Views/App/RootView.swift
+++ b/macos/Sources/Lithe/Views/App/RootView.swift
@@ -3,6 +3,7 @@ import LitheLocalHistoryModule
 import SwiftUI
 
 enum LitheWindowID {
+    static let welcome = "welcome"
     static let settings = "settings"
     static let project = "project"
 }
@@ -15,6 +16,41 @@ extension EnvironmentValues {
     var projectWindowScope: ProjectWindowScope {
         get { self[ProjectWindowScopeKey.self] }
         set { self[ProjectWindowScopeKey.self] = newValue }
+    }
+}
+
+/// Installs window present callbacks from a live SwiftUI scene environment so
+/// they are not tied to the primary window's lifetime alone.
+private struct ProjectWindowSceneBridge: View {
+    @EnvironmentObject private var projectWindowLauncher: ProjectWindowLauncher
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .accessibilityHidden(true)
+            .onAppear(perform: installCallbacks)
+    }
+
+    private func installCallbacks() {
+        projectWindowLauncher.presentProjectWindow = { windowID in
+            openWindow(id: LitheWindowID.project, value: windowID)
+        }
+        projectWindowLauncher.dismissProjectWindow = { windowID in
+            ProjectWindowAppKitDismisser.dismiss(windowID: windowID)
+        }
+        projectWindowLauncher.presentPrimaryWindow = {
+            openWindow(id: LitheWindowID.welcome)
+        }
+    }
+}
+
+enum ProjectWindowAppKitDismisser {
+    static func dismiss(windowID: UUID) {
+        let identifier = NSUserInterfaceItemIdentifier(windowID.uuidString)
+        for window in NSApplication.shared.windows where window.identifier == identifier {
+            window.close()
+        }
     }
 }
 
@@ -38,9 +74,12 @@ struct RootView: View {
                     isActive: isSessionActive(session)
                 )
             }
-            ActiveSessionChrome(scope: scope, session: scopedModel)
+            if let scopedModel {
+                ActiveSessionChrome(scope: scope, session: scopedModel)
+            }
         }
         .environment(\.projectWindowScope, scope)
+        .background(ProjectWindowSceneBridge())
         .frame(
             minWidth: windowLayout.minimumContentSize.width,
             minHeight: windowLayout.minimumContentSize.height
@@ -104,12 +143,6 @@ struct RootView: View {
                 Text(LocalizedStringKey(prompt.message))
             }
         }
-        .onAppear {
-            guard scope == .primary else { return }
-            projectWindowLauncher.presentProjectWindow = { sessionID in
-                openWindow(id: LitheWindowID.project, value: sessionID)
-            }
-        }
         .task {
             guard scope == .primary else { return }
             guard !didStartAutomaticUpdateCheck else { return }
@@ -120,43 +153,21 @@ struct RootView: View {
     }
 
     private var visibleSessions: [AppModel] {
-        switch scope {
-        case .primary:
-            return projectSessions.primarySessions
-        case .dedicated(let sessionID):
-            if let session = projectSessions.session(for: sessionID) {
-                return [session]
-            }
-            return []
-        }
+        projectSessions.sessions(in: scope)
     }
 
     private func isSessionActive(_ session: AppModel) -> Bool {
-        switch scope {
-        case .primary:
-            return session.id == projectSessions.activeSessionID
-                || (projectSessions.isDedicatedWindowSession(projectSessions.activeSessionID)
-                    && session.id == projectSessions.primarySessions.first?.id)
-        case .dedicated:
-            return true
-        }
+        session.id == projectSessions.activeSessionID(in: scope)
     }
 
-    private var scopedModel: AppModel {
-        switch scope {
-        case .primary:
-            if projectSessions.isDedicatedWindowSession(projectSessions.activeSessionID),
-               let primary = projectSessions.primarySessions.first {
-                return primary
-            }
-            return projectSessions.activeModel
-        case .dedicated(let sessionID):
-            return projectSessions.session(for: sessionID) ?? projectSessions.activeModel
-        }
+    private var scopedModel: AppModel? {
+        let sessions = visibleSessions
+        guard !sessions.isEmpty else { return nil }
+        return projectSessions.activeModel(in: scope)
     }
 
     private var windowLayout: LitheWindowLayout {
-        let model = scopedModel
+        guard let model = scopedModel else { return .welcome }
         if model.standaloneFileURL != nil { return .standalone }
         return model.workspaceURL == nil ? .welcome : .workspace
     }
@@ -255,8 +266,8 @@ private struct ActiveSessionChrome: View {
         switch scope {
         case .primary:
             return PrimaryProjectWindowSessions(manager: projectSessions)
-        case .dedicated(let sessionID):
-            return DedicatedProjectWindowSessions(manager: projectSessions, sessionID: sessionID)
+        case .dedicated(let windowID):
+            return DedicatedProjectWindowSessions(manager: projectSessions, windowID: windowID)
         }
     }
 
@@ -398,149 +409,12 @@ protocol ProjectWindowSessionHandling: UnsavedDocumentHandling {
     /// When true, closing the active project dismisses the window instead of
     /// converting it into a welcome shell.
     var shouldDismissWindowWhenClosingActiveSession: Bool { get }
+    var windowScope: ProjectWindowScope { get }
     func closeActiveProject()
     func requestCloseActiveWorkbenchItem() -> Bool
     func requestCloseActiveSession() -> Bool
     func resetForProjectWindowClose() async
-}
-
-@MainActor
-final class PrimaryProjectWindowSessions: ProjectWindowSessionHandling {
-    private let manager: ProjectSessionManager
-
-    init(manager: ProjectSessionManager) {
-        self.manager = manager
-    }
-
-    var hasUnsavedDocuments: Bool {
-        manager.primarySessions.contains(where: \.hasUnsavedDocuments)
-    }
-
-    var unsavedDocumentNames: [String] {
-        manager.primarySessions.flatMap { model in
-            model.openDocuments
-                .filter(\.isDirty)
-                .map { "\(model.projectName)/\($0.displayName)" }
-        }
-    }
-
-    var hasActiveProject: Bool {
-        scopedActiveModel.workspaceURL != nil
-    }
-
-    var hasActiveStandaloneFile: Bool {
-        scopedActiveModel.standaloneFileURL != nil
-            && !manager.isDedicatedWindowSession(scopedActiveModel.id)
-    }
-
-    var shouldDismissWindowWhenClosingActiveSession: Bool {
-        manager.shouldDismissPrimaryWindowWhenClosingActiveSession
-    }
-
-    func closeActiveProject() {
-        scopedActiveModel.closeProject()
-    }
-
-    func requestCloseActiveWorkbenchItem() -> Bool {
-        scopedActiveModel.requestCloseActiveWorkbenchItem()
-    }
-
-    func requestCloseActiveSession() -> Bool {
-        let model = scopedActiveModel
-        if model.workspaceURL != nil {
-            model.closeProject()
-            return false
-        }
-        if model.standaloneFileURL != nil {
-            if model.hasUnsavedDocuments {
-                model.closeStandaloneFile()
-                return false
-            }
-            return true
-        }
-        return true
-    }
-
-    func saveAllDocuments() -> Bool {
-        var savedAll = true
-        for model in manager.primarySessions where !model.saveAllDocuments() {
-            savedAll = false
-        }
-        return savedAll
-    }
-
-    func resetForProjectWindowClose() async {
-        if manager.shouldDismissPrimaryWindowWhenClosingActiveSession {
-            await manager.resetPrimaryWindowSessions()
-        } else {
-            await manager.resetForProjectWindowClose()
-        }
-    }
-
-    private var scopedActiveModel: AppModel {
-        if manager.isDedicatedWindowSession(manager.activeSessionID),
-           let primary = manager.primarySessions.first {
-            return primary
-        }
-        return manager.activeModel
-    }
-}
-
-@MainActor
-final class DedicatedProjectWindowSessions: ProjectWindowSessionHandling {
-    private let manager: ProjectSessionManager
-    private let sessionID: UUID
-
-    init(manager: ProjectSessionManager, sessionID: UUID) {
-        self.manager = manager
-        self.sessionID = sessionID
-    }
-
-    private var session: AppModel? {
-        manager.session(for: sessionID)
-    }
-
-    var hasUnsavedDocuments: Bool {
-        session?.hasUnsavedDocuments == true
-    }
-
-    var unsavedDocumentNames: [String] {
-        guard let session else { return [] }
-        return session.openDocuments
-            .filter(\.isDirty)
-            .map { "\(session.projectName)/\($0.displayName)" }
-    }
-
-    var hasActiveProject: Bool {
-        session?.workspaceURL != nil
-    }
-
-    var hasActiveStandaloneFile: Bool {
-        session?.standaloneFileURL != nil
-    }
-
-    var shouldDismissWindowWhenClosingActiveSession: Bool { true }
-
-    func closeActiveProject() {
-        session?.closeProject()
-    }
-
-    func requestCloseActiveWorkbenchItem() -> Bool {
-        session?.requestCloseActiveWorkbenchItem() ?? false
-    }
-
-    func requestCloseActiveSession() -> Bool {
-        // Dedicated windows always dismiss instead of becoming welcome.
-        false
-    }
-
-    func saveAllDocuments() -> Bool {
-        session?.saveAllDocuments() ?? true
-    }
-
-    func resetForProjectWindowClose() async {
-        await manager.resetDedicatedWindowSession(sessionID)
-    }
+    func noteWindowBecameKey()
 }
 
 @MainActor
@@ -584,7 +458,13 @@ final class LitheWindowCoordinator: NSObject, NSWindowDelegate {
             restoredWorkspaceFrame = nil
             startMonitoringCloseCommand()
         }
+        if case .dedicated(let windowID) = projectSessions.windowScope {
+            window.identifier = NSUserInterfaceItemIdentifier(windowID.uuidString)
+        }
         apply(layout, title: title, to: window)
+        if window.isKeyWindow {
+            projectSessions.noteWindowBecameKey()
+        }
     }
 
     func toggleWorkspaceZoom() {
@@ -608,6 +488,11 @@ final class LitheWindowCoordinator: NSObject, NSWindowDelegate {
         window.setFrame(targetFrame, display: true, animate: window.isVisible)
     }
 
+    func windowDidBecomeKey(_ notification: Notification) {
+        guard notification.object as? NSWindow === window else { return }
+        projectSessions.noteWindowBecameKey()
+    }
+
     func windowShouldClose(_ sender: NSWindow) -> Bool {
         if case .projectCleanupCompleted? = pendingNativeWindowCloseIntent {
             pendingNativeWindowCloseIntent = nil
@@ -617,6 +502,9 @@ final class LitheWindowCoordinator: NSObject, NSWindowDelegate {
         if case .commandW? = pendingNativeWindowCloseIntent {
             pendingNativeWindowCloseIntent = nil
             guard confirmUnsavedDocuments(projectSessions) else { return false }
+            // Cmd+W closes this window's sessions only. Dedicated windows always
+            // dismiss; primary windows either dismiss or tear down primary scope
+            // without touching other project windows.
             closeWindowAfterProjectCleanup(sender)
             return false
         }

--- a/macos/Sources/Lithe/Views/App/RootView.swift
+++ b/macos/Sources/Lithe/Views/App/RootView.swift
@@ -1,25 +1,46 @@
 import AppKit
+import LitheLocalHistoryModule
 import SwiftUI
 
 enum LitheWindowID {
     static let settings = "settings"
+    static let project = "project"
+}
+
+private struct ProjectWindowScopeKey: EnvironmentKey {
+    static let defaultValue: ProjectWindowScope = .primary
+}
+
+extension EnvironmentValues {
+    var projectWindowScope: ProjectWindowScope {
+        get { self[ProjectWindowScopeKey.self] }
+        set { self[ProjectWindowScopeKey.self] = newValue }
+    }
 }
 
 struct RootView: View {
+    let scope: ProjectWindowScope
     @EnvironmentObject private var projectSessions: ProjectSessionManager
+    @EnvironmentObject private var projectWindowLauncher: ProjectWindowLauncher
     @EnvironmentObject private var updateChecker: UpdateChecker
+    @Environment(\.openWindow) private var openWindow
     @State private var didStartAutomaticUpdateCheck = false
+
+    init(scope: ProjectWindowScope = .primary) {
+        self.scope = scope
+    }
 
     var body: some View {
         ZStack {
-            ForEach(projectSessions.sessions) { session in
+            ForEach(visibleSessions) { session in
                 ProjectSessionContent(
                     session: session,
-                    isActive: session.id == projectSessions.activeSessionID
+                    isActive: isSessionActive(session)
                 )
             }
-            ActiveSessionChrome()
+            ActiveSessionChrome(scope: scope, session: scopedModel)
         }
+        .environment(\.projectWindowScope, scope)
         .frame(
             minWidth: windowLayout.minimumContentSize.width,
             minHeight: windowLayout.minimumContentSize.height
@@ -83,7 +104,14 @@ struct RootView: View {
                 Text(LocalizedStringKey(prompt.message))
             }
         }
+        .onAppear {
+            guard scope == .primary else { return }
+            projectWindowLauncher.presentProjectWindow = { sessionID in
+                openWindow(id: LitheWindowID.project, value: sessionID)
+            }
+        }
         .task {
+            guard scope == .primary else { return }
             guard !didStartAutomaticUpdateCheck else { return }
             didStartAutomaticUpdateCheck = true
             guard !LithePerformanceBaseline.isEnabled else { return }
@@ -91,10 +119,46 @@ struct RootView: View {
         }
     }
 
+    private var visibleSessions: [AppModel] {
+        switch scope {
+        case .primary:
+            return projectSessions.primarySessions
+        case .dedicated(let sessionID):
+            if let session = projectSessions.session(for: sessionID) {
+                return [session]
+            }
+            return []
+        }
+    }
+
+    private func isSessionActive(_ session: AppModel) -> Bool {
+        switch scope {
+        case .primary:
+            return session.id == projectSessions.activeSessionID
+                || (projectSessions.isDedicatedWindowSession(projectSessions.activeSessionID)
+                    && session.id == projectSessions.primarySessions.first?.id)
+        case .dedicated:
+            return true
+        }
+    }
+
+    private var scopedModel: AppModel {
+        switch scope {
+        case .primary:
+            if projectSessions.isDedicatedWindowSession(projectSessions.activeSessionID),
+               let primary = projectSessions.primarySessions.first {
+                return primary
+            }
+            return projectSessions.activeModel
+        case .dedicated(let sessionID):
+            return projectSessions.session(for: sessionID) ?? projectSessions.activeModel
+        }
+    }
+
     private var windowLayout: LitheWindowLayout {
-        let activeModel = projectSessions.activeModel
-        if activeModel.standaloneFileURL != nil { return .standalone }
-        return activeModel.workspaceURL == nil ? .welcome : .workspace
+        let model = scopedModel
+        if model.standaloneFileURL != nil { return .standalone }
+        return model.workspaceURL == nil ? .welcome : .workspace
     }
 
     private var updatePromptPresented: Binding<Bool> {
@@ -135,8 +199,9 @@ private struct ProjectSessionContent: View {
 }
 
 private struct ActiveSessionChrome: View {
+    let scope: ProjectWindowScope
+    @ObservedObject var session: AppModel
     @Environment(\.openWindow) private var openWindow
-    @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var projectSessions: ProjectSessionManager
 
     var body: some View {
@@ -146,26 +211,29 @@ private struct ActiveSessionChrome: View {
             .accessibilityHidden(true)
             .background(
                 WindowCloseGuard(
-                    projectSessions: projectSessions,
+                    windowHandler: windowHandler,
                     layout: windowLayout,
                     title: windowTitle
                 )
             )
-            .onReceive(model.workbenchFeature.$isSettingsPresented) { isPresented in
+            .onReceive(session.workbenchFeature.$isSettingsPresented) { isPresented in
                 guard isPresented else { return }
                 openWindow(id: LitheWindowID.settings)
             }
-            .sheet(isPresented: $model.isCloneRepositoryPresented) {
+            .sheet(isPresented: Binding(
+                get: { session.workbenchFeature.isCloneRepositoryPresented },
+                set: { session.workbenchFeature.isCloneRepositoryPresented = $0 }
+            )) {
                 CloneRepositoryView()
-                    .environmentObject(model)
+                    .environmentObject(session)
             }
-            .sheet(item: $model.localHistoryRequest) { request in
+            .sheet(item: scopedLocalHistoryRequest) { request in
                 LocalHistoryView(request: request)
-                    .environmentObject(model)
+                    .environmentObject(session)
             }
-            .sheet(item: $model.projectLocalHistoryRequest) { request in
+            .sheet(item: scopedProjectLocalHistoryRequest) { request in
                 ProjectLocalHistoryView(request: request)
-                    .environmentObject(model)
+                    .environmentObject(session)
             }
             .confirmationDialog(
                 "Close Running Terminal?",
@@ -173,28 +241,50 @@ private struct ActiveSessionChrome: View {
                 titleVisibility: .visible
             ) {
                 Button("Close Terminal", role: .destructive) {
-                    model.confirmTerminalClose()
+                    session.confirmTerminalClose()
                 }
                 Button("Cancel", role: .cancel) {
-                    model.cancelTerminalClose()
+                    session.cancelTerminalClose()
                 }
             } message: {
                 Text("Closing this terminal will stop its shell and any running command.")
             }
     }
 
+    private var windowHandler: any ProjectWindowSessionHandling {
+        switch scope {
+        case .primary:
+            return PrimaryProjectWindowSessions(manager: projectSessions)
+        case .dedicated(let sessionID):
+            return DedicatedProjectWindowSessions(manager: projectSessions, sessionID: sessionID)
+        }
+    }
+
     private var windowLayout: LitheWindowLayout {
-        let activeModel = projectSessions.activeModel
-        if activeModel.standaloneFileURL != nil { return .standalone }
-        return activeModel.workspaceURL == nil ? .welcome : .workspace
+        if session.standaloneFileURL != nil { return .standalone }
+        return session.workspaceURL == nil ? .welcome : .workspace
+    }
+
+    private var scopedLocalHistoryRequest: Binding<LocalHistoryRequest?> {
+        Binding(
+            get: { session.localHistoryRequest },
+            set: { session.localHistoryRequest = $0 }
+        )
+    }
+
+    private var scopedProjectLocalHistoryRequest: Binding<ProjectLocalHistoryRequest?> {
+        Binding(
+            get: { session.projectLocalHistoryRequest },
+            set: { session.projectLocalHistoryRequest = $0 }
+        )
     }
 
     private var terminalCloseConfirmationPresented: Binding<Bool> {
         Binding(
-            get: { model.pendingTerminalCloseSessionID != nil },
+            get: { session.pendingTerminalCloseSessionID != nil },
             set: { isPresented in
                 if !isPresented {
-                    model.cancelTerminalClose()
+                    session.cancelTerminalClose()
                 }
             }
         )
@@ -202,26 +292,26 @@ private struct ActiveSessionChrome: View {
 
     private var windowTitle: String? {
         if windowLayout == .standalone {
-            return projectSessions.activeModel.standaloneFileURL?.lastPathComponent ?? "Lithe"
+            return session.standaloneFileURL?.lastPathComponent ?? "Lithe"
         }
         if windowLayout == .workspace {
-            return projectSessions.activeModel.workspaceURL?.lastPathComponent ?? "Lithe"
+            return session.workspaceURL?.lastPathComponent ?? "Lithe"
         }
         return String(
             localized: "Welcome to Lithe",
             bundle: .main,
-            locale: model.settings.language.locale
+            locale: session.settings.language.locale
         )
     }
 }
 
 private struct WindowCloseGuard: NSViewRepresentable {
-    let projectSessions: ProjectSessionManager
+    let windowHandler: any ProjectWindowSessionHandling
     let layout: LitheWindowLayout
     let title: String?
 
     func makeCoordinator() -> LitheWindowCoordinator {
-        LitheWindowCoordinator(projectSessions: projectSessions)
+        LitheWindowCoordinator(projectSessions: windowHandler)
     }
 
     func makeNSView(context: Context) -> NSView {
@@ -233,7 +323,7 @@ private struct WindowCloseGuard: NSViewRepresentable {
     }
 
     func updateNSView(_ view: NSView, context: Context) {
-        context.coordinator.projectSessions = projectSessions
+        context.coordinator.projectSessions = windowHandler
         DispatchQueue.main.async {
             context.coordinator.attach(to: view.window, layout: layout, title: title)
         }
@@ -305,19 +395,151 @@ enum LitheWindowLayout: Equatable {
 protocol ProjectWindowSessionHandling: UnsavedDocumentHandling {
     var hasActiveProject: Bool { get }
     var hasActiveStandaloneFile: Bool { get }
+    /// When true, closing the active project dismisses the window instead of
+    /// converting it into a welcome shell.
+    var shouldDismissWindowWhenClosingActiveSession: Bool { get }
     func closeActiveProject()
     func requestCloseActiveWorkbenchItem() -> Bool
     func requestCloseActiveSession() -> Bool
     func resetForProjectWindowClose() async
 }
 
-extension ProjectSessionManager: ProjectWindowSessionHandling {
+@MainActor
+final class PrimaryProjectWindowSessions: ProjectWindowSessionHandling {
+    private let manager: ProjectSessionManager
+
+    init(manager: ProjectSessionManager) {
+        self.manager = manager
+    }
+
+    var hasUnsavedDocuments: Bool {
+        manager.primarySessions.contains(where: \.hasUnsavedDocuments)
+    }
+
+    var unsavedDocumentNames: [String] {
+        manager.primarySessions.flatMap { model in
+            model.openDocuments
+                .filter(\.isDirty)
+                .map { "\(model.projectName)/\($0.displayName)" }
+        }
+    }
+
     var hasActiveProject: Bool {
-        activeModel.workspaceURL != nil
+        scopedActiveModel.workspaceURL != nil
     }
 
     var hasActiveStandaloneFile: Bool {
-        activeModel.standaloneFileURL != nil
+        scopedActiveModel.standaloneFileURL != nil
+            && !manager.isDedicatedWindowSession(scopedActiveModel.id)
+    }
+
+    var shouldDismissWindowWhenClosingActiveSession: Bool {
+        manager.shouldDismissPrimaryWindowWhenClosingActiveSession
+    }
+
+    func closeActiveProject() {
+        scopedActiveModel.closeProject()
+    }
+
+    func requestCloseActiveWorkbenchItem() -> Bool {
+        scopedActiveModel.requestCloseActiveWorkbenchItem()
+    }
+
+    func requestCloseActiveSession() -> Bool {
+        let model = scopedActiveModel
+        if model.workspaceURL != nil {
+            model.closeProject()
+            return false
+        }
+        if model.standaloneFileURL != nil {
+            if model.hasUnsavedDocuments {
+                model.closeStandaloneFile()
+                return false
+            }
+            return true
+        }
+        return true
+    }
+
+    func saveAllDocuments() -> Bool {
+        var savedAll = true
+        for model in manager.primarySessions where !model.saveAllDocuments() {
+            savedAll = false
+        }
+        return savedAll
+    }
+
+    func resetForProjectWindowClose() async {
+        if manager.shouldDismissPrimaryWindowWhenClosingActiveSession {
+            await manager.resetPrimaryWindowSessions()
+        } else {
+            await manager.resetForProjectWindowClose()
+        }
+    }
+
+    private var scopedActiveModel: AppModel {
+        if manager.isDedicatedWindowSession(manager.activeSessionID),
+           let primary = manager.primarySessions.first {
+            return primary
+        }
+        return manager.activeModel
+    }
+}
+
+@MainActor
+final class DedicatedProjectWindowSessions: ProjectWindowSessionHandling {
+    private let manager: ProjectSessionManager
+    private let sessionID: UUID
+
+    init(manager: ProjectSessionManager, sessionID: UUID) {
+        self.manager = manager
+        self.sessionID = sessionID
+    }
+
+    private var session: AppModel? {
+        manager.session(for: sessionID)
+    }
+
+    var hasUnsavedDocuments: Bool {
+        session?.hasUnsavedDocuments == true
+    }
+
+    var unsavedDocumentNames: [String] {
+        guard let session else { return [] }
+        return session.openDocuments
+            .filter(\.isDirty)
+            .map { "\(session.projectName)/\($0.displayName)" }
+    }
+
+    var hasActiveProject: Bool {
+        session?.workspaceURL != nil
+    }
+
+    var hasActiveStandaloneFile: Bool {
+        session?.standaloneFileURL != nil
+    }
+
+    var shouldDismissWindowWhenClosingActiveSession: Bool { true }
+
+    func closeActiveProject() {
+        session?.closeProject()
+    }
+
+    func requestCloseActiveWorkbenchItem() -> Bool {
+        session?.requestCloseActiveWorkbenchItem() ?? false
+    }
+
+    func requestCloseActiveSession() -> Bool {
+        // Dedicated windows always dismiss instead of becoming welcome.
+        false
+    }
+
+    func saveAllDocuments() -> Bool {
+        session?.saveAllDocuments() ?? true
+    }
+
+    func resetForProjectWindowClose() async {
+        await manager.resetDedicatedWindowSession(sessionID)
     }
 }
 
@@ -326,6 +548,7 @@ final class LitheWindowCoordinator: NSObject, NSWindowDelegate {
     private enum NativeWindowCloseIntent {
         case commandW
         case projectCleanupCompleted
+        case dismissActiveSession
     }
 
     var projectSessions: any ProjectWindowSessionHandling
@@ -398,6 +621,12 @@ final class LitheWindowCoordinator: NSObject, NSWindowDelegate {
             return false
         }
         if projectSessions.hasActiveProject || projectSessions.hasActiveStandaloneFile {
+            if projectSessions.shouldDismissWindowWhenClosingActiveSession {
+                guard confirmUnsavedDocuments(projectSessions) else { return false }
+                pendingNativeWindowCloseIntent = .dismissActiveSession
+                closeWindowAfterProjectCleanup(sender)
+                return false
+            }
             return projectSessions.requestCloseActiveSession()
         }
         return true

--- a/macos/Sources/Lithe/Views/App/RootView.swift
+++ b/macos/Sources/Lithe/Views/App/RootView.swift
@@ -85,7 +85,7 @@ struct RootView: View {
             minHeight: windowLayout.minimumContentSize.height
         )
         .background(LitheTheme.window)
-        .sheet(item: $projectSessions.pendingProjectOpen) { request in
+        .sheet(item: scopedPendingProjectOpen) { request in
             OpenProjectLocationDialog(request: request) { placement, doNotAskAgain in
                 projectSessions.resolvePendingOpen(
                     request,
@@ -170,6 +170,20 @@ struct RootView: View {
         guard let model = scopedModel else { return .welcome }
         if model.standaloneFileURL != nil { return .standalone }
         return model.workspaceURL == nil ? .welcome : .workspace
+    }
+
+    private var scopedPendingProjectOpen: Binding<PendingProjectOpen?> {
+        Binding(
+            get: { projectSessions.pendingProjectOpen(in: scope) },
+            set: { newValue in
+                guard newValue == nil,
+                      let pending = projectSessions.pendingProjectOpen,
+                      projectSessions.scope(for: pending.sourceSessionID) == scope else {
+                    return
+                }
+                projectSessions.cancelPendingOpen()
+            }
+        )
     }
 
     private var updatePromptPresented: Binding<Bool> {

--- a/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
+++ b/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
@@ -458,11 +458,14 @@ struct WorkbenchView: View {
                     .frame(minWidth: geometry.size.width, alignment: .leading)
                 }
                 .onAppear {
-                    proxy.scrollTo(projectSessions.activeSessionID, anchor: .center)
+                    proxy.scrollTo(projectSessions.activeSessionID(in: projectWindowScope), anchor: .center)
                 }
-                .onChange(of: projectSessions.activeSessionID) { id in
+                .onChange(of: projectSessions.activeSessionIDs) { _ in
                     withAnimation(.easeOut(duration: 0.12)) {
-                        proxy.scrollTo(id, anchor: .center)
+                        proxy.scrollTo(
+                            projectSessions.activeSessionID(in: projectWindowScope),
+                            anchor: .center
+                        )
                     }
                 }
             }
@@ -472,7 +475,7 @@ struct WorkbenchView: View {
     }
 
     private func projectTab(_ projectModel: AppModel, width: CGFloat) -> some View {
-        let isActive = projectModel.id == projectSessions.activeSessionID
+        let isActive = projectModel.id == projectSessions.activeSessionID(in: projectWindowScope)
         let isHovered = projectModel.id == hoveredProjectTabID
 
         return ZStack(alignment: .trailing) {

--- a/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
+++ b/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
@@ -68,6 +68,7 @@ struct WorkbenchView: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var projectSessions: ProjectSessionManager
     @EnvironmentObject private var settings: AppSettings
+    @Environment(\.projectWindowScope) private var projectWindowScope
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var linuxDoWebSession = LinuxDoAnonymousWebSession()
     @State private var sidebarWidth: CGFloat = 320
@@ -94,7 +95,7 @@ struct WorkbenchView: View {
         VStack(spacing: 0) {
             topBar
 
-            if projectSessions.openProjects.count > 1 {
+            if projectSessions.openProjects(in: projectWindowScope).count > 1 {
                 projectTabBar
             }
 
@@ -430,12 +431,16 @@ struct WorkbenchView: View {
         }
     }
 
+    private var scopedOpenProjects: [AppModel] {
+        projectSessions.openProjects(in: projectWindowScope)
+    }
+
     private var projectTabBar: some View {
         GeometryReader { geometry in
             let horizontalPadding: CGFloat = 6
             let tabSpacing: CGFloat = 6
             let minimumTabWidth: CGFloat = 180
-            let projectCount = CGFloat(max(projectSessions.openProjects.count, 1))
+            let projectCount = CGFloat(max(scopedOpenProjects.count, 1))
             let availableWidth = geometry.size.width
                 - horizontalPadding * 2
                 - tabSpacing * (projectCount - 1)
@@ -444,7 +449,7 @@ struct WorkbenchView: View {
             ScrollViewReader { proxy in
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: tabSpacing) {
-                        ForEach(projectSessions.openProjects) { projectModel in
+                        ForEach(scopedOpenProjects) { projectModel in
                             projectTab(projectModel, width: tabWidth)
                                 .id(projectModel.id)
                         }

--- a/macos/Sources/Lithe/Views/Workspace/ProjectSwitcherPopover.swift
+++ b/macos/Sources/Lithe/Views/Workspace/ProjectSwitcherPopover.swift
@@ -8,14 +8,19 @@ enum ProjectSwitcherLayoutMetrics {
 struct ProjectSwitcherPopover: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var projectSessions: ProjectSessionManager
+    @Environment(\.projectWindowScope) private var projectWindowScope
     @Binding var isPresented: Bool
     let onNewProject: () -> Void
     let onOpenProject: () -> Void
     let onCloneRepository: () -> Void
     let onOpenRecentProject: (RecentProject) -> Void
 
+    private var scopedOpenProjects: [AppModel] {
+        projectSessions.openProjects(in: projectWindowScope)
+    }
+
     private var openProjectPaths: Set<String> {
-        Set(projectSessions.openProjects.compactMap { $0.workspaceURL?.standardizedFileURL.path })
+        Set(scopedOpenProjects.compactMap { $0.workspaceURL?.standardizedFileURL.path })
     }
 
     private var recentProjects: [RecentProject] {
@@ -38,7 +43,7 @@ struct ProjectSwitcherPopover: View {
                 divider
 
                 sectionTitle("Open Projects")
-                ForEach(projectSessions.openProjects) { projectModel in
+                ForEach(scopedOpenProjects) { projectModel in
                     openProjectRow(projectModel)
                 }
 
@@ -100,7 +105,7 @@ struct ProjectSwitcherPopover: View {
     }
 
     private func openProjectRow(_ projectModel: AppModel) -> some View {
-        let isCurrent = projectModel.id == projectSessions.activeSessionID
+        let isCurrent = projectModel.id == projectSessions.activeSessionID(in: projectWindowScope)
         return Button {
             isPresented = false
             projectSessions.activateSession(projectModel.id)

--- a/macos/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/macos/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -211,6 +211,102 @@ struct LitheCoreLogicTests {
 
     @Test
     @MainActor
+    func dismissingADedicatedProjectWindowResetsThatWindowSession() async {
+        let sessions = TestProjectWindowSessions(hasActiveProject: true)
+        sessions.shouldDismissWindowWhenClosingActiveSession = true
+        let coordinator = LitheWindowCoordinator(
+            projectSessions: sessions,
+            confirmUnsavedDocuments: { _ in true }
+        )
+        let window = CloseCommandTestWindow()
+        coordinator.attach(to: window, layout: .workspace)
+
+        #expect(!coordinator.windowShouldClose(window))
+        #expect(await window.waitUntilNativeCloseAllowed())
+        #expect(sessions.resetForProjectWindowCloseCallCount == 1)
+        #expect(sessions.requestCloseActiveSessionCallCount == 0)
+    }
+
+    @Test
+    @MainActor
+    func openingAProjectInANewWindowCreatesADedicatedSession() throws {
+        let store = MutableKeyValueStore()
+        let settings = AppSettings(store: store)
+        settings.projectOpenBehavior = .newWindow
+        var presentedSessionIDs: [UUID] = []
+        let manager = ProjectSessionManager(
+            settings: settings,
+            modelFactory: {
+                AppModel(
+                    settings: settings,
+                    services: MacServiceContainer(
+                        store: store,
+                        settings: settings,
+                        moduleLaunchMode: .safeMode
+                    ).services
+                )
+            },
+            projectWindowPresenter: { presentedSessionIDs.append($0) }
+        )
+
+        let firstURL = URL(fileURLWithPath: "/tmp/lithe-primary-project")
+        let secondURL = URL(fileURLWithPath: "/tmp/lithe-dedicated-project")
+        manager.openStartupProject(firstURL)
+        let primaryID = manager.activeSessionID
+
+        manager.requestOpenProject(secondURL, from: primaryID)
+
+        #expect(manager.openProjects.count == 2)
+        #expect(manager.primaryOpenProjects.count == 1)
+        #expect(manager.primaryOpenProjects.first?.id == primaryID)
+        #expect(presentedSessionIDs.count == 1)
+        let dedicatedID = try #require(presentedSessionIDs.first)
+        #expect(manager.isDedicatedWindowSession(dedicatedID))
+        #expect(manager.session(for: dedicatedID)?.workspaceURL?.standardizedFileURL == secondURL)
+        #expect(manager.shouldDismissPrimaryWindowWhenClosingActiveSession)
+    }
+
+    @Test
+    @MainActor
+    func resettingADedicatedWindowKeepsOtherProjectsOpen() async throws {
+        let store = MutableKeyValueStore()
+        let settings = AppSettings(store: store)
+        settings.projectOpenBehavior = .newWindow
+        var presentedSessionIDs: [UUID] = []
+        let manager = ProjectSessionManager(
+            settings: settings,
+            modelFactory: {
+                AppModel(
+                    settings: settings,
+                    services: MacServiceContainer(
+                        store: store,
+                        settings: settings,
+                        moduleLaunchMode: .safeMode
+                    ).services
+                )
+            },
+            projectWindowPresenter: { presentedSessionIDs.append($0) }
+        )
+
+        manager.openStartupProject(URL(fileURLWithPath: "/tmp/lithe-keep-primary"))
+        let primaryID = manager.activeSessionID
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-close-dedicated"),
+            from: primaryID
+        )
+        let dedicatedID = try #require(presentedSessionIDs.first)
+
+        await manager.resetDedicatedWindowSession(dedicatedID)
+
+        #expect(!manager.isDedicatedWindowSession(dedicatedID))
+        #expect(manager.session(for: dedicatedID) == nil)
+        #expect(manager.openProjects.count == 1)
+        #expect(manager.activeSessionID == primaryID)
+        #expect(manager.activeModel.workspaceURL != nil)
+    }
+
+    @Test
+    @MainActor
     func closingAProjectWindowReplacesAllSessionsWithAnEmptyActiveSession() async {
         let store = MutableKeyValueStore()
         let settings = AppSettings(store: store)
@@ -229,7 +325,7 @@ struct LitheCoreLogicTests {
                 createdModels.append(model)
                 return model
             },
-            newWindowOpener: { _ in }
+            projectWindowPresenter: { _ in }
         )
 
         manager.openStandaloneFile(URL(fileURLWithPath: "/tmp/lithe-close-first.swift"))
@@ -265,7 +361,7 @@ struct LitheCoreLogicTests {
                     services: MacServiceContainer(store: store, settings: settings).services
                 )
             },
-            newWindowOpener: { _ in }
+            projectWindowPresenter: { _ in }
         )
         let previousModel = manager.activeModel
         let runtime = previousModel.services.moduleRuntime
@@ -3080,6 +3176,7 @@ private final class ProjectWindowShutdownTestModule: LitheModule {
 private final class TestProjectWindowSessions: ProjectWindowSessionHandling {
     var hasActiveProject: Bool
     var hasActiveStandaloneFile = false
+    var shouldDismissWindowWhenClosingActiveSession = false
     var consumesWorkbenchCloseCommand = false
     var hasUnsavedDocuments = false
     var unsavedDocumentNames: [String] = []

--- a/macos/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/macos/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -233,7 +233,7 @@ struct LitheCoreLogicTests {
         let store = MutableKeyValueStore()
         let settings = AppSettings(store: store)
         settings.projectOpenBehavior = .newWindow
-        var presentedSessionIDs: [UUID] = []
+        var presentedWindowIDs: [UUID] = []
         let manager = ProjectSessionManager(
             settings: settings,
             modelFactory: {
@@ -246,24 +246,208 @@ struct LitheCoreLogicTests {
                     ).services
                 )
             },
-            projectWindowPresenter: { presentedSessionIDs.append($0) }
+            projectWindowPresenter: { presentedWindowIDs.append($0) }
         )
 
         let firstURL = URL(fileURLWithPath: "/tmp/lithe-primary-project")
         let secondURL = URL(fileURLWithPath: "/tmp/lithe-dedicated-project")
         manager.openStartupProject(firstURL)
-        let primaryID = manager.activeSessionID
+        let primaryID = manager.activeSessionID(in: .primary)
 
         manager.requestOpenProject(secondURL, from: primaryID)
 
         #expect(manager.openProjects.count == 2)
         #expect(manager.primaryOpenProjects.count == 1)
         #expect(manager.primaryOpenProjects.first?.id == primaryID)
-        #expect(presentedSessionIDs.count == 1)
-        let dedicatedID = try #require(presentedSessionIDs.first)
-        #expect(manager.isDedicatedWindowSession(dedicatedID))
-        #expect(manager.session(for: dedicatedID)?.workspaceURL?.standardizedFileURL == secondURL)
+        #expect(presentedWindowIDs.count == 1)
+        let dedicatedWindowID = try #require(presentedWindowIDs.first)
+        #expect(manager.activeSessionID(in: .primary) == primaryID)
+        #expect(manager.isDedicatedWindowSession(dedicatedWindowID))
+        #expect(
+            manager.activeModel(in: .dedicated(dedicatedWindowID))
+                .workspaceURL?.standardizedFileURL == secondURL
+        )
         #expect(manager.shouldDismissPrimaryWindowWhenClosingActiveSession)
+    }
+
+    @Test
+    @MainActor
+    func openingInThisWindowFromDedicatedStaysInDedicatedScope() throws {
+        let store = MutableKeyValueStore()
+        let settings = AppSettings(store: store)
+        settings.projectOpenBehavior = .newWindow
+        var presentedWindowIDs: [UUID] = []
+        let manager = ProjectSessionManager(
+            settings: settings,
+            modelFactory: {
+                AppModel(
+                    settings: settings,
+                    services: MacServiceContainer(
+                        store: store,
+                        settings: settings,
+                        moduleLaunchMode: .safeMode
+                    ).services
+                )
+            },
+            projectWindowPresenter: { presentedWindowIDs.append($0) }
+        )
+
+        manager.openStartupProject(URL(fileURLWithPath: "/tmp/lithe-primary-a"))
+        let primaryID = manager.activeSessionID(in: .primary)
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-dedicated-b"),
+            from: primaryID
+        )
+        let dedicatedWindowID = try #require(presentedWindowIDs.first)
+        let dedicatedSessionID = manager.activeSessionID(in: .dedicated(dedicatedWindowID))
+
+        settings.projectOpenBehavior = .thisWindow
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-dedicated-d"),
+            from: dedicatedSessionID
+        )
+
+        #expect(manager.primaryOpenProjects.count == 1)
+        #expect(manager.openProjects(in: .dedicated(dedicatedWindowID)).count == 2)
+        #expect(
+            manager.openProjects(in: .dedicated(dedicatedWindowID))
+                .contains { $0.workspaceURL?.path.hasSuffix("lithe-dedicated-d") == true }
+        )
+        #expect(manager.activeSessionID(in: .primary) == primaryID)
+    }
+
+    @Test
+    @MainActor
+    func removingADedicatedSessionDismissesItsWindow() throws {
+        let store = MutableKeyValueStore()
+        let settings = AppSettings(store: store)
+        settings.projectOpenBehavior = .newWindow
+        var presentedWindowIDs: [UUID] = []
+        var dismissedWindowIDs: [UUID] = []
+        let manager = ProjectSessionManager(
+            settings: settings,
+            modelFactory: {
+                AppModel(
+                    settings: settings,
+                    services: MacServiceContainer(
+                        store: store,
+                        settings: settings,
+                        moduleLaunchMode: .safeMode
+                    ).services
+                )
+            },
+            projectWindowPresenter: { presentedWindowIDs.append($0) },
+            projectWindowDismisser: { dismissedWindowIDs.append($0) }
+        )
+
+        manager.openStartupProject(URL(fileURLWithPath: "/tmp/lithe-primary-keep"))
+        let primaryID = manager.activeSessionID(in: .primary)
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-dedicated-close"),
+            from: primaryID
+        )
+        let dedicatedWindowID = try #require(presentedWindowIDs.first)
+        let dedicatedSessionID = manager.activeSessionID(in: .dedicated(dedicatedWindowID))
+
+        manager.closeProject(dedicatedSessionID)
+
+        #expect(dismissedWindowIDs == [dedicatedWindowID])
+        #expect(manager.session(for: dedicatedSessionID) == nil)
+        #expect(manager.openProjects.count == 1)
+        #expect(manager.activeSessionID(in: .primary) == primaryID)
+    }
+
+    @Test
+    @MainActor
+    func resettingPrimaryWindowDoesNotDestroyDedicatedSessions() async throws {
+        let store = MutableKeyValueStore()
+        let settings = AppSettings(store: store)
+        settings.projectOpenBehavior = .thisWindow
+        var presentedWindowIDs: [UUID] = []
+        let manager = ProjectSessionManager(
+            settings: settings,
+            modelFactory: {
+                AppModel(
+                    settings: settings,
+                    services: MacServiceContainer(
+                        store: store,
+                        settings: settings,
+                        moduleLaunchMode: .safeMode
+                    ).services
+                )
+            },
+            projectWindowPresenter: { presentedWindowIDs.append($0) }
+        )
+
+        manager.openStartupProject(URL(fileURLWithPath: "/tmp/lithe-primary-a"))
+        let primaryID = manager.activeSessionID(in: .primary)
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-primary-b"),
+            from: primaryID
+        )
+        settings.projectOpenBehavior = .newWindow
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-dedicated-c"),
+            from: manager.activeSessionID(in: .primary)
+        )
+        let dedicatedWindowID = try #require(presentedWindowIDs.first)
+        let dedicatedSessionID = manager.activeSessionID(in: .dedicated(dedicatedWindowID))
+
+        #expect(manager.primaryOpenProjects.count == 2)
+        await manager.resetForProjectWindowClose()
+
+        #expect(manager.primaryOpenProjects.isEmpty)
+        #expect(manager.session(for: dedicatedSessionID) != nil)
+        #expect(
+            manager.activeModel(in: .dedicated(dedicatedWindowID))
+                .workspaceURL?.path.hasSuffix("lithe-dedicated-c") == true
+        )
+    }
+
+    @Test
+    @MainActor
+    func activatingADedicatedSessionDoesNotChangePrimaryActiveTab() throws {
+        let store = MutableKeyValueStore()
+        let settings = AppSettings(store: store)
+        settings.projectOpenBehavior = .thisWindow
+        var presentedWindowIDs: [UUID] = []
+        let manager = ProjectSessionManager(
+            settings: settings,
+            modelFactory: {
+                AppModel(
+                    settings: settings,
+                    services: MacServiceContainer(
+                        store: store,
+                        settings: settings,
+                        moduleLaunchMode: .safeMode
+                    ).services
+                )
+            },
+            projectWindowPresenter: { presentedWindowIDs.append($0) }
+        )
+
+        manager.openStartupProject(URL(fileURLWithPath: "/tmp/lithe-primary-a"))
+        let primaryA = manager.activeSessionID(in: .primary)
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-primary-b"),
+            from: primaryA
+        )
+        let primaryB = manager.activeSessionID(in: .primary)
+        #expect(primaryB != primaryA)
+
+        settings.projectOpenBehavior = .newWindow
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-dedicated-c"),
+            from: primaryB
+        )
+        let dedicatedWindowID = try #require(presentedWindowIDs.first)
+
+        #expect(manager.activeSessionID(in: .primary) == primaryB)
+        #expect(manager.activeSessionID(in: .dedicated(dedicatedWindowID)) != primaryB)
+
+        manager.noteWindowBecameKey(.primary)
+        #expect(manager.activeSessionID(in: .primary) == primaryB)
+        #expect(manager.focusedScope == .primary)
     }
 
     @Test
@@ -272,7 +456,8 @@ struct LitheCoreLogicTests {
         let store = MutableKeyValueStore()
         let settings = AppSettings(store: store)
         settings.projectOpenBehavior = .newWindow
-        var presentedSessionIDs: [UUID] = []
+        var presentedWindowIDs: [UUID] = []
+        var dismissedWindowIDs: [UUID] = []
         let manager = ProjectSessionManager(
             settings: settings,
             modelFactory: {
@@ -285,24 +470,63 @@ struct LitheCoreLogicTests {
                     ).services
                 )
             },
-            projectWindowPresenter: { presentedSessionIDs.append($0) }
+            projectWindowPresenter: { presentedWindowIDs.append($0) },
+            projectWindowDismisser: { dismissedWindowIDs.append($0) }
         )
 
         manager.openStartupProject(URL(fileURLWithPath: "/tmp/lithe-keep-primary"))
-        let primaryID = manager.activeSessionID
+        let primaryID = manager.activeSessionID(in: .primary)
         manager.requestOpenProject(
             URL(fileURLWithPath: "/tmp/lithe-close-dedicated"),
             from: primaryID
         )
-        let dedicatedID = try #require(presentedSessionIDs.first)
+        let dedicatedWindowID = try #require(presentedWindowIDs.first)
 
-        await manager.resetDedicatedWindowSession(dedicatedID)
+        await manager.resetDedicatedWindowSession(windowID: dedicatedWindowID)
 
-        #expect(!manager.isDedicatedWindowSession(dedicatedID))
-        #expect(manager.session(for: dedicatedID) == nil)
+        #expect(dismissedWindowIDs == [dedicatedWindowID])
+        #expect(manager.sessions(in: .dedicated(dedicatedWindowID)).isEmpty)
         #expect(manager.openProjects.count == 1)
+        #expect(manager.activeSessionID(in: .primary) == primaryID)
+        #expect(manager.activeModel(in: .primary).workspaceURL != nil)
+    }
+
+    @Test
+    @MainActor
+    func windowFocusUpdatesMenuCommandTargetSession() throws {
+        let store = MutableKeyValueStore()
+        let settings = AppSettings(store: store)
+        settings.projectOpenBehavior = .newWindow
+        var presentedWindowIDs: [UUID] = []
+        let manager = ProjectSessionManager(
+            settings: settings,
+            modelFactory: {
+                AppModel(
+                    settings: settings,
+                    services: MacServiceContainer(
+                        store: store,
+                        settings: settings,
+                        moduleLaunchMode: .safeMode
+                    ).services
+                )
+            },
+            projectWindowPresenter: { presentedWindowIDs.append($0) }
+        )
+
+        manager.openStartupProject(URL(fileURLWithPath: "/tmp/lithe-focus-primary"))
+        let primaryID = manager.activeSessionID(in: .primary)
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-focus-dedicated"),
+            from: primaryID
+        )
+        let dedicatedWindowID = try #require(presentedWindowIDs.first)
+        let dedicatedID = manager.activeSessionID(in: .dedicated(dedicatedWindowID))
+
+        #expect(manager.activeSessionID == dedicatedID)
+        manager.noteWindowBecameKey(.primary)
         #expect(manager.activeSessionID == primaryID)
-        #expect(manager.activeModel.workspaceURL != nil)
+        manager.noteWindowBecameKey(.dedicated(dedicatedWindowID))
+        #expect(manager.activeSessionID == dedicatedID)
     }
 
     @Test
@@ -3177,6 +3401,7 @@ private final class TestProjectWindowSessions: ProjectWindowSessionHandling {
     var hasActiveProject: Bool
     var hasActiveStandaloneFile = false
     var shouldDismissWindowWhenClosingActiveSession = false
+    var windowScope: ProjectWindowScope = .primary
     var consumesWorkbenchCloseCommand = false
     var hasUnsavedDocuments = false
     var unsavedDocumentNames: [String] = []
@@ -3187,6 +3412,7 @@ private final class TestProjectWindowSessions: ProjectWindowSessionHandling {
     private(set) var closeActiveWorkbenchItemCallCount = 0
     private(set) var requestCloseActiveSessionCallCount = 0
     private(set) var resetForProjectWindowCloseCallCount = 0
+    private(set) var noteWindowBecameKeyCallCount = 0
     private(set) var saveAllDocumentsCallCount = 0
 
     init(hasActiveProject: Bool) {
@@ -3219,6 +3445,10 @@ private final class TestProjectWindowSessions: ProjectWindowSessionHandling {
         if let projectWindowCleanupRelease {
             _ = await projectWindowCleanupRelease.waitUntilOpen()
         }
+    }
+
+    func noteWindowBecameKey() {
+        noteWindowBecameKeyCallCount += 1
     }
 }
 

--- a/macos/Tests/LitheTests/LitheCoreLogicTests.swift
+++ b/macos/Tests/LitheTests/LitheCoreLogicTests.swift
@@ -493,6 +493,54 @@ struct LitheCoreLogicTests {
 
     @Test
     @MainActor
+    func askPromptIsScopedToTheSourceWindowOnly() throws {
+        let store = MutableKeyValueStore()
+        let settings = AppSettings(store: store)
+        settings.projectOpenBehavior = .newWindow
+        var presentedWindowIDs: [UUID] = []
+        let manager = ProjectSessionManager(
+            settings: settings,
+            modelFactory: {
+                AppModel(
+                    settings: settings,
+                    services: MacServiceContainer(
+                        store: store,
+                        settings: settings,
+                        moduleLaunchMode: .safeMode
+                    ).services
+                )
+            },
+            projectWindowPresenter: { presentedWindowIDs.append($0) }
+        )
+
+        manager.openStartupProject(URL(fileURLWithPath: "/tmp/lithe-ask-primary"))
+        let primaryID = manager.activeSessionID(in: .primary)
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-ask-dedicated"),
+            from: primaryID
+        )
+        let dedicatedWindowID = try #require(presentedWindowIDs.first)
+        let dedicatedSessionID = manager.activeSessionID(in: .dedicated(dedicatedWindowID))
+
+        settings.projectOpenBehavior = .ask
+        manager.requestOpenProject(
+            URL(fileURLWithPath: "/tmp/lithe-ask-next"),
+            from: dedicatedSessionID
+        )
+
+        let pending = try #require(manager.pendingProjectOpen)
+        #expect(manager.scope(for: pending.sourceSessionID) == .dedicated(dedicatedWindowID))
+        #expect(manager.pendingProjectOpen(in: .dedicated(dedicatedWindowID))?.id == pending.id)
+        #expect(manager.pendingProjectOpen(in: .primary) == nil)
+
+        manager.resolvePendingOpen(pending, placement: .thisWindow, doNotAskAgain: false)
+        #expect(manager.pendingProjectOpen == nil)
+        #expect(manager.openProjects(in: .dedicated(dedicatedWindowID)).count == 2)
+        #expect(manager.primaryOpenProjects.count == 1)
+    }
+
+    @Test
+    @MainActor
     func windowFocusUpdatesMenuCommandTargetSession() throws {
         let store = MutableKeyValueStore()
         let settings = AppSettings(store: store)


### PR DESCRIPTION
## Summary
- 修复 macOS 上「新窗口打开项目」会拉起独立进程、Dock 出现多个 Lithe 图标的问题。
- 改为同一应用实例内通过 `WindowGroup` 打开专用项目窗口；关闭非最后一个项目窗口时不再落到欢迎页，仅当最后一个项目关闭后才出现欢迎页。
- 同步更新窗口关闭路径与相关单元测试，覆盖专用窗口创建/关闭与主窗口共存行为。

Closes #524

## Test plan
- [x] `./scripts/preview.sh` 启动应用
- [x] 打开项目 A，再以「New Window / 新窗口」打开项目 B、C
- [x] 确认 Dock 中只有 **一个** Lithe 图标，活动监视器中只有 **一个** Lithe 进程
- [x] 关闭其中一个项目窗口后，其余项目窗口仍保持工作台，不回到欢迎页
- [x] 关闭到最后一个项目后，才出现欢迎页
- [x] 「This Window / 此窗口」打开多个项目时，项目标签栏切换仍正常
- [x] 运行：`swift test --disable-sandbox --filter LitheCoreLogicTests/(ordinaryWindowClose|dismissingADedicated|openingAProjectInANewWindow|resettingADedicatedWindow|closingAProjectWindowReplaces|closingTheWelcomeWindow|applicationTerminates)`（或等价的本地验证）

## Notes
- Base branch: `preview`
- Head branch: `feat/issue-524-single-instance-multi-window`
- Platform: macOS only