### PR TITLE
ci: 自动上传可下载的 macOS 和 Windows 测试包

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -232,7 +232,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.macos_release == 'true'
     runs-on: macos-14
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     steps:
       - name: Check out source
@@ -253,6 +253,7 @@ jobs:
         with:
           swiftpm: "true"
           cargo: "true"
+          jdtls: "true"
 
       - name: Check packaging scripts and metadata
         shell: zsh {0}
@@ -267,6 +268,56 @@ jobs:
           ruby -c scripts/test-macos-update-manifest.rb
           ruby scripts/test-macos-update-manifest.rb
           plutil -lint macos/Resources/Info.plist
+
+      # The packaging smoke test below uses fake Java runtimes. Build the
+      # downloadable app separately with real resources, reusing compilation.
+      - name: Package downloadable macOS app
+        shell: zsh {0}
+        env:
+          LITHE_ARCH: universal
+          LITHE_CODESIGN_IDENTITY: "-"
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          ./scripts/package-app.sh
+          codesign --verify --deep --strict dist/Lithe.app
+          lipo dist/Lithe.app/Contents/MacOS/Lithe -verify_arch arm64 x86_64
+          artifact_directory="$GITHUB_WORKSPACE/.artifacts/ci-builds/macos"
+          mkdir -p "$artifact_directory"
+          # Archive first so artifact upload preserves app permissions and links.
+          ditto -c -k --sequesterRsrc --keepParent \
+            dist/Lithe.app "$artifact_directory/Lithe-macos-universal.zip"
+          {
+            echo "Lithe macOS universal CI test build (arm64 + x86_64)"
+            echo "Built commit: $(git rev-parse HEAD)"
+            echo "PR head commit: ${PR_HEAD_SHA:-not a pull request}"
+            echo "Workflow: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "Extract Lithe-macos-universal.zip to get Lithe.app."
+            echo "This app is ad-hoc signed, not notarized, and uses normal Lithe user data."
+            echo "Artifact availability does not mean all CI tests passed; check the workflow results."
+          } > "$artifact_directory/BUILD-INFO.txt"
+
+      - name: Upload macOS test build
+        id: app-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lithe-macos-universal-${{ github.sha }}
+          path: .artifacts/ci-builds/macos/
+          include-hidden-files: true
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+      - name: Link macOS test build
+        env:
+          ARTIFACT_URL: ${{ steps.app-artifact.outputs.artifact-url }}
+        run: |
+          {
+            echo "### Download macOS test build"
+            echo "[Lithe for Apple Silicon and Intel Macs]($ARTIFACT_URL)"
+            echo "Built commit: \`$GITHUB_SHA\`. Ad-hoc signed; not notarized."
+            echo "See BUILD-INFO.txt in the artifact for launch instructions and source identity."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build and verify default universal package
         env:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -306,7 +306,7 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
           compression-level: 0
-          retention-days: 14
+          retention-days: 3
 
       - name: Link macOS test build
         env:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -269,7 +269,7 @@ jobs:
           # The staged runtime tree includes Java resource identity files.
           include-hidden-files: true
           if-no-files-found: error
-          retention-days: 14
+          retention-days: 3
 
       - name: Link Windows test build
         if: needs.changes.outputs.windows == 'true'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -223,6 +223,68 @@ jobs:
         shell: pwsh
         run: ./scripts/build-windows.ps1 -Configuration Release
 
+      - name: Stage downloadable Windows app
+        if: needs.changes.outputs.windows == 'true'
+        shell: pwsh
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          $runtimeRoot = Join-Path $env:GITHUB_WORKSPACE 'windows/tauri/src-tauri/target/x86_64-pc-windows-msvc/release'
+          $artifact = Join-Path $env:GITHUB_WORKSPACE '.artifacts/ci-builds/windows'
+          New-Item -ItemType Directory -Force -Path $artifact | Out-Null
+          # Upload runtime files only, never Cargo caches, debug symbols, or test binaries.
+          foreach ($relativePath in @('lithe-windows.exe', 'extensions', 'LanguageServers')) {
+            $source = Join-Path $runtimeRoot $relativePath
+            if (-not (Test-Path -LiteralPath $source)) {
+              throw "Windows test build is missing: $relativePath"
+            }
+            Copy-Item -LiteralPath $source -Destination $artifact -Recurse -Force
+          }
+          Get-ChildItem -LiteralPath $runtimeRoot -Filter '*.dll' -File | ForEach-Object {
+            Copy-Item -LiteralPath $_.FullName -Destination $artifact -Force
+          }
+          $revision = git rev-parse HEAD
+          if ($LASTEXITCODE -ne 0) { throw 'Could not resolve the built commit.' }
+          $prHead = if ($env:PR_HEAD_SHA) { $env:PR_HEAD_SHA } else { 'not a pull request' }
+          @(
+            'Lithe Windows x64 CI test build',
+            "Built commit: $revision",
+            "PR head commit: $prHead",
+            "Workflow: $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID",
+            'Extract the entire artifact to a local folder, then run lithe-windows.exe.',
+            'Keep extensions, LanguageServers, and DLLs beside the executable.',
+            'Requires the Microsoft Edge WebView2 Runtime. No IDE or build toolchain is needed.',
+            'Windows 11 ARM supports x64 emulation; this is not a native ARM64 build.',
+            'This unsigned test build uses normal Lithe user data.',
+            'Artifact availability does not mean all CI tests passed; check the workflow results.'
+          ) | Set-Content -LiteralPath (Join-Path $artifact 'BUILD-INFO.txt') -Encoding utf8
+
+      - name: Upload Windows test build
+        id: app-artifact
+        if: needs.changes.outputs.windows == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: lithe-windows-x64-${{ github.sha }}
+          path: .artifacts/ci-builds/windows/
+          # The staged runtime tree includes Java resource identity files.
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Link Windows test build
+        if: needs.changes.outputs.windows == 'true'
+        shell: pwsh
+        env:
+          ARTIFACT_URL: ${{ steps.app-artifact.outputs.artifact-url }}
+        run: |
+          @(
+            '### Download Windows test build',
+            "[Lithe for Windows x64]($env:ARTIFACT_URL)",
+            "Built commit: $env:GITHUB_SHA. Extract the whole ZIP and run lithe-windows.exe.",
+            'Windows 11 ARM can run this x64 build through emulation.',
+            'See BUILD-INFO.txt in the artifact for requirements and source identity.'
+          ) | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+
       - name: Verify Windows boundaries
         if: needs.changes.outputs.windows == 'true'
         shell: pwsh

--- a/docs/ci-test-builds.md
+++ b/docs/ci-test-builds.md
@@ -1,0 +1,39 @@
+# Downloading CI test builds
+
+The macOS CI and Windows CI workflows upload runnable test builds when their
+respective application build lanes are selected. Builds are retained for 14
+days. Documentation-only or test-only changes may skip application packaging;
+use `workflow_dispatch` on the desired branch to run all lanes of that workflow.
+
+1. Open the PR's **Checks**, then the **macOS CI** or **Windows CI** workflow run.
+2. Download the application from the job summary link or the run's **Artifacts**
+   section. GitHub requires you to sign in to download artifacts.
+3. Match `BUILD-INFO.txt` to the revision you want to test. Artifact names contain
+   the built commit SHA. For PR runs this is normally GitHub's test merge commit;
+   the PR head commit is recorded separately.
+
+| Artifact | Contents | Launch |
+| --- | --- | --- |
+| `lithe-macos-universal-<sha>` | An archived `Lithe.app` for Apple Silicon and Intel, with real bundled Java runtimes, language server, and official plugins | Extract the downloaded artifact, then extract `Lithe-macos-universal.zip` and open `Lithe.app` |
+| `lithe-windows-x64-<sha>` | `lithe-windows.exe`, adjacent runtime DLLs, bundled extensions, JDK, and language server | Extract the whole artifact to a local Windows folder and run `lithe-windows.exe` |
+
+Windows test builds require the Microsoft Edge WebView2 Runtime. You do not need
+to clone the repository or install an IDE, Bun, Rust, or a compiler in the VM.
+Keep the Windows resource directories beside the executable; copying only the
+EXE leaves the app without its bundled resources.
+
+Windows 11 on ARM supports x64 application emulation, so the x64 artifact can be
+used for compatibility testing on an ARM VM. This is not a native ARM64 build,
+and it does not establish that every Lithe feature works under emulation. See
+[Microsoft's emulation documentation](https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation).
+
+These are development builds: macOS apps are ad-hoc signed and not notarized,
+and Windows executables are unsigned. OS trust checks can differ from signed
+release installs. Test builds use the same application identity and user data
+as ordinary Lithe builds; they are not isolated profiles.
+
+Application artifacts are uploaded before subsequent tests, so a build may be
+available even if a later check fails. Always review the workflow results as
+well as the artifact. A failed application build does not upload a partial
+package. The macOS fixture package used by the packaging smoke test is never
+uploaded as a runnable test build.

--- a/docs/ci-test-builds.md
+++ b/docs/ci-test-builds.md
@@ -1,7 +1,7 @@
 # Downloading CI test builds
 
 The macOS CI and Windows CI workflows upload runnable test builds when their
-respective application build lanes are selected. Builds are retained for 14
+respective application build lanes are selected. Builds are retained for 3
 days. Documentation-only or test-only changes may skip application packaging;
 use `workflow_dispatch` on the desired branch to run all lanes of that workflow.
 


### PR DESCRIPTION
macOS 和 Windows CI 当前只提供测试报告，构建成功后无法下载应用，导致在内存有限的 Windows 虚拟机中验证 PR 时还需要安装工具链并重新编译。本 PR 在应用构建成功后自动上传完整测试包，并在工作流摘要中提供下载链接，保留 3 天。

- macOS 提供包含真实 JDK、语言服务器和官方插件的 universal 应用归档，覆盖 Apple Silicon 和 Intel；使用 `ditto` 保留应用权限与链接。现有打包 smoke test 的 Java 夹具包继续只用于测试。
- Windows 复用已构建的 x64 EXE，附带运行时 DLL、扩展和 Java 工具，排除 Cargo 缓存、调试符号和测试程序。解压整个包即可运行，需要 WebView2 Runtime。
- 两端附带 `BUILD-INFO.txt`，记录实际构建提交、PR head 和 workflow 链接。上传发生在后续测试前，测试失败时仍可下载成功构建的应用用于排查。
- 新增 `docs/ci-test-builds.md`，说明下载入口、版本核对、资源要求及测试包与正式版本共用用户数据的行为。

Windows 11 ARM 支持 x64 模拟，因此本次保留现有 x64 构建，不新增 ARM64 CI lane；Lithe 各功能在 ARM VM 中的兼容性仍需实测。参考：https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation

验证：`actionlint`（两份工作流）、新增 zsh 步骤语法检查、测试稳定性静态检查（`--platform all`）、Windows 架构边界检查和 `git diff --check` 均通过。两端完整构建与 artifact 上传由本 PR 的 GitHub Actions 实际验证；本地没有把这些未执行的检查计为通过。

测试包不作为正式发布：macOS 使用 ad-hoc 签名且未公证，Windows EXE 未签名。macOS 构建 job 的上限从 40 分钟调整为 60 分钟，为真实运行资源准备和归档留出空间。
