### PR TITLE
docs(release): prepare v0.4.6

### DIFF
--- a/docs/releases/v0.4.6.md
+++ b/docs/releases/v0.4.6.md
@@ -1,0 +1,77 @@
+## 中文
+
+本次更新修复 Windows Git 项目加载问题，并改进 Maven 操作和生成文件的显示设置。
+
+### 下载
+
+- [项目主页](https://github.com/1lck/Lithe-IDEA)
+- [macOS Apple Silicon](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.6/Lithe-0.4.6-arm64.dmg)
+- [macOS Intel](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.6/Lithe-0.4.6-x86_64.dmg)
+- [Windows x64](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.6/Lithe-0.4.6-windows-x64.exe)
+- [全部下载文件](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.6)
+
+### 重点更新
+
+- 修复 Windows 打开本地 Git 项目时，源代码管理和提交记录可能一直提示无法加载的问题。
+- Windows Maven 项目和模块右键菜单支持运行、调试、测试、打包、执行自定义目标、打开 pom.xml 和重新加载。
+- Windows Maven 生命周期节点支持通过右键菜单执行当前阶段。
+- macOS 隐藏路径设置新增添加和移除推荐规则的快捷操作，可按需隐藏 `.factorypath` 等语言服务生成文件，并在 Git 项目中同步本地忽略规则。
+
+### 升级说明
+
+- macOS：打开对应架构的 DMG，将 Lithe.app 拖入“应用程序”。
+- Homebrew：新版配方更新后，运行 `brew update && brew upgrade --cask lithe`。
+- Windows：下载并运行 x64 安装包。
+
+### 兼容性与已知问题
+
+- macOS 需要 13 或更高版本；Windows 安装包未配置发布者证书，系统可能显示提示。
+- 生成文件默认不会隐藏；推荐规则需要在设置中手动添加，文件仍保留在磁盘上。
+
+如果 macOS 提示无法打开 Lithe.app，请在“应用程序”中按住 Control 点按应用并选择“打开”；如果仍被阻止，可在终端执行 `xattr -dr com.apple.quarantine /Applications/Lithe.app`。仅对可信来源的应用使用。
+
+[查看完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.4.5...v0.4.6)
+
+---
+
+## English
+
+This release fixes Git project loading on Windows and improves Maven actions and generated-file visibility settings.
+
+### Downloads
+
+- [Project homepage](https://github.com/1lck/Lithe-IDEA)
+- [macOS Apple Silicon](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.6/Lithe-0.4.6-arm64.dmg)
+- [macOS Intel](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.6/Lithe-0.4.6-x86_64.dmg)
+- [Windows x64](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.6/Lithe-0.4.6-windows-x64.exe)
+- [All downloads](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.6)
+
+### Highlights
+
+- Fixed Source Control and commit history remaining unable to load when opening a local Git project on Windows.
+- Windows Maven project and module context menus now support running, debugging, testing, packaging, custom goals, opening pom.xml, and reloading.
+- Windows Maven lifecycle nodes can execute their phase from the context menu.
+- macOS Hidden paths settings can add or remove recommended rules for language-service files such as `.factorypath`, also updating local ignore rules in Git projects.
+
+### Upgrade instructions
+
+- macOS: open the DMG for your architecture and drag Lithe.app to Applications.
+- Homebrew: run `brew update && brew upgrade --cask lithe` after the cask update is available.
+- Windows: download and run the x64 installer.
+
+### Compatibility and known issues
+
+- Requires macOS 13 or later; the Windows installer has no publisher certificate and may show a system warning.
+- Generated files are not hidden by default; add the recommended rules in Settings if desired. Files remain on disk.
+
+If macOS says it cannot open Lithe.app, Control-click it in Applications and choose Open. If it is still blocked, run `xattr -dr com.apple.quarantine /Applications/Lithe.app` in Terminal. Use this only for an app from a source you trust.
+
+[Full changelog](https://github.com/1lck/Lithe-IDEA/compare/v0.4.5...v0.4.6)
+
+### 贡献者
+
+[@1lck](https://github.com/1lck) · [@Mucheen](https://github.com/Mucheen) · [@xdn-code](https://github.com/xdn-code)
+
+### Contributors
+
+[@1lck](https://github.com/1lck) · [@Mucheen](https://github.com/Mucheen) · [@xdn-code](https://github.com/xdn-code)


### PR DESCRIPTION
Prepare bilingual v0.4.6 release notes for the Windows Git loading fix, Windows Maven actions, and macOS generated-file visibility controls. Release notes validation and git diff --check passed.