### PR TITLE
docs(release): prepare v0.4.7

### DIFF
--- a/docs/releases/v0.4.7.md
+++ b/docs/releases/v0.4.7.md
@@ -1,0 +1,79 @@
+## 中文
+
+本次更新让 Git、编辑器和 Maven/运行工作流更完整、更稳定，并改善了大型 Java 项目的编辑体验。
+
+### 下载
+
+- [项目主页](https://github.com/1lck/Lithe-IDEA)
+- [macOS Apple Silicon](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.7/Lithe-0.4.7-arm64.dmg)
+- [macOS Intel](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.7/Lithe-0.4.7-x86_64.dmg)
+- [Windows x64](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.7/Lithe-0.4.7-windows-x64.exe)
+- [全部下载文件](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.7)
+
+### 重点更新
+
+- Git 历史视图新增更清晰的提交图、引用树和日期排序，分支与提交关系更容易查看。
+- 支持创建工作树、导入导出补丁、整理提交历史和初始化仓库，常见 Git 操作可以直接在 Lithe 中完成。
+- macOS 和 Windows 的运行面板进一步统一，Maven 模块、生命周期和测试运行操作更容易发现和使用。
+- 大型 Java 文件编辑、语法高亮和语言服务同步更流畅，减少滚动或连续输入时的卡顿。
+- 修复深层 MyBatis/Java 语法树可能导致索引栈溢出并退出的问题，并改善 Windows Git 项目加载和快捷键体验。
+- Windows 支持更完整的 Markdown 编辑/预览切换与 SVG 编辑预览；诊断信息也可导出为脱敏包，便于反馈问题。
+
+### 升级说明
+
+- macOS：打开对应架构的 DMG，将 Lithe.app 拖入“应用程序”。
+- Homebrew：新版配方更新后，运行 `brew update && brew upgrade --cask lithe`。
+- Windows：下载并运行 x64 安装包。
+
+### 兼容性与已知问题
+
+- macOS 需要 13 或更高版本；Windows 安装包未配置发布者证书，系统可能显示提示。
+
+如果 macOS 提示无法打开 Lithe.app，请在“应用程序”中按住 Control 点按应用并选择“打开”；如果仍被阻止，可在终端执行 `xattr -dr com.apple.quarantine /Applications/Lithe.app`。仅对可信来源的应用使用。
+
+[查看完整变更](https://github.com/1lck/Lithe-IDEA/compare/v0.4.6...v0.4.7)
+
+---
+
+## English
+
+This release makes Git, editor, and Maven/run workflows more complete and stable, while improving editing large Java projects.
+
+### Downloads
+
+- [Project homepage](https://github.com/1lck/Lithe-IDEA)
+- [macOS Apple Silicon](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.7/Lithe-0.4.7-arm64.dmg)
+- [macOS Intel](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.7/Lithe-0.4.7-x86_64.dmg)
+- [Windows x64](https://github.com/1lck/Lithe-IDEA/releases/download/v0.4.7/Lithe-0.4.7-windows-x64.exe)
+- [All downloads](https://github.com/1lck/Lithe-IDEA/releases/tag/v0.4.7)
+
+### Highlights
+
+- Git history now offers a clearer commit graph, reference tree, and date ordering so branch and commit relationships are easier to follow.
+- Create worktrees, import or export patches, reorganize commit history, and initialize repositories directly in Lithe.
+- macOS and Windows run panels are more consistent, with Maven module, lifecycle, and test actions easier to find and use.
+- Editing large Java files, syntax highlighting, and language-service synchronization are smoother, with less lag during scrolling or continuous input.
+- Fixed indexing crashes caused by deeply nested MyBatis/Java syntax trees, and improved Windows Git project loading and keyboard shortcuts.
+- Windows now has more complete Markdown editor/preview switching and SVG editing previews; diagnostics can also be exported as a redacted bundle for issue reports.
+
+### Upgrade instructions
+
+- macOS: open the DMG for your architecture and drag Lithe.app to Applications.
+- Homebrew: run `brew update && brew upgrade --cask lithe` after the cask update is available.
+- Windows: download and run the x64 installer.
+
+### Compatibility and known issues
+
+- Requires macOS 13 or later; the Windows installer has no publisher certificate and may show a system warning.
+
+If macOS says it cannot open Lithe.app, Control-click it in Applications and choose Open. If it is still blocked, run `xattr -dr com.apple.quarantine /Applications/Lithe.app` in Terminal. Use this only for an app from a source you trust.
+
+[Full changelog](https://github.com/1lck/Lithe-IDEA/compare/v0.4.6...v0.4.7)
+
+### 贡献者
+
+[@1lck](https://github.com/1lck) · [@Mucheen](https://github.com/Mucheen) · [@xiaoyumuxi](https://github.com/xiaoyumuxi) · [@JayF211](https://github.com/JayF211) · [@mirakyux](https://github.com/mirakyux) · [@xdn-code](https://github.com/xdn-code)
+
+### Contributors
+
+[@1lck](https://github.com/1lck) · [@Mucheen](https://github.com/Mucheen) · [@xiaoyumuxi](https://github.com/xiaoyumuxi) · [@JayF211](https://github.com/JayF211) · [@mirakyux](https://github.com/mirakyux) · [@xdn-code](https://github.com/xdn-code)


### PR DESCRIPTION
## Summary
- add bilingual stable release notes for v0.4.7
- document verified Git, editor, Maven, Windows, and diagnostics improvements

## Validation
- `node scripts/validate-stable-release-notes.mjs docs/releases/v0.4.7.md`
- `git diff --check`