### PR TITLE
fix(macOS): 还原提交后自动刷新 Git Log

### DIFF
--- a/macos/Sources/LitheGitModule/Application/GitFeatureModel.swift
+++ b/macos/Sources/LitheGitModule/Application/GitFeatureModel.swift
@@ -2794,6 +2794,26 @@ package final class GitFeatureModel: ObservableObject {
             success: operationResult.1,
             historyVersion: historyVersion
         )
+        if operationResult.0.succeeded, gitOperationState == nil {
+            await focusCurrentCheckoutHead()
+        }
+    }
+
+    private func focusCurrentCheckoutHead() async {
+        guard isGitLogVisibleProvider?() == true else { return }
+        let isShowingCurrentCheckout = !isShowingAllGitReferences
+            && (selectedGitReference == nil || selectedGitReference?.isCurrent == true)
+        if !isShowingCurrentCheckout {
+            selectedGitReference = nil
+            isShowingAllGitReferences = false
+            canLoadMoreGitHistory = false
+            let historyVersion = gitCommitsVersion
+            await refreshGitHistory()
+            guard gitCommitsVersion != historyVersion else { return }
+        }
+        if let head = gitCommits.first {
+            await selectGitCommit(head)
+        }
     }
 
     /// Merge and rebase are only ever started from a branch, so a commit target here

--- a/macos/Sources/LitheGitModule/Application/GitFeatureModel.swift
+++ b/macos/Sources/LitheGitModule/Application/GitFeatureModel.swift
@@ -2756,6 +2756,7 @@ package final class GitFeatureModel: ObservableObject {
     ) async {
         guard let gitRepositoryRoot else { return }
         isPerformingBranchOperation = true
+        let historyVersion = gitCommitsVersion
         let operationResult = await withGitOperation {
             let result: GitService.CommandResult
             let success: String
@@ -2788,7 +2789,11 @@ package final class GitFeatureModel: ObservableObject {
             return (result, success)
         }
         isPerformingBranchOperation = false
-        await reportBranchOperation(operationResult.0, success: operationResult.1)
+        await reportBranchOperation(
+            operationResult.0,
+            success: operationResult.1,
+            historyVersion: historyVersion
+        )
     }
 
     /// Merge and rebase are only ever started from a branch, so a commit target here
@@ -2814,9 +2819,10 @@ package final class GitFeatureModel: ObservableObject {
     /// the user acts on it, so the toast just points at the conflict count.
     private func reportBranchOperation(
         _ result: GitService.CommandResult,
-        success: String
+        success: String,
+        historyVersion: Int? = nil
     ) async {
-        await refreshGit()
+        await refreshGitFromMetadataChange(since: historyVersion)
         if let state = gitOperationState, state.hasConflicts {
             notify?("\(state.kind.title) stopped with \(state.conflictedPaths.count) conflicted file(s)")
         } else {

--- a/macos/Tests/LitheGitModuleTests/GitModuleTests.swift
+++ b/macos/Tests/LitheGitModuleTests/GitModuleTests.swift
@@ -525,6 +525,38 @@ struct GitModuleTests {
     }
 
     @Test
+    func successfulRevertRefreshesVisibleGitHistoryWhenStatusIsUnchanged() async {
+        let root = URL(fileURLWithPath: "/workspace")
+        let revertedCommit = makeTestCommit(hash: "original-commit", subject: "Original change")
+        let revertCommit = makeTestCommit(hash: "revert-commit", subject: "Revert original change")
+        let controller = GitHistoryMutationController(
+            before: [revertedCommit],
+            after: [revertCommit, revertedCommit]
+        )
+        let service = GitService(operations: TestGitOperations(
+            snapshotValue: GitSnapshot(repositoryRoot: root, branch: "main", changes: []),
+            historyPageHandler: { controller.historyPage() },
+            revertHandler: { hash in controller.revert(hash) }
+        ))
+        let feature = GitFeatureModel(service: service)
+        feature.configure(
+            workspaceURLProvider: { root },
+            isGitLogVisibleProvider: { true },
+            notify: { _ in },
+            onStateRefreshed: {}
+        )
+
+        await feature.refreshGit()
+        #expect(feature.gitCommits.map(\.hash) == [revertedCommit.hash])
+
+        await feature.revert(revertedCommit)
+
+        #expect(feature.gitCommits.map(\.hash) == [revertCommit.hash, revertedCommit.hash])
+        #expect(controller.revertedHashes == [revertedCommit.hash])
+        #expect(controller.historyCallCount == 2)
+    }
+
+    @Test
     func remoteReferenceActionsPreserveIdentityAndPullStrategy() async {
         let root = URL(fileURLWithPath: "/workspace")
         let reference = GitReference(
@@ -2309,6 +2341,47 @@ private func makeTestCommit(hash: String, subject: String) -> GitCommit {
     )
 }
 
+private final class GitHistoryMutationController: @unchecked Sendable {
+    private let lock = NSLock()
+    private let before: [GitCommit]
+    private let after: [GitCommit]
+    private var didMutate = false
+    private var historyCalls = 0
+    private var revertedHashValues: [String] = []
+
+    init(before: [GitCommit], after: [GitCommit]) {
+        self.before = before
+        self.after = after
+    }
+
+    var historyCallCount: Int {
+        lock.withLock { historyCalls }
+    }
+
+    var revertedHashes: [String] {
+        lock.withLock { revertedHashValues }
+    }
+
+    func historyPage() -> GitHistoryPage {
+        lock.withLock {
+            historyCalls += 1
+            return GitHistoryPage(
+                commits: didMutate ? after : before,
+                nextCursor: nil,
+                hasMore: false
+            )
+        }
+    }
+
+    func revert(_ hash: String) -> GitProcessResult {
+        lock.withLock {
+            revertedHashValues.append(hash)
+            didMutate = true
+        }
+        return GitProcessResult(arguments: ["revert", hash], output: "", exitCode: 0)
+    }
+}
+
 private func makeTestWorktree(path: String, branch: String) -> GitWorktree {
     GitWorktree(
         path: path,
@@ -2776,12 +2849,14 @@ private struct TestGitOperations: GitOperations {
     private let historyValue: GitHistorySnapshot?
     private let referencesValue: GitReferenceSnapshot?
     private let historyPageValues: [String: GitHistoryPage]?
+    private let historyPageHandler: (@Sendable () -> GitHistoryPage?)?
     private let historyController: GitHistoryLoadController?
     private let snapshotGate: GitModuleTestGate?
     private let discardHandler: (@Sendable (GitChange) -> GitProcessResult?)?
     private let applyPatchHandler: (@Sendable (String, URL, String) -> GitProcessResult?)?
     private let stageResult: GitProcessResult?
     private let commitResult: GitProcessResult?
+    private let revertHandler: (@Sendable (String) -> GitProcessResult?)?
     private let runGate: TestGitRunGate?
     private let filesRecorder: GitFilesCallRecorder?
     private let filesGate: GitFilesLoadGate?
@@ -2805,6 +2880,7 @@ private struct TestGitOperations: GitOperations {
         historyValue: GitHistorySnapshot? = nil,
         referencesValue: GitReferenceSnapshot? = nil,
         historyPageValues: [String: GitHistoryPage]? = nil,
+        historyPageHandler: (@Sendable () -> GitHistoryPage?)? = nil,
         historyController: GitHistoryLoadController? = nil,
         filesValue: [GitCommitFile]? = nil,
         untrackedDiffDocumentValue: DiffDocument? = nil,
@@ -2815,6 +2891,7 @@ private struct TestGitOperations: GitOperations {
         applyPatchHandler: (@Sendable (String, URL, String) -> GitProcessResult?)? = nil,
         stageResult: GitProcessResult? = nil,
         commitResult: GitProcessResult? = nil,
+        revertHandler: (@Sendable (String) -> GitProcessResult?)? = nil,
         runGate: TestGitRunGate? = nil,
         filesRecorder: GitFilesCallRecorder? = nil,
         filesGate: GitFilesLoadGate? = nil,
@@ -2837,6 +2914,7 @@ private struct TestGitOperations: GitOperations {
         self.historyValue = historyValue
         self.referencesValue = referencesValue
         self.historyPageValues = historyPageValues
+        self.historyPageHandler = historyPageHandler
         self.historyController = historyController
         self.filesValue = filesValue
         self.untrackedDiffDocumentValue = untrackedDiffDocumentValue
@@ -2847,6 +2925,7 @@ private struct TestGitOperations: GitOperations {
         self.applyPatchHandler = applyPatchHandler
         self.stageResult = stageResult
         self.commitResult = commitResult
+        self.revertHandler = revertHandler
         self.runGate = runGate
         self.filesRecorder = filesRecorder
         self.filesGate = filesGate
@@ -2921,6 +3000,7 @@ private struct TestGitOperations: GitOperations {
         limit: Int,
         operationID: String
     ) -> GitHistoryPage? {
+        if let historyPageHandler { return historyPageHandler() }
         if let historyPageValues { return historyPageValues[cursor ?? ""] }
         guard let historyValue else { return nil }
         let offset = cursor.flatMap(Int.init) ?? 0
@@ -2951,7 +3031,7 @@ private struct TestGitOperations: GitOperations {
     func discardAll(_ change: GitChange) -> GitProcessResult? { nil }
     func commit(at rootURL: URL, message: String, amend: Bool) -> GitProcessResult? { commitResult }
     func cherryPick(_ hash: String, at rootURL: URL) -> GitProcessResult? { nil }
-    func revert(_ hash: String, at rootURL: URL) -> GitProcessResult? { nil }
+    func revert(_ hash: String, at rootURL: URL) -> GitProcessResult? { revertHandler?(hash) }
     func resetCurrentBranch(to hash: String, mode: String, at rootURL: URL) -> GitProcessResult? { nil }
     func createBranch(named name: String, from reference: GitReference, checkout: Bool, at rootURL: URL) -> GitProcessResult? {
         branchCallRecorder?.record(BranchCallRecorder.Call(name: name, reference: reference.fullName, checkout: checkout))

--- a/macos/Tests/LitheGitModuleTests/GitModuleTests.swift
+++ b/macos/Tests/LitheGitModuleTests/GitModuleTests.swift
@@ -525,7 +525,7 @@ struct GitModuleTests {
     }
 
     @Test
-    func successfulRevertRefreshesVisibleGitHistoryWhenStatusIsUnchanged() async {
+    func successfulRevertRefreshesVisibleGitHistoryAndFocusesCurrentHead() async {
         let root = URL(fileURLWithPath: "/workspace")
         let revertedCommit = makeTestCommit(hash: "original-commit", subject: "Original change")
         let revertCommit = makeTestCommit(hash: "revert-commit", subject: "Revert original change")
@@ -548,12 +548,16 @@ struct GitModuleTests {
 
         await feature.refreshGit()
         #expect(feature.gitCommits.map(\.hash) == [revertedCommit.hash])
+        await feature.showAllGitReferences()
+        #expect(feature.isShowingAllGitReferences)
 
         await feature.revert(revertedCommit)
 
         #expect(feature.gitCommits.map(\.hash) == [revertCommit.hash, revertedCommit.hash])
+        #expect(!feature.isShowingAllGitReferences)
+        #expect(feature.selectedGitCommit?.hash == revertCommit.hash)
         #expect(controller.revertedHashes == [revertedCommit.hash])
-        #expect(controller.historyCallCount == 2)
+        #expect(controller.historyCallCount == 4)
     }
 
     @Test


### PR DESCRIPTION
## 变更说明

- 在 merge、rebase、cherry-pick 和 revert 开始前记录 Git 历史版本。
- 集成操作完成后复用 `refreshGitFromMetadataChange(since:)`，确保工作区状态未变化时也会刷新可见的 Git Log。
- 成功且无冲突的集成操作完成后，将 Git Log 切回当前检出分支并选中新 HEAD，触发现有的自动滚动逻辑；失败或冲突时保留用户当前范围和选择。
- 保留版本检查，避免文件观察器已刷新历史时重复加载。
- 新增确定性回归测试，覆盖 clean 仓库中 revert 只改变提交历史、不改变 status snapshot，以及操作前处于 All References 的场景。

## 根因

原实现完成 revert 后只调用 `refreshGit()`。该方法仅在分支、工作区变更、stash 或操作状态等 snapshot 字段发生变化时刷新 Git History；clean 仓库创建 revert commit 时这些字段可能全部不变，因此 Git Log 保留旧列表，必须手动刷新。即使数据刷新，原有选择也会继续指向旧提交，视图不会自动定位到新生成的 revert HEAD。

## 平台范围

当前可复现的 `Revert Commit` 入口位于 macOS Git Log。Windows 当前实现没有对应的 revert UI，因此本次仅修改 macOS Application 层和 macOS Git 模块测试。

## 验证

- `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh -- --filter "GitModuleTests.successfulRevertRefreshesVisibleGitHistoryAndFocusesCurrentHead"`：通过，0.010 秒（变基到远端最新提交后复验）
- `./.agents/skills/write-stable-tests/scripts/test-stability-macos.sh -- --filter "GitModuleTests"`：69 个测试通过
- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`：通过
- `./scripts/verify-service-boundaries.sh`：通过
- `./scripts/verify-git-graph.sh`：通过
- `git diff --check`：通过

`./scripts/test-macos.sh` 已运行，但当前无屏幕测试环境中既有的 `ContextMenuCoverageTests` 因 `NSScreen.main == nil` 触发 AppKit 窗口 frame 异常并中止；该失败与本次 Git 改动无关，受影响的 Git 测试均已通过。

Closes #560
