### PR TITLE
feat: reveal active file in project tree

### DIFF
--- a/macos/Sources/Lithe/Views/Workspace/ProjectSidebarView.swift
+++ b/macos/Sources/Lithe/Views/Workspace/ProjectSidebarView.swift
@@ -163,6 +163,16 @@ struct ProjectSidebarView: View {
                 .font(.system(size: 9, weight: .semibold))
                 .foregroundStyle(LitheTheme.secondaryText)
             Spacer()
+            if let activeURL = model.activeDocument?.url,
+               model.canRevealInProjectTree(activeURL) {
+                Button {
+                    model.revealInProjectTree(activeURL)
+                } label: {
+                    LitheSystemIcon(systemImage: "scope")
+                }
+                .litheIconButton()
+                .help("Reveal Active File in Project Tree")
+            }
             if model.isRefreshingWorkspace {
                 ProgressView()
                     .controlSize(.small)


### PR DESCRIPTION
## Summary

- Add a macOS Project Tree scope button for the active project file.
- Reuse the existing `revealInProjectTree` flow to expand parent directories, scroll to the file, and select it.
- Keep the change limited to the macOS project sidebar.

This implements the manual “Reveal Active File in Project Tree” action requested by #460.

## Validation

- `./scripts/preview.sh`
- Verified on macOS development build `0.1.0`.
- Opened `macos/Sources/Lithe/LitheApp.swift` and clicked the scope button; the tree expanded and selected the file.
- `git diff --check`

Closes #460
