### PR TITLE
fix(macos): 修复提交文件树文字重叠并支持悬停展开

### DIFF
--- a/macos/Sources/Lithe/Views/Git/GitCommitFileTreeView.swift
+++ b/macos/Sources/Lithe/Views/Git/GitCommitFileTreeView.swift
@@ -41,10 +41,10 @@ struct GitCommitFileTreeScrollView: NSViewRepresentable {
         onToggleFolder: @escaping (String) -> Void,
         onSelectFile: @escaping (GitCommitFile) -> Void
     ) -> NSScrollView {
-        let scrollView = NSScrollView()
+        let scrollView = GitCommitFileTreeScrollNSView()
         scrollView.drawsBackground = false
         scrollView.borderType = .noBorder
-        scrollView.hasHorizontalScroller = false
+        scrollView.hasHorizontalScroller = true
         scrollView.hasVerticalScroller = true
         scrollView.autohidesScrollers = true
         scrollView.scrollerStyle = .overlay
@@ -54,7 +54,7 @@ struct GitCommitFileTreeScrollView: NSViewRepresentable {
         scrollView.scrollsDynamically = true
 
         let documentView = GitCommitFileTreeNSView()
-        documentView.autoresizingMask = [.width]
+        documentView.autoresizingMask = []
         documentView.update(
             items: items,
             selectedFileID: selectedFileID,
@@ -64,13 +64,13 @@ struct GitCommitFileTreeScrollView: NSViewRepresentable {
             onSelectFile: onSelectFile
         )
         scrollView.documentView = documentView
+        scrollView.updateDocumentLayout()
         return scrollView
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         guard let documentView = nsView.documentView as? GitCommitFileTreeNSView else { return }
-        let previousOrigin = nsView.contentView.bounds.origin
-        let contentChanged = documentView.update(
+        documentView.update(
             items: items,
             selectedFileID: selectedFileID,
             rootSubtitle: rootSubtitle,
@@ -78,27 +78,44 @@ struct GitCommitFileTreeScrollView: NSViewRepresentable {
             onToggleFolder: onToggleFolder,
             onSelectFile: onSelectFile
         )
-        let layoutChanged = documentView.updateLayout(width: nsView.contentView.bounds.width)
-        if contentChanged || layoutChanged {
-            nsView.contentView.setBoundsOrigin(Self.preservedScrollOrigin(
-                previous: previousOrigin,
-                documentHeight: documentView.bounds.height,
-                viewportHeight: nsView.contentView.bounds.height
-            ))
-        }
+        (nsView as? GitCommitFileTreeScrollNSView)?.updateDocumentLayout()
     }
 
     static func preservedScrollOrigin(
         previous: CGPoint,
         documentHeight: CGFloat,
-        viewportHeight: CGFloat
+        viewportHeight: CGFloat,
+        documentWidth: CGFloat,
+        viewportWidth: CGFloat
     ) -> CGPoint {
         let maxY = max(0, documentHeight - viewportHeight)
-        return CGPoint(x: max(previous.x, 0), y: min(max(previous.y, 0), maxY))
+        let maxX = max(0, documentWidth - viewportWidth)
+        return CGPoint(x: min(max(previous.x, 0), maxX), y: min(max(previous.y, 0), maxY))
     }
 }
 
-final class GitCommitFileTreeNSView: NSView {
+final class GitCommitFileTreeScrollNSView: NSScrollView {
+    override func layout() {
+        super.layout()
+        updateDocumentLayout()
+    }
+
+    func updateDocumentLayout() {
+        guard let documentView = documentView as? GitCommitFileTreeNSView else { return }
+        let previousOrigin = contentView.bounds.origin
+        guard documentView.updateLayout(width: contentView.bounds.width) else { return }
+        contentView.setBoundsOrigin(GitCommitFileTreeScrollView.preservedScrollOrigin(
+            previous: previousOrigin,
+            documentHeight: documentView.bounds.height,
+            viewportHeight: contentView.bounds.height,
+            documentWidth: documentView.bounds.width,
+            viewportWidth: contentView.bounds.width
+        ))
+        reflectScrolledClipView(contentView)
+    }
+}
+
+final class GitCommitFileTreeNSView: NSControl {
     static let rowHeight: CGFloat = 28
     private let verticalInset: CGFloat = 5
 
@@ -110,13 +127,16 @@ final class GitCommitFileTreeNSView: NSView {
     private var onSelectFile: ((GitCommitFile) -> Void)?
     private var drawingStyle: DrawingStyle?
     private var hoveredIndex: Int?
-    private var lastLayoutWidth: CGFloat = -.greatestFiniteMagnitude
+    private var rowPresentations: [RowPresentation] = []
+    private var contentWidth: CGFloat = 0
+    private var hoverTrackingArea: NSTrackingArea?
 
     override var isOpaque: Bool { false }
     override var isFlipped: Bool { true }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
+        allowsExpansionToolTips = true
         setAccessibilityRole(.outline)
         setAccessibilityLabel(String(localized: "Commit changed files"))
     }
@@ -133,9 +153,9 @@ final class GitCommitFileTreeNSView: NSView {
         onToggleFolder: @escaping (String) -> Void,
         onSelectFile: @escaping (GitCommitFile) -> Void
     ) -> Bool {
-        let changed = self.items != items
+        let contentChanged = self.items != items || self.rootSubtitle != rootSubtitle
+        let changed = contentChanged
             || self.selectedFileID != selectedFileID
-            || self.rootSubtitle != rootSubtitle
             || self.collapsedFolderIDs != collapsedFolderIDs
         self.items = items
         self.selectedFileID = selectedFileID
@@ -144,16 +164,19 @@ final class GitCommitFileTreeNSView: NSView {
         self.onToggleFolder = onToggleFolder
         self.onSelectFile = onSelectFile
         setAccessibilityValue(String(format: String(localized: "%lld changed files"), items.count))
+        if contentChanged {
+            rebuildRowPresentations()
+            hoveredIndex = nil
+        }
         if changed { needsDisplay = true }
         return changed
     }
 
     @discardableResult
     func updateLayout(width: CGFloat) -> Bool {
-        guard width.isFinite, width > 0, width != lastLayoutWidth else { return false }
-        lastLayoutWidth = width
+        guard width.isFinite, width >= 0 else { return false }
         let size = CGSize(
-            width: width,
+            width: max(width, contentWidth),
             height: CGFloat(items.count) * Self.rowHeight + verticalInset * 2
         )
         guard frame.size != size else { return false }
@@ -164,28 +187,42 @@ final class GitCommitFileTreeNSView: NSView {
 
     override func layout() {
         super.layout()
-        _ = updateLayout(width: bounds.width)
+        _ = updateLayout(width: enclosingScrollView?.contentView.bounds.width ?? bounds.width)
     }
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         drawingStyle = nil
+        rebuildRowPresentations()
+        enclosingScrollView?.needsLayout = true
         needsDisplay = true
     }
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
-        trackingAreas.forEach(removeTrackingArea)
-        addTrackingArea(NSTrackingArea(
+        if let hoverTrackingArea { removeTrackingArea(hoverTrackingArea) }
+        let area = NSTrackingArea(
             rect: bounds,
             options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow, .inVisibleRect],
             owner: self,
             userInfo: nil
-        ))
+        )
+        hoverTrackingArea = area
+        addTrackingArea(area)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        updateHover(at: convert(event.locationInWindow, from: nil))
     }
 
     override func mouseMoved(with event: NSEvent) {
-        let index = rowIndex(at: convert(event.locationInWindow, from: nil))
+        super.mouseMoved(with: event)
+        updateHover(at: convert(event.locationInWindow, from: nil))
+    }
+
+    private func updateHover(at point: CGPoint) {
+        let index = rowIndex(at: point)
         guard hoveredIndex != index else { return }
         if let hoveredIndex { setNeedsDisplay(rowRect(for: hoveredIndex)) }
         hoveredIndex = index
@@ -193,6 +230,7 @@ final class GitCommitFileTreeNSView: NSView {
     }
 
     override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
         guard hoveredIndex != nil else { return }
         if let hoveredIndex { setNeedsDisplay(rowRect(for: hoveredIndex)) }
         hoveredIndex = nil
@@ -210,6 +248,24 @@ final class GitCommitFileTreeNSView: NSView {
         case let .file(file, _):
             onSelectFile?(file)
         }
+    }
+
+    override func expansionFrame(withFrame contentFrame: NSRect) -> NSRect {
+        guard let hoveredIndex, rowPresentations.indices.contains(hoveredIndex) else { return .zero }
+        let presentation = rowPresentations[hoveredIndex]
+        let row = rowRect(for: hoveredIndex)
+        let titleRect = CGRect(x: presentation.textX, y: row.minY, width: presentation.textWidth, height: row.height)
+        guard titleRect.intersects(visibleRect), !visibleRect.contains(titleRect) else { return .zero }
+        return titleRect
+    }
+
+    override func draw(withExpansionFrame contentFrame: NSRect, in view: NSView) {
+        guard let hoveredIndex, rowPresentations.indices.contains(hoveredIndex) else { return }
+        let presentation = rowPresentations[hoveredIndex]
+        let style = resolvedDrawingStyle()
+        style.background.setFill()
+        contentFrame.fill()
+        drawText(presentation.title, in: contentFrame, font: presentation.font)
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -230,9 +286,9 @@ final class GitCommitFileTreeNSView: NSView {
             }
             switch items[index] {
             case let .folder(node, depth):
-                drawFolder(node, depth: depth, in: rowRect, style: style, context: context)
+                drawFolder(node, depth: depth, presentation: rowPresentations[index], in: rowRect, style: style, context: context)
             case let .file(file, depth):
-                drawFile(file, depth: depth, in: rowRect, style: style, context: context)
+                drawFile(file, depth: depth, presentation: rowPresentations[index], in: rowRect, style: style, context: context)
             }
         }
     }
@@ -269,6 +325,7 @@ final class GitCommitFileTreeNSView: NSView {
     private func drawFolder(
         _ node: GitCommitFileTreeNode,
         depth: Int,
+        presentation: RowPresentation,
         in rect: CGRect,
         style: DrawingStyle,
         context: CGContext
@@ -276,12 +333,11 @@ final class GitCommitFileTreeNSView: NSView {
         let x = 8 + CGFloat(depth * 16)
         let isCollapsed = collapsedFolderIDs.contains(node.id)
         drawText(isCollapsed ? ">" : "v", in: CGRect(x: x, y: rect.minY, width: 10, height: rect.height), font: style.disclosureFont, color: style.secondaryText)
-        drawText(node.name, in: CGRect(x: x + 21, y: rect.minY, width: max(0, rect.width - x - 125), height: rect.height), font: style.mediumFont, color: style.primaryText)
-        let countText = node.fileCount == 1 ? String(localized: "1 file") : String(format: String(localized: "%lld files"), node.fileCount)
-        drawText(countText, in: CGRect(x: max(x + 95, rect.maxX - 118), y: rect.minY, width: 70, height: rect.height), font: style.metadataFont, color: style.secondaryText, alignment: .right)
-        if depth == 0, let rootSubtitle {
-            drawText(rootSubtitle, in: CGRect(x: max(x + 170, rect.maxX - 300), y: rect.minY, width: 170, height: rect.height), font: style.metadataFont, color: style.tertiaryText, alignment: .right)
-        }
+        drawText(
+            presentation.title,
+            in: CGRect(x: presentation.textX, y: rect.minY, width: presentation.textWidth, height: rect.height),
+            font: presentation.font
+        )
         context.setFillColor(style.divider.cgColor)
         context.fill(CGRect(x: 0, y: rect.maxY - 1, width: rect.width, height: 1))
     }
@@ -289,6 +345,7 @@ final class GitCommitFileTreeNSView: NSView {
     private func drawFile(
         _ file: GitCommitFile,
         depth: Int,
+        presentation: RowPresentation,
         in rect: CGRect,
         style: DrawingStyle,
         context: CGContext
@@ -299,8 +356,11 @@ final class GitCommitFileTreeNSView: NSView {
         }
         let x = 30 + CGFloat(max(depth - 1, 0) * 16)
         drawText(file.status, in: CGRect(x: x, y: rect.minY, width: 18, height: rect.height), font: style.statusFont, color: statusColor(file.status, style: style), alignment: .center)
-        let title = (file.path as NSString).lastPathComponent
-        drawText(title, in: CGRect(x: x + 26, y: rect.minY, width: max(0, rect.width - x - 34), height: rect.height), font: style.bodyFont, color: style.primaryText)
+        drawText(
+            presentation.title,
+            in: CGRect(x: presentation.textX, y: rect.minY, width: presentation.textWidth, height: rect.height),
+            font: presentation.font
+        )
         context.setFillColor(style.divider.cgColor)
         context.fill(CGRect(x: 0, y: rect.maxY - 1, width: rect.width, height: 1))
     }
@@ -312,17 +372,75 @@ final class GitCommitFileTreeNSView: NSView {
         color: NSColor,
         alignment: NSTextAlignment = .left
     ) {
+        drawText(
+            NSAttributedString(string: text, attributes: [.font: font, .foregroundColor: color]),
+            in: rect,
+            font: font,
+            alignment: alignment
+        )
+    }
+
+    private func drawText(
+        _ text: NSAttributedString,
+        in rect: CGRect,
+        font: NSFont,
+        alignment: NSTextAlignment = .left
+    ) {
         guard rect.width > 0 else { return }
         let paragraph = NSMutableParagraphStyle()
-        paragraph.lineBreakMode = .byTruncatingTail
+        paragraph.lineBreakMode = .byClipping
         paragraph.alignment = alignment
         let height = ceil(font.ascender - font.descender)
         let textRect = CGRect(x: rect.minX, y: rect.midY - height / 2, width: rect.width, height: height)
-        (text as NSString).draw(in: textRect, withAttributes: [
-            .font: font,
-            .foregroundColor: color,
-            .paragraphStyle: paragraph
-        ])
+        let attributedText = NSMutableAttributedString(attributedString: text)
+        attributedText.addAttribute(.paragraphStyle, value: paragraph, range: NSRange(location: 0, length: attributedText.length))
+        NSGraphicsContext.saveGraphicsState()
+        textRect.clip()
+        attributedText.draw(in: textRect)
+        NSGraphicsContext.restoreGraphicsState()
+    }
+
+    private struct RowPresentation {
+        let title: NSAttributedString
+        let font: NSFont
+        let textX: CGFloat
+        let textWidth: CGFloat
+    }
+
+    private func rebuildRowPresentations() {
+        let style = resolvedDrawingStyle()
+        // Intrinsic widths depend on content and fonts, never on the viewport.
+        // Scrolling and splitter drags only move or resize the native clip view.
+        rowPresentations = items.map { item in
+            let title: NSMutableAttributedString
+            let font: NSFont
+            let textX: CGFloat
+            switch item {
+            case let .folder(node, depth):
+                font = style.mediumFont
+                textX = 29 + CGFloat(depth * 16)
+                title = NSMutableAttributedString(string: node.name, attributes: [
+                    .font: font, .foregroundColor: style.primaryText
+                ])
+                let count = node.fileCount == 1 ? String(localized: "1 file") : String(format: String(localized: "%lld files"), node.fileCount)
+                title.append(NSAttributedString(string: "  \(count)", attributes: [
+                    .font: style.metadataFont, .foregroundColor: style.secondaryText
+                ]))
+                if depth == 0, let rootSubtitle, !rootSubtitle.isEmpty {
+                    title.append(NSAttributedString(string: "  \(rootSubtitle)", attributes: [
+                        .font: style.metadataFont, .foregroundColor: style.tertiaryText
+                    ]))
+                }
+            case let .file(file, depth):
+                font = style.bodyFont
+                textX = 56 + CGFloat(max(depth - 1, 0) * 16)
+                title = NSMutableAttributedString(string: (file.path as NSString).lastPathComponent, attributes: [
+                    .font: font, .foregroundColor: style.primaryText
+                ])
+            }
+            return RowPresentation(title: title, font: font, textX: textX, textWidth: ceil(title.size().width))
+        }
+        contentWidth = rowPresentations.reduce(0) { max($0, $1.textX + $1.textWidth + 8) }
     }
 
     private func resolvedDrawingStyle() -> DrawingStyle {
@@ -346,6 +464,7 @@ final class GitCommitFileTreeNSView: NSView {
         let metadataFont = NSFont.systemFont(ofSize: 12)
         let disclosureFont = NSFont.systemFont(ofSize: 9, weight: .bold)
         let statusFont = NSFont.monospacedSystemFont(ofSize: 11, weight: .bold)
+        let background: NSColor
         let primaryText: NSColor
         let secondaryText: NSColor
         let tertiaryText: NSColor
@@ -358,6 +477,7 @@ final class GitCommitFileTreeNSView: NSView {
         let selection: NSColor
 
         init(isDark: Bool) {
+            background = LitheTheme.nsColor(.sidebar, isDark: isDark)
             primaryText = LitheTheme.nsColor(.primaryText, isDark: isDark)
             secondaryText = LitheTheme.nsColor(.secondaryText, isDark: isDark)
             tertiaryText = LitheTheme.nsColor(.secondaryText, isDark: isDark).withAlphaComponent(0.76)

--- a/macos/Tests/LitheTests/GitCommitFileTreeLayoutTests.swift
+++ b/macos/Tests/LitheTests/GitCommitFileTreeLayoutTests.swift
@@ -1,0 +1,115 @@
+import AppKit
+import Testing
+
+@testable import Lithe
+@testable import LitheGitModule
+
+@Suite("Commit file tree layout", .serialized)
+@MainActor
+struct GitCommitFileTreeLayoutTests {
+    @Test
+    func longRowsKeepTheirFullWidthAcrossViewportResizes() throws {
+        let file = GitCommitFile(
+            status: "M", path: "Sources/" + String(repeating: "LongName", count: 12) + ".swift")
+        let scroll = try makeScroll(items: [.file(file, depth: 8)], width: 240)
+        let document = try #require(scroll.documentView as? GitCommitFileTreeNSView)
+        let fullWidth = document.frame.width
+        #expect(scroll.hasHorizontalScroller)
+        #expect(fullWidth > scroll.contentView.bounds.width)
+
+        for width: CGFloat in [0, 180, 420, 240] {
+            scroll.frame.size.width = width
+            scroll.tile()
+            scroll.updateDocumentLayout()
+            #expect(document.frame.width == fullWidth)
+            #expect(document.frame.height > 0)
+        }
+
+        scroll.frame.size.width = fullWidth + 100
+        scroll.tile()
+        scroll.updateDocumentLayout()
+        #expect(document.frame.width == scroll.contentView.bounds.width)
+    }
+
+    @Test
+    func replacingRowsAtTheSameViewportSizeUpdatesBothScrollExtents() throws {
+        let file = GitCommitFile(status: "M", path: String(repeating: "LongName", count: 12) + ".swift")
+        let rows = (0..<40).map { GitCommitFileTreeItem.file(file, depth: $0) }
+        let scroll = try makeScroll(items: rows, width: 240)
+        let document = try #require(scroll.documentView as? GitCommitFileTreeNSView)
+        scroll.contentView.scroll(to: CGPoint(x: 300, y: 600))
+        #expect(scroll.contentView.bounds.minX > 0)
+        #expect(scroll.contentView.bounds.minY > 0)
+
+        document.update(
+            items: [], selectedFileID: nil, rootSubtitle: nil, collapsedFolderIDs: [],
+            onToggleFolder: { _ in }, onSelectFile: { _ in })
+        scroll.updateDocumentLayout()
+        #expect(document.frame.width == scroll.contentView.bounds.width)
+        #expect(document.frame.height < scroll.contentView.bounds.height)
+        #expect(scroll.contentView.bounds.origin == .zero)
+    }
+
+    @Test
+    func clippedFolderAnnotationsExpandOnHoverAndFitAfterWidening() throws {
+        let root = GitCommitFileTreeNode.build(
+            from: [GitCommitFile(status: "M", path: "File.swift")], rootName: "Repository")
+        let scroll = try makeScroll(
+            items: [.folder(root, depth: 0)], width: 180,
+            subtitle: String(repeating: "ParentDirectory/", count: 8) + "Repository")
+        let document = try #require(scroll.documentView as? GitCommitFileTreeNSView)
+        try hover(document, at: CGPoint(x: 60, y: 15))
+        #expect(document.allowsExpansionToolTips)
+        let expansion = document.expansionFrame(withFrame: document.bounds)
+        #expect(!expansion.isEmpty)
+        #expect(expansion.maxX > document.visibleRect.maxX)
+        #expect(expansion.minY >= 0)
+        #expect(expansion.height <= GitCommitFileTreeNSView.rowHeight)
+
+        scroll.frame.size.width = document.frame.width + 100
+        scroll.tile()
+        scroll.updateDocumentLayout()
+        #expect(document.expansionFrame(withFrame: document.bounds).isEmpty)
+    }
+
+    @Test
+    func fileHoverExpansionFollowsTheHoveredRowAndClearsOnExit() throws {
+        let longFile = GitCommitFile(status: "M", path: String(repeating: "LongName", count: 12) + ".swift")
+        let shortFile = GitCommitFile(status: "A", path: "File.swift")
+        let scroll = try makeScroll(
+            items: [.file(longFile, depth: 1), .file(shortFile, depth: 1)], width: 240)
+        let document = try #require(scroll.documentView as? GitCommitFileTreeNSView)
+        try hover(document, at: CGPoint(x: 70, y: 15))
+        #expect(!document.expansionFrame(withFrame: document.bounds).isEmpty)
+        try hover(document, at: CGPoint(x: 70, y: 43))
+        #expect(document.expansionFrame(withFrame: document.bounds).isEmpty)
+        try hover(document, at: CGPoint(x: 70, y: 15))
+        let exit = try #require(
+            NSEvent.enterExitEvent(
+                with: .mouseExited, location: .zero, modifierFlags: [], timestamp: 0, windowNumber: 0,
+                context: nil, eventNumber: 0, trackingNumber: 0, userData: nil))
+        document.mouseExited(with: exit)
+        #expect(document.expansionFrame(withFrame: document.bounds).isEmpty)
+    }
+
+    private func makeScroll(items: [GitCommitFileTreeItem], width: CGFloat, subtitle: String? = nil) throws
+        -> GitCommitFileTreeScrollNSView
+    {
+        let scroll = try #require(
+            GitCommitFileTreeScrollView.makeScrollView(
+                items: items, selectedFileID: nil, rootSubtitle: subtitle, collapsedFolderIDs: [],
+                onToggleFolder: { _ in }, onSelectFile: { _ in }) as? GitCommitFileTreeScrollNSView)
+        scroll.frame = CGRect(x: 0, y: 0, width: width, height: 100)
+        scroll.tile()
+        scroll.updateDocumentLayout()
+        return scroll
+    }
+
+    private func hover(_ view: NSView, at point: CGPoint) throws {
+        let event = try #require(
+            NSEvent.mouseEvent(
+                with: .mouseMoved, location: view.convert(point, to: nil), modifierFlags: [], timestamp: 0,
+                windowNumber: 0, context: nil, eventNumber: 0, clickCount: 0, pressure: 0))
+        view.mouseMoved(with: event)
+    }
+}


### PR DESCRIPTION
Git 日志的提交文件树在面板较窄时，仓库路径和文件数使用的固定绘制区域相互交叉，导致文字重叠。此修改将名称、文件数和仓库路径按顺序放入同一个文本布局，并保留行的完整内容宽度：超出面板的部分通过横向滚动查看，悬停时使用 AppKit 原生展开提示，不插入省略号。

文字尺寸只在内容或外观变化时重新计算；滚动和调整面板宽度继续使用原生容器，不触发高频整页重建。新增测试覆盖长行与深层缩进、面板缩放、内容变短后的滚动范围修正，以及悬停行切换和退出。

验证：

- macOS 产品构建通过。
- 基于 `preview` 的独立 PR 工作区运行 macOS 完整回归：1,099 项测试、123 个测试套件全部通过（31.678 秒）。使用测试稳定性计时脚本调用 `scripts/test-macos.sh --no-parallel --scratch-path <existing-build-cache>`。
- 服务边界检查、测试稳定性检查和 `git diff --check` 通过。
- 原生文件树性能检查通过：5,522 行中仅绘制可见行，单帧中位数约 0.17 ms。

原生绘制结果已检查。桌面自动化连接超时，因此真实鼠标停留后系统浮层的显示效果尚未完成视觉复核；悬停展开回调与绘制已通过 AppKit 测试和离屏绘制检查。
