### PR TITLE
docs(release): prepare v0.4.5 and reusable release template

### DIFF
--- a/.agents/skills/release-lithe/SKILL.md
+++ b/.agents/skills/release-lithe/SKILL.md
@@ -45,14 +45,16 @@ two sections equivalent in meaning. Use these literal required headings and
 this order:
 
 1. `## 中文`, a short release summary, `### 下载`, and `### 重点更新`.
-2. Optional product-area groupings when they make the changes easier to scan.
+2. A brief overview sentence under `### 重点更新`, then `#### ✨ 新功能`,
+   `#### ⚡ 改进`, and `#### 🛠 修复`; omit categories with no changes.
 3. `### 升级说明` and `### 兼容性与已知问题`.
 4. A comparison link from the previous stable tag to the new tag.
 5. `## English`, a short release summary, `### Downloads`, and `### Highlights`.
-6. English counterparts for any optional product-area groupings.
+6. A matching overview under `### Highlights`, then `#### ✨ New features`,
+   `#### ⚡ Improvements`, and `#### 🛠 Fixes`; omit the same empty categories.
 7. `### Upgrade instructions` and `### Compatibility and known issues`.
 8. The equivalent English comparison link.
-9. At the very bottom, `### 贡献者` followed by `### Contributors`, with
+9. At the very bottom, `### 🙌 感谢贡献者` followed by `### 🙌 Contributors`, with
    equivalent contributor names or GitHub profile links in both languages.
 
 The download sections cover the project page, both macOS architectures,
@@ -84,9 +86,20 @@ apply to that version.
   `xattr -dr com.apple.quarantine /Applications/Lithe.app` in Terminal. Use
   this only for an app from a source you trust.”
 
-Use the most recent stable file under `docs/releases/` as the formatting
-reference, but verify every statement and URL for the new version instead of
-copying stale details.
+Use [the reusable release template](../../../docs/releases/TEMPLATE.md) as the
+formatting source of truth. Copy it to `docs/releases/v<version>.md`, replace
+all placeholders, and remove its authoring comment. Previous releases are only
+factual references; do not inherit their structure or stale claims.
+
+Keep change bullets as single Markdown source lines with no nested lists. Aim
+for roughly 40 Chinese characters or 20 English words when practical; this is
+a writing target, not a display-width guarantee. Put the platform first only
+when a change is platform-specific. Group by new capability, improvement, or
+fix, not by implementation layer. Credit verified contributors together at
+the bottom; optional per-item attribution must be verified and stay concise.
+Do not copy another project's features, identities, or compatibility claims.
+Run `node scripts/validate-stable-release-notes.mjs docs/releases/v<version>.md`
+before committing the notes.
 
 ## Contributors
 

--- a/docs/releases/TEMPLATE.md
+++ b/docs/releases/TEMPLATE.md
@@ -1,0 +1,103 @@
+<!--
+复用方式：复制为 v<version>.md，替换 {version}、{previous_version} 和正文占位符，再删除本注释。
+以“新功能 → 改进 → 修复”为固定分类顺序；删除没有内容的分类，中英文保持一致。
+每条只写一个用户可感知的变化、一个短句、一行 Markdown，不嵌套列表。
+建议中文约 40 字以内、英文约 20 词以内；按需写平台名，不承诺任何屏幕宽度下都不换行。
+不列内部类名、实现机制、测试数量或原始提交列表；贡献者在底部集中致谢。
+保留双语下载、升级、可信来源 Gatekeeper 提示和版本对比；链接与兼容性必须逐版核实。
+发布标题使用 Lithe v<version>，不要复制其他项目的名称、功能或贡献者。
+-->
+
+## 中文
+
+{一句话概括本次更新对用户的帮助。}
+
+### 下载
+
+- [项目主页](https://github.com/1lck/Lithe-IDEA)
+- [macOS Apple Silicon](https://github.com/1lck/Lithe-IDEA/releases/download/v{version}/Lithe-{version}-arm64.dmg)
+- [macOS Intel](https://github.com/1lck/Lithe-IDEA/releases/download/v{version}/Lithe-{version}-x86_64.dmg)
+- [Windows x64](https://github.com/1lck/Lithe-IDEA/releases/download/v{version}/Lithe-{version}-windows-x64.exe)
+- [全部下载文件](https://github.com/1lck/Lithe-IDEA/releases/tag/v{version})
+
+### 重点更新
+
+本次更新内容如下。
+
+#### ✨ 新功能
+
+- {一句短句描述用户可感知的变化。}
+
+#### ⚡ 改进
+
+- {一句短句描述用户可感知的变化。}
+
+#### 🛠 修复
+
+- {一句短句描述用户可感知的变化。}
+
+### 升级说明
+
+- macOS：打开对应架构的 DMG，将 Lithe.app 拖入“应用程序”。
+- Homebrew：新版配方更新后，运行 `brew update && brew upgrade --cask lithe`。
+- Windows：下载并运行 x64 安装包。
+
+### 兼容性与已知问题
+
+- {核实并填写本版系统要求、签名状态和已知限制。}
+
+如果 macOS 提示无法打开 Lithe.app，请在“应用程序”中按住 Control 点按应用并选择“打开”；如果仍被阻止，可在终端执行 `xattr -dr com.apple.quarantine /Applications/Lithe.app`。仅对可信来源的应用使用。
+
+[查看完整变更](https://github.com/1lck/Lithe-IDEA/compare/v{previous_version}...v{version})
+
+---
+
+## English
+
+{Short user-facing release summary.}
+
+### Downloads
+
+- [Project homepage](https://github.com/1lck/Lithe-IDEA)
+- [macOS Apple Silicon](https://github.com/1lck/Lithe-IDEA/releases/download/v{version}/Lithe-{version}-arm64.dmg)
+- [macOS Intel](https://github.com/1lck/Lithe-IDEA/releases/download/v{version}/Lithe-{version}-x86_64.dmg)
+- [Windows x64](https://github.com/1lck/Lithe-IDEA/releases/download/v{version}/Lithe-{version}-windows-x64.exe)
+- [All downloads](https://github.com/1lck/Lithe-IDEA/releases/tag/v{version})
+
+### Highlights
+
+Changes are grouped below.
+
+#### ✨ New features
+
+- {One short sentence describing a user-visible change.}
+
+#### ⚡ Improvements
+
+- {One short sentence describing a user-visible change.}
+
+#### 🛠 Fixes
+
+- {One short sentence describing a user-visible change.}
+
+### Upgrade instructions
+
+- macOS: open the DMG for your architecture and drag Lithe.app to Applications.
+- Homebrew: run `brew update && brew upgrade --cask lithe` after the cask update is available.
+- Windows: download and run the x64 installer.
+
+### Compatibility and known issues
+
+- {Verify system requirements, signing status, and known limitations for this version.}
+
+If macOS says it cannot open Lithe.app, Control-click it in Applications and choose Open. If it is still blocked, run `xattr -dr com.apple.quarantine /Applications/Lithe.app` in Terminal. Use this only for an app from a source you trust.
+
+[Full changelog](https://github.com/1lck/Lithe-IDEA/compare/v{previous_version}...v{version})
+
+### 🙌 感谢贡献者
+
+{Verified GitHub contributor links.}
+
+### 🙌 Contributors
+
+{Verified GitHub contributor links.}

--- a/docs/releases/v0.4.5.md
+++ b/docs/releases/v0.4.5.md
@@ -1,0 +1,133 @@
+## 中文
+
+本次更新带来 Git 历史整理、SVG 编辑，以及 Maven 项目体验改进。
+
+### 下载
+
+- [项目主页](https://github.com/1lck/Lithe-IDEA)
+- [macOS Apple Silicon](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.5/Lithe-0.4.5-arm64.dmg)
+- [macOS Intel](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.5/Lithe-0.4.5-x86_64.dmg)
+- [Windows x64](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.5/Lithe-0.4.5-windows-x64.exe)
+- [全部下载文件](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.5)
+
+### 重点更新
+
+本次更新内容如下。
+
+#### ✨ 新功能
+
+- 支持编辑 SVG 图片源码，并实时查看预览。
+- Windows Markdown 支持编辑、分栏和预览切换，并同步滚动。
+- 支持撤销提交、修改提交说明、合并或移除提交，整理 Git 历史。
+- 支持创建和管理 Git 工作树，同时处理多个分支。
+- 支持导入和导出 Git 补丁，方便分享代码改动。
+- 支持初始化 Git 仓库，并在设置中配置提交姓名和邮箱。
+- Windows 支持运行 Maven JUnit 测试，并查看结果和失败位置。
+- macOS 支持为项目和子项目分别设置 JDK 与 Maven。
+- Windows 终端新增右键复制和粘贴菜单。
+
+#### ⚡ 改进
+
+- 修改 Maven 项目配置后，可按提示重新加载并同步 Java 项目。
+- 更新提示不再打断操作，可选择稍后提醒或跳过版本。
+- macOS 更新支持差分下载，后续有匹配版本时可减少下载量。
+- Windows 切换文件标签更流畅，减少重复加载和重新上色。
+- Windows Git 单文件暂存和取消暂存响应更及时。
+- macOS Maven 依赖树补全中英文界面文案。
+- PowerShell 文件使用更易辨认的 Windows 风格图标。
+
+#### 🛠 修复
+
+- 修复大型 Maven 项目导入较慢时，误报 Java 服务启动失败的问题。
+- 修复 Windows Git 查询暂时返回空结果时，变更列表意外清空的问题。
+- 修复 Windows 点击新建终端按钮无响应的问题。
+- 修复 macOS 终端输入焦点异常，光标仅显示在当前焦点面板。
+- 修复 macOS Git 丢弃更改操作异常的问题。
+- 修复 macOS 还原提交后，Git 日志未自动刷新的问题。
+
+### 升级说明
+
+- macOS：打开对应架构的 DMG，将 Lithe.app 拖入“应用程序”。
+- Homebrew：新版配方更新后，运行 `brew update && brew upgrade --cask lithe`。
+- Windows：下载并运行 x64 安装包。
+
+### 兼容性与已知问题
+
+- macOS 需要 13 或更高版本；Windows 安装包未配置发布者证书，系统可能显示提示。
+- macOS 首次升级到新版更新器仍需完整下载，后续有匹配版本时才使用差分下载。
+
+如果 macOS 提示无法打开 Lithe.app，请在“应用程序”中按住 Control 点按应用并选择“打开”；如果仍被阻止，可在终端执行 `xattr -dr com.apple.quarantine /Applications/Lithe.app`。仅对可信来源的应用使用。
+
+[查看完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.4.4...v0.4.5)
+
+---
+
+## English
+
+This release adds Git history tools, SVG editing, and Maven workflow improvements.
+
+### Downloads
+
+- [Project homepage](https://github.com/1lck/Lithe-IDEA)
+- [macOS Apple Silicon](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.5/Lithe-0.4.5-arm64.dmg)
+- [macOS Intel](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.5/Lithe-0.4.5-x86_64.dmg)
+- [Windows x64](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.5/Lithe-0.4.5-windows-x64.exe)
+- [All downloads](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.5)
+
+### Highlights
+
+Changes are grouped below.
+
+#### ✨ New features
+
+- Edit SVG source and see a live image preview.
+- Windows Markdown supports editor, split, and preview modes with synchronized scrolling.
+- Undo commits, edit messages, squash or drop commits, and reorganize Git history.
+- Create and manage Git worktrees to work on multiple branches at once.
+- Import and export Git patches to share code changes.
+- Initialize Git repositories and configure your commit name and email in Settings.
+- Windows can run Maven JUnit tests and show results and failure locations.
+- macOS can configure JDK and Maven separately for projects and subprojects.
+- Windows terminals now offer Copy and Paste in the context menu.
+
+#### ⚡ Improvements
+
+- After Maven configuration changes, reload and synchronize your Java project from the prompt.
+- Update notices no longer interrupt your work; choose Later or skip a version.
+- macOS supports differential updates, reducing future downloads when a matching earlier version is available.
+- Windows file tabs switch more smoothly with less reloading and recoloring.
+- Windows responds more promptly when staging or unstaging a single Git file.
+- The macOS Maven dependency tree now has complete Chinese and English labels.
+- PowerShell files have a more recognizable Windows-style icon.
+
+#### 🛠 Fixes
+
+- Fixed false Java service startup failures while importing large Maven projects.
+- Fixed Windows Git change lists unexpectedly clearing after a temporarily empty query result.
+- Fixed the unresponsive New Terminal button on Windows.
+- Fixed macOS terminal input focus; the cursor now appears only in the focused pane.
+- Fixed problems discarding Git changes on macOS.
+- Fixed the macOS Git log not refreshing after reverting a commit.
+
+### Upgrade instructions
+
+- macOS: open the DMG for your architecture and drag Lithe.app to Applications.
+- Homebrew: run `brew update && brew upgrade --cask lithe` after the cask update is available.
+- Windows: download and run the x64 installer.
+
+### Compatibility and known issues
+
+- Requires macOS 13 or later; the Windows installer has no publisher certificate and may show a system warning.
+- The first macOS release with the new updater uses a full download; differential downloads require matching later releases.
+
+If macOS says it cannot open Lithe.app, Control-click it in Applications and choose Open. If it is still blocked, run `xattr -dr com.apple.quarantine /Applications/Lithe.app` in Terminal. Use this only for an app from a source you trust.
+
+[Full changelog](https://github.com/1lck/Lithe-IDEA/compare/v0.4.4...v0.4.5)
+
+### 🙌 感谢贡献者
+
+[@1lck](https://github.com/1lck) · [@xiaoyumuxi](https://github.com/xiaoyumuxi) · [@Mucheen](https://github.com/Mucheen) · [@xdn-code](https://github.com/xdn-code) · [@xtr-hub](https://github.com/xtr-hub) · [@ElvisLin101](https://github.com/ElvisLin101) · [@caiyq925-cell](https://github.com/caiyq925-cell)
+
+### 🙌 Contributors
+
+[@1lck](https://github.com/1lck) · [@xiaoyumuxi](https://github.com/xiaoyumuxi) · [@Mucheen](https://github.com/Mucheen) · [@xdn-code](https://github.com/xdn-code) · [@xtr-hub](https://github.com/xtr-hub) · [@ElvisLin101](https://github.com/ElvisLin101) · [@caiyq925-cell](https://github.com/caiyq925-cell)


### PR DESCRIPTION
将稳定版说明统一为面向用户的「新功能 / 改进 / 修复 / 感谢贡献者」，每条使用一个简短句子。新增可复用模板并更新 release-lithe 规范，保留双语下载、升级、兼容性和可信来源 Gatekeeper 指引。

根据 v0.4.4 到最新主分支的提交准备 v0.4.5 说明，核实平台范围、安装包名称与贡献者。本 PR 仅修改发行文档和写作规范。

验证：两份文档通过现有发行说明校验器，release-lithe 技能校验通过，Prettier 和 git diff --check 通过。产品构建与打包由稳定版工作流执行。
