### PR TITLE
fix(macos): 修复 Git 丢弃更改并优化相关测试等待

### DIFF
--- a/macos/Sources/Lithe/Models/AppModel/AppModel+GitOperations.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+GitOperations.swift
@@ -83,9 +83,9 @@ extension AppModel {
         await gitFeature.refreshGit()
     }
 
-    func confirmDiscardHunk() async {
+    func confirmDiscardHunk(_ request: DiffHunkRequest) async {
         guard let gitFeature = await activateGitModule() else { return }
-        await gitFeature.confirmDiscardHunk()
+        await gitFeature.confirmDiscardHunk(request)
     }
 
     func cancelDiscardHunk() {
@@ -100,9 +100,9 @@ extension AppModel {
         gitFeatureIfActive?.requestDiscardChange(change)
     }
 
-    func confirmDiscardChange() async {
+    func confirmDiscardChange(_ change: GitChange) async {
         guard let gitFeature = await activateGitModule() else { return }
-        await gitFeature.confirmDiscardChange()
+        await gitFeature.confirmDiscardChange(change)
     }
 
     func cancelDiscardChange() {

--- a/macos/Sources/Lithe/Models/AppModel/AppModel+RunConfiguration.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+RunConfiguration.swift
@@ -360,32 +360,36 @@ extension AppModel {
 
     func startRunConfiguration(_ configuration: RunConfiguration) {
         Task { [weak self] in
-            guard let self else { return }
-            guard let identity = currentWorkspaceIdentity else { return }
-            guard let runFeature = await activateExecutionModule()?.runFeature else { return }
-            guard isCurrentWorkspace(identity) else { return }
-            switch await ensureRunProjectReady(runFeature, for: identity) {
-            case .ready:
-                clearPendingRunAction(for: identity)
-            case .waitingForSnapshot(let waitingIdentity):
-                // Direct play buttons reach here without going through
-                // `runSelectedConfiguration`, so they need the same readiness
-                // gate and must remember which configuration to resume — bound
-                // to the opening this task started for, not whatever is current
-                // after an await.
-                deferRunAction(.startConfiguration(configuration), for: waitingIdentity)
-                return
-            case .stale:
-                return
-            }
-            guard await activateLanguageRunExtensionIfNeeded(
-                for: configuration,
-                currentFileURL: activeDocument?.url,
-                runFeature: runFeature
-            ) else { return }
-            guard isCurrentWorkspace(identity) else { return }
-            runFeature.startConfiguration(configuration)
+            await self?.performStartRunConfiguration(configuration)
         }
+    }
+
+    /// Completes the entry workflow, including rejecting actions from an earlier workspace opening.
+    func performStartRunConfiguration(_ configuration: RunConfiguration) async {
+        guard let identity = currentWorkspaceIdentity else { return }
+        guard let runFeature = await activateExecutionModule()?.runFeature else { return }
+        guard isCurrentWorkspace(identity) else { return }
+        switch await ensureRunProjectReady(runFeature, for: identity) {
+        case .ready:
+            clearPendingRunAction(for: identity)
+        case .waitingForSnapshot(let waitingIdentity):
+            // Direct play buttons reach here without going through
+            // `runSelectedConfiguration`, so they need the same readiness
+            // gate and must remember which configuration to resume — bound
+            // to the opening this task started for, not whatever is current
+            // after an await.
+            deferRunAction(.startConfiguration(configuration), for: waitingIdentity)
+            return
+        case .stale:
+            return
+        }
+        guard await activateLanguageRunExtensionIfNeeded(
+            for: configuration,
+            currentFileURL: activeDocument?.url,
+            runFeature: runFeature
+        ) else { return }
+        guard isCurrentWorkspace(identity) else { return }
+        runFeature.startConfiguration(configuration)
     }
 
     func runAllServiceConfigurations() {

--- a/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
+++ b/macos/Sources/Lithe/Views/Workbench/WorkbenchView.swift
@@ -231,7 +231,8 @@ struct WorkbenchView: View {
             titleVisibility: .visible
         ) {
             Button(model.pendingDiscardChange?.isUntracked == true ? "Delete File" : "Discard Changes", role: .destructive) {
-                Task { await model.confirmDiscardChange() }
+                guard let change = model.pendingDiscardChange else { return }
+                Task { await model.confirmDiscardChange(change) }
             }
             .lithePointer()
             Button("Cancel", role: .cancel) { model.cancelDiscardChange() }
@@ -266,7 +267,8 @@ struct WorkbenchView: View {
             titleVisibility: .visible
         ) {
             Button("Discard Block", role: .destructive) {
-                Task { await model.confirmDiscardHunk() }
+                guard let request = model.pendingDiscardHunk else { return }
+                Task { await model.confirmDiscardHunk(request) }
             }
             .lithePointer()
             Button("Cancel", role: .cancel) { model.cancelDiscardHunk() }

--- a/macos/Sources/LitheGitModule/Application/GitFeatureModel.swift
+++ b/macos/Sources/LitheGitModule/Application/GitFeatureModel.swift
@@ -887,8 +887,8 @@ package final class GitFeatureModel: ObservableObject {
         pendingDiscardHunk = DiffHunkRequest(change: change, hunk: hunk)
     }
 
-    package func confirmDiscardHunk() async {
-        guard let request = pendingDiscardHunk else { return }
+    // Receive the confirmed value before SwiftUI dismisses and clears the dialog binding.
+    package func confirmDiscardHunk(_ request: DiffHunkRequest) async {
         pendingDiscardHunk = nil
         let result = await withGitOperation {
             await service.discard(hunk: request.hunk, of: request.change)
@@ -914,8 +914,8 @@ package final class GitFeatureModel: ObservableObject {
         pendingDiscardChange = change
     }
 
-    package func confirmDiscardChange() async {
-        guard let change = pendingDiscardChange else { return }
+    // Receive the confirmed value before SwiftUI dismisses and clears the dialog binding.
+    package func confirmDiscardChange(_ change: GitChange) async {
         pendingDiscardChange = nil
         let result = await withGitOperation { await service.discard(change) }
         showResult(result, success: "Discarded \(change.path)")

--- a/macos/Tests/LitheGitModuleTests/GitModuleTests.swift
+++ b/macos/Tests/LitheGitModuleTests/GitModuleTests.swift
@@ -579,6 +579,66 @@ struct GitModuleTests {
         #expect(feature.gitConsoleEntries.first?.succeeded == true)
     }
 
+    @Test(arguments: [false, true])
+    func confirmedDiscardSurvivesDialogDismissal(untracked: Bool) async throws {
+        let root = URL(fileURLWithPath: "/workspace")
+        let change = GitChange(repositoryRoot: root, path: "target.txt", originalPath: nil,
+                               indexStatus: untracked ? "?" : " ", workTreeStatus: untracked ? "?" : "M")
+        let service = GitService(operations: TestGitOperations(
+            snapshotValue: GitSnapshot(repositoryRoot: root, branch: "main", changes: []),
+            discardHandler: { target in
+                GitProcessResult(arguments: ["discard", target.path], output: "", standardOutput: "",
+                                 standardError: "", exitCode: 0)
+            }
+        ))
+        let feature = GitFeatureModel(service: service)
+        var notifications: [String] = []
+        feature.configure(workspaceURLProvider: { root }, isGitLogVisibleProvider: { false },
+                          notify: { notifications.append($0) }, onStateRefreshed: {})
+        await feature.refreshGit()
+        feature.clearGitConsole()
+        feature.requestDiscardChange(change)
+        let confirmed = try #require(feature.pendingDiscardChange)
+        // SwiftUI dismisses the dialog before the button's asynchronous operation starts.
+        feature.cancelDiscardChange()
+        #expect(feature.gitConsoleEntries.isEmpty)
+        await feature.confirmDiscardChange(confirmed)
+        #expect(feature.gitConsoleEntries.map(\.arguments) == [["discard", "target.txt"]])
+        #expect(notifications == ["Discarded target.txt"])
+        #expect(feature.pendingDiscardChange == nil)
+        #expect(feature.gitChanges.isEmpty)
+    }
+
+    @Test
+    func confirmedDiscardHunkSurvivesDialogDismissalAndReportsFailure() async throws {
+        let root = URL(fileURLWithPath: "/workspace")
+        let change = GitChange(repositoryRoot: root, path: "target.txt", originalPath: nil,
+                               indexStatus: " ", workTreeStatus: "M")
+        let hunk = DiffHunk(id: "h1", header: "@@ -1 +1 @@", patch: "confirmed patch")
+        let service = GitService(operations: TestGitOperations(
+            snapshotValue: GitSnapshot(repositoryRoot: root, branch: "main", changes: [change]),
+            applyPatchHandler: { patch, _, mode in
+                GitProcessResult(arguments: [mode, patch], output: "Patch no longer applies",
+                                 standardOutput: "", standardError: "Patch no longer applies", exitCode: 1)
+            }
+        ))
+        let feature = GitFeatureModel(service: service)
+        var notifications: [String] = []
+        feature.configure(workspaceURLProvider: { root }, isGitLogVisibleProvider: { false },
+                          notify: { notifications.append($0) }, onStateRefreshed: {})
+        await feature.refreshGit()
+        feature.clearGitConsole()
+        feature.requestDiscardHunk(hunk, in: change)
+        let confirmed = try #require(feature.pendingDiscardHunk)
+        feature.cancelDiscardHunk()
+        #expect(feature.gitConsoleEntries.isEmpty)
+        await feature.confirmDiscardHunk(confirmed)
+        #expect(feature.gitConsoleEntries.map(\.arguments) == [["discard", "confirmed patch"]])
+        #expect(notifications == ["Patch no longer applies"])
+        #expect(feature.pendingDiscardHunk == nil)
+        #expect(feature.gitChanges == [change])
+    }
+
     // MARK: Tag management
 
     @Test
@@ -2688,6 +2748,8 @@ private struct TestGitOperations: GitOperations {
     private let historyPageValues: [String: GitHistoryPage]?
     private let historyController: GitHistoryLoadController?
     private let snapshotGate: GitModuleTestGate?
+    private let discardHandler: (@Sendable (GitChange) -> GitProcessResult?)?
+    private let applyPatchHandler: (@Sendable (String, URL, String) -> GitProcessResult?)?
     private let stageResult: GitProcessResult?
     private let commitResult: GitProcessResult?
     private let runGate: TestGitRunGate?
@@ -2718,6 +2780,8 @@ private struct TestGitOperations: GitOperations {
         comparisonDiffDocumentValue: DiffDocument? = nil,
         typedComparisonDiffDocumentValue: DiffDocument? = nil,
         snapshotGate: GitModuleTestGate? = nil,
+        discardHandler: (@Sendable (GitChange) -> GitProcessResult?)? = nil,
+        applyPatchHandler: (@Sendable (String, URL, String) -> GitProcessResult?)? = nil,
         stageResult: GitProcessResult? = nil,
         commitResult: GitProcessResult? = nil,
         runGate: TestGitRunGate? = nil,
@@ -2747,6 +2811,8 @@ private struct TestGitOperations: GitOperations {
         self.comparisonDiffDocumentValue = comparisonDiffDocumentValue
         self.typedComparisonDiffDocumentValue = typedComparisonDiffDocumentValue
         self.snapshotGate = snapshotGate
+        self.discardHandler = discardHandler
+        self.applyPatchHandler = applyPatchHandler
         self.stageResult = stageResult
         self.commitResult = commitResult
         self.runGate = runGate
@@ -2793,7 +2859,9 @@ private struct TestGitOperations: GitOperations {
     func commitDiffDocument(at rootURL: URL, commit: String, pathspecs: [String], whitespace: GitDiffWhitespaceMode) -> DiffDocument? { nil }
     func comparisonDiffDocument(at rootURL: URL, reference: String, pathspecs: [String], whitespace: GitDiffWhitespaceMode) -> DiffDocument? { comparisonDiffDocumentValue }
     func comparisonDiffDocument(at rootURL: URL, reference: GitReference, targetReference: GitReference?, pathspecs: [String], whitespace: GitDiffWhitespaceMode) -> DiffDocument? { typedComparisonDiffDocumentValue }
-    func applyPatch(_ patch: String, at rootURL: URL, mode: String) -> GitProcessResult? { nil }
+    func applyPatch(_ patch: String, at rootURL: URL, mode: String) -> GitProcessResult? {
+        applyPatchHandler?(patch, rootURL, mode)
+    }
     func history(at rootURL: URL, reference: GitReference?, limit: Int) -> GitHistorySnapshot? {
         if let historyController {
             return historyController.history(at: rootURL, reference: reference, limit: limit)
@@ -2842,7 +2910,7 @@ private struct TestGitOperations: GitOperations {
     func blame(at rootURL: URL, relativePath: String) -> [GitBlameLine]? { nil }
     func stage(_ change: GitChange) -> GitProcessResult? { stageResult }
     func unstage(_ change: GitChange) -> GitProcessResult? { nil }
-    func discard(_ change: GitChange) -> GitProcessResult? { nil }
+    func discard(_ change: GitChange) -> GitProcessResult? { discardHandler?(change) }
     func discardAll(_ change: GitChange) -> GitProcessResult? { nil }
     func commit(at rootURL: URL, message: String, amend: Bool) -> GitProcessResult? { commitResult }
     func cherryPick(_ hash: String, at rootURL: URL) -> GitProcessResult? { nil }

--- a/macos/Tests/LitheTests/GitStatusObservationTests.swift
+++ b/macos/Tests/LitheTests/GitStatusObservationTests.swift
@@ -239,7 +239,6 @@ struct GitStatusObservationTests {
             ["init", "-q", "--separate-git-dir=\(gitDirectory.path)", workspace.path],
             at: fixture.url
         )
-        try await fixture.configureRepository(at: workspace)
         try Data("initial\n".utf8).write(to: workspace.appendingPathComponent("tracked.txt"))
         try await fixture.git(["add", "tracked.txt"], at: workspace)
         try await fixture.git(["commit", "-q", "-m", "initial"], at: workspace)
@@ -273,7 +272,6 @@ struct GitStatusObservationTests {
         )
         try await fixture.git(["commit", "-q", "-am", "add submodule"], at: parent)
         let submodule = parent.appendingPathComponent("modules/child", isDirectory: true)
-        try await fixture.configureRepository(at: submodule)
         try Data("changed\n".utf8).write(to: submodule.appendingPathComponent("tracked.txt"))
         let recorder = GitObservationRecorder()
         let model = makeObservationModel(recorder: recorder)
@@ -304,7 +302,6 @@ struct GitStatusObservationTests {
         )
         try await fixture.git(["commit", "-q", "-am", "add submodule"], at: parent)
         let submodule = parent.appendingPathComponent("modules/child", isDirectory: true)
-        try await fixture.configureRepository(at: submodule)
         try Data("changed\n".utf8).write(to: submodule.appendingPathComponent("tracked.txt"))
         try await fixture.git(["add", "tracked.txt"], at: submodule)
         let recorder = GitObservationRecorder()
@@ -427,16 +424,9 @@ private final class GitObservationFixture {
         try? FileManager.default.removeItem(at: url)
     }
 
-    func configureRepository(at repository: URL) async throws {
-        try await git(["config", "user.email", "tests@lithe.local"], at: repository)
-        try await git(["config", "user.name", "Lithe Tests"], at: repository)
-        try await git(["config", "core.autocrlf", "false"], at: repository)
-    }
-
     func initializeRepository(at repository: URL) async throws {
         try FileManager.default.createDirectory(at: repository, withIntermediateDirectories: true)
         try await git(["init", "-q"], at: repository)
-        try await configureRepository(at: repository)
         try Data("initial\n".utf8).write(to: repository.appendingPathComponent("tracked.txt"))
         try await git(["add", "tracked.txt"], at: repository)
         try await git(["commit", "-q", "-m", "initial"], at: repository)
@@ -446,7 +436,8 @@ private final class GitObservationFixture {
     func git(_ arguments: [String], at directory: URL) async throws -> String {
         let result = try await TestProcess.run(
             executableURL: URL(fileURLWithPath: "/usr/bin/git"),
-            arguments: arguments,
+            arguments: ["-c", "user.email=tests@lithe.local", "-c", "user.name=Lithe Tests",
+                        "-c", "core.autocrlf=false"] + arguments,
             currentDirectoryURL: directory
         )
         guard result.terminationStatus == 0 else {
@@ -496,37 +487,18 @@ private enum GitObservationTestError: Error {
 
 private struct GitObservationWatchContextProvider: GitWatchContextProviding {
     func watchContext(for workspace: URL) async -> GitWatchContext? {
-        guard let repositoryRoot = await Self.resolvePath(
-            at: workspace,
-            arguments: ["rev-parse", "--show-toplevel"]
-        ),
-        let gitDirectory = await Self.resolvePath(
-            at: workspace,
-            arguments: ["rev-parse", "--absolute-git-dir"]
-        ),
-        let gitCommonDirectory = await Self.resolvePath(
-            at: workspace,
-            arguments: ["rev-parse", "--path-format=absolute", "--git-common-dir"]
-        ) else { return nil }
-        return GitWatchContext(
-            repositoryRoot: repositoryRoot,
-            gitDirectory: gitDirectory,
-            gitCommonDirectory: gitCommonDirectory
-        )
-    }
-
-    private static func resolvePath(at workspace: URL, arguments: [String]) async -> URL? {
+        // Resolve all three paths from one Git process; each output line corresponds to an option.
         guard let result = try? await TestProcess.run(
             executableURL: URL(fileURLWithPath: "/usr/bin/git"),
-            arguments: arguments,
+            arguments: ["rev-parse", "--path-format=absolute", "--show-toplevel",
+                        "--absolute-git-dir", "--git-common-dir"],
             currentDirectoryURL: workspace
         ), result.terminationStatus == 0 else { return nil }
-        let path = String(
-            decoding: result.output,
-            as: UTF8.self
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !path.isEmpty else { return nil }
-        return URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath()
+        let paths = String(decoding: result.output, as: UTF8.self)
+            .split(separator: "\n").map(String.init)
+        guard paths.count == 3 else { return nil }
+        let urls = paths.map { URL(fileURLWithPath: $0).standardizedFileURL.resolvingSymlinksInPath() }
+        return GitWatchContext(repositoryRoot: urls[0], gitDirectory: urls[1], gitCommonDirectory: urls[2])
     }
 }
 
@@ -574,6 +546,8 @@ private func startObservation(
     at workspace: URL,
     recorder: GitObservationRecorder
 ) async throws {
+    let marker = workspace.appendingPathComponent("watcher-ready.txt").standardizedFileURL
+    try Data("preparing\n".utf8).write(to: marker)
     model.beginWorkspace(at: workspace, visibilityRules: .default)
     let result = await model.rebuild(
         at: workspace,
@@ -583,7 +557,15 @@ private func startObservation(
     guard case .loaded = result else {
         throw GitObservationTestError.workspaceUnavailable
     }
-    try await Task.sleep(for: .milliseconds(750))
+    // FSEvents can deliver setup writes after stream installation. Wait for a
+    // later marker to traverse the real watcher and refresh pipeline before
+    // measuring the operation, instead of guessing when setup events settle.
+    let initialRefreshCount = recorder.gitRefreshCount
+    try Data("ready\n".utf8).write(to: marker)
+    try #require(await waitUntil {
+        recorder.externalChangeBatches.flatMap { $0 }.contains(marker)
+            && recorder.gitRefreshCount > initialRefreshCount
+    }, "The watcher did not process its readiness marker")
     recorder.reset()
 }
 

--- a/macos/Tests/LitheTests/RunEntryPointTests.swift
+++ b/macos/Tests/LitheTests/RunEntryPointTests.swift
@@ -411,7 +411,8 @@ struct RunEntryPointTests {
         let configurationB = ReadyRunConfigurationOperations.serviceEntryPoint
 
         model.openProjectDirectly(workspaceA.root)
-        model.startRunConfiguration(configurationA)
+        let earlierStart = Task { await model.performStartRunConfiguration(configurationA) }
+        defer { earlierStart.cancel() }
         #expect(await runConfigurations.inspectionEntered(1))
 
         model.openProjectDirectly(workspaceB.root)
@@ -430,13 +431,7 @@ struct RunEntryPointTests {
         // A's in-flight ensure finishes after the switch. It must be treated as
         // stale: no re-defer against B, and B's pending must survive.
         runConfigurations.release(1)
-        let corruptedByStaleA = await awaitChange(on: model, timeout: .seconds(1)) {
-            model.pendingRunAction?.kind == .startConfiguration(configurationA)
-        }
-        #expect(
-            !corruptedByStaleA,
-            "a stale entry task for A must not re-defer its configuration onto B"
-        )
+        #expect(await waitForRunEntryCompletion(earlierStart), "the stale entry task must finish")
         #expect(
             model.pendingRunAction?.kind == .startConfiguration(configurationB)
                 && model.pendingRunAction?.identity.url == workspaceB.root.standardizedFileURL,
@@ -472,7 +467,8 @@ struct RunEntryPointTests {
         let earlierConfiguration = ReadyRunConfigurationOperations.entryPoint
 
         model.openProjectDirectly(workspace.root)
-        model.startRunConfiguration(earlierConfiguration)
+        let earlierStart = Task { await model.performStartRunConfiguration(earlierConfiguration) }
+        defer { earlierStart.cancel() }
         #expect(
             await runConfigurations.inspectionEntered(1),
             "the direct start never began its own load"
@@ -498,26 +494,18 @@ struct RunEntryPointTests {
         // The earlier opening's task finishes last. Its captured URL still
         // matches, so only the generation can reject it.
         runConfigurations.release(1)
-        #expect(
-            await runConfigurations.launchPlanNotRequested(within: .seconds(1)),
-            "a task from the previous opening must not launch into the current one"
-        )
+        #expect(await waitForRunEntryCompletion(earlierStart), "the earlier opening's entry task must finish")
+        #expect(runConfigurations.launchPlanCallCount == 0,
+                "a task from the previous opening must not launch into the current one")
         #expect(
             model.pendingRunAction == nil,
             "a discarded task must not record a pending action either"
         )
-        // The discarded task completes on the run service's utility queue. Wait
-        // for its final publication before asserting the current inventory so a
-        // slow CI worker cannot observe the brief transition while that task is
-        // unwinding after its generation check.
-        let currentInventorySurvived = await awaitChange(on: model, timeout: .seconds(1)) {
+        #expect(
             model.runFeatureIfActive?.isProjectReady(
                 for: workspace.root,
                 snapshotID: currentSnapshotID
-            ) == true
-        }
-        #expect(
-            currentInventorySurvived,
+            ) == true,
             "the current opening's inventory must survive the discarded task"
         )
     }
@@ -866,12 +854,6 @@ private final class InspectionGatedRunConfigurationOperations: RunConfigurationO
         await launchPlanRequests[ordinal - 1].waitUntilOpen(timeout: .seconds(30))
     }
 
-    /// Asserting that no launch happens needs a short deadline: the whole wait is
-    /// paid on the passing path, so it must not carry a load-sized one.
-    func launchPlanNotRequested(within duration: Duration) async -> Bool {
-        await !launchPlanRequests[0].waitUntilOpen(timeout: duration)
-    }
-
     var resolveCallCount: Int {
         lock.lock()
         defer { lock.unlock() }
@@ -1072,4 +1054,15 @@ private final class RunEntryPointTestStore: KeyValueStore, @unchecked Sendable {
     func string(forKey key: String) -> String? { values[key] as? String }
     func stringArray(forKey key: String) -> [String]? { values[key] as? [String] }
     func set(_ value: Any?, forKey key: String) { values[key] = value }
+}
+
+@MainActor
+private func waitForRunEntryCompletion(_ task: Task<Void, Never>) async -> Bool {
+    let completed = TestGate()
+    let observer = Task {
+        await task.value
+        completed.open()
+    }
+    defer { observer.cancel() }
+    return await completed.waitUntilOpen(timeout: .seconds(5))
 }


### PR DESCRIPTION
点击 macOS Git「丢弃更改」并确认后，确认框的关闭回调可能先清空待处理状态，异步任务随后读取空值并直接返回。本次改为在按钮回调中同步捕获已确认的文件或差异块，通过 AppModel 显式传入 Git 功能模型，确保丢弃操作执行并保留成功刷新和失败提示。

关联 #387。

- 新增受跟踪文件、未跟踪文件和差异块失败提示回归测试，明确模拟确认框先清空状态、异步操作后执行的顺序。
- 根据测试报告优化 Git 监听测试：合并三次仓库路径查询，使用命令级配置减少初始化子进程，并以真实文件事件就绪标记替代启动后的固定 750 毫秒等待。保留真实 Git 仓库、worktree、submodule 和 FSEvents 覆盖。
- 将运行配置入口的异步工作流提取为可等待操作，保留原有 UI 调用接口。工作区切换回归测试等待旧任务完成后断言，不再等待固定 1 秒判断是否发生错误。

同一机器、同一 preview 基线的全量计时对比（单次测量，存在正常波动）：

| 测试场景 | 优化前 | 优化后 |
| --- | ---: | ---: |
| 外部提交触发 Git 刷新 | 2.383 秒 | 2.166 秒 |
| 直接打开子模块后暂存 | 1.797 秒 | 1.246 秒 |
| 独立 Git 目录暂存 | 1.559 秒 | 1.138 秒 |
| 打开子目录后修改仓库其他文件 | 1.573 秒 | 1.096 秒 |
| 切换到其他工作区后旧启动任务结束 | 1.088 秒 | 0.073 秒 |
| 重新打开同一路径后旧启动任务结束 | 1.134 秒 | 0.067 秒 |

验证：

- `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh`：1,119 个测试、125 个测试套件全部通过；新增丢弃回归测试各约 1 毫秒。
- `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh -- --filter 'GitStatusObservationTests|RunEntryPointTests'`：25 个定向测试通过，另外重复运行一次也通过。
- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`、`./scripts/verify-service-boundaries.sh`、`git diff --check` 均通过。
- 已生成并检查 HTML / JUnit 逐项报告。原生测试在可访问剪贴板、FSEvents 等系统服务的环境中执行。

1 秒告警阈值没有调整。部分真实文件监听测试仍超过告警线；外部提交测试保留事件合并观察窗口，不以删除断言来消除告警。本 PR 分为修复与测试优化两个提交，方便分别审阅。
