### PR TITLE
ci: 加速 macOS 打包并提供 CI 安装包下载

### DIFF
--- a/.github/actions/prepare-macos-dependency-cache/action.yml
+++ b/.github/actions/prepare-macos-dependency-cache/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: Restore Cargo crate archives.
     required: false
     default: "false"
+  cargo-build:
+    description: Cache macOS Rust compilation outputs in addition to crate archives.
+    required: false
+    default: "false"
+  cargo-build-architecture:
+    description: Partition compilation caches by arm64, x86_64, or universal packaging.
+    required: false
+    default: "universal"
   jdtls:
     description: Restore JDTLS and Lombok downloads.
     required: false
@@ -19,7 +27,7 @@ inputs:
     required: false
     default: "false"
   jdk-architecture:
-    description: Target JDK architecture, either arm64 or x86_64.
+    description: Target JDK architecture, arm64, x86_64, or universal for both.
     required: false
     default: ""
   restore-only:
@@ -46,8 +54,8 @@ runs:
         JDK_ARCHITECTURE: ${{ inputs.jdk-architecture }}
       run: |
         case "$JDK_ARCHITECTURE" in
-          arm64|x86_64) ;;
-          *) print -u2 -- "jdk-architecture must be arm64 or x86_64 when the JDK cache is enabled"; exit 2 ;;
+          arm64|x86_64|universal) ;;
+          *) print -u2 -- "jdk-architecture must be arm64, x86_64, or universal when the JDK cache is enabled"; exit 2 ;;
         esac
 
     - name: Restore SwiftPM repositories
@@ -184,3 +192,62 @@ runs:
       if: inputs.swiftpm == 'true'
       shell: zsh {0}
       run: "$GITHUB_WORKSPACE/scripts/prepare-macos-dependencies.sh"
+
+    - name: Resolve Cargo compilation cache identity
+      id: cargo_build_identity
+      if: inputs.cargo-build == 'true'
+      shell: bash
+      env:
+        BUILD_ARCHITECTURE: ${{ inputs.cargo-build-architecture }}
+      run: |
+        case "$BUILD_ARCHITECTURE" in
+          arm64|x86_64|universal) ;;
+          *) echo "Unsupported Cargo cache architecture: $BUILD_ARCHITECTURE" >&2; exit 2 ;;
+        esac
+        identity=$({
+          rustc -Vv
+          xcodebuild -version
+          xcrun --sdk macosx --show-sdk-version
+          sw_vers -productVersion
+          printf '%s\n' "${MACOSX_DEPLOYMENT_TARGET:-13.0}" "${RUSTFLAGS:-}"
+        } | shasum -a 256 | cut -d ' ' -f 1)
+        echo "identity=$identity" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Cargo compilation outputs
+      id: cargo_build
+      if: inputs.cargo-build == 'true' && inputs.restore-only != 'true'
+      continue-on-error: true
+      uses: actions/cache@v6
+      with:
+        # Core uses target/macos; database helpers use target directly. Include
+        # both layouts, while leaving final executables for Cargo to regenerate.
+        path: |
+          rust/target/**/.fingerprint
+          rust/target/**/build
+          rust/target/**/deps
+        key: macos-cargo-build-v1-${{ runner.arch }}-${{ steps.cargo_build_identity.outputs.identity }}-${{ inputs.cargo-build-architecture }}-${{ hashFiles('rust/Cargo.lock', 'rust/**/Cargo.toml', 'rust/.cargo/**', 'scripts/build-rust-core.sh', 'scripts/build-database-*.sh') }}
+        restore-keys: |
+          macos-cargo-build-v1-${{ runner.arch }}-${{ steps.cargo_build_identity.outputs.identity }}-${{ inputs.cargo-build-architecture }}-
+          macos-cargo-build-v1-${{ runner.arch }}-${{ steps.cargo_build_identity.outputs.identity }}-universal-
+
+    - name: Restore Cargo compilation outputs without saving
+      id: cargo_build_restore
+      if: inputs.cargo-build == 'true' && inputs.restore-only == 'true'
+      continue-on-error: true
+      uses: actions/cache/restore@v6
+      with:
+        path: |
+          rust/target/**/.fingerprint
+          rust/target/**/build
+          rust/target/**/deps
+        key: macos-cargo-build-v1-${{ runner.arch }}-${{ steps.cargo_build_identity.outputs.identity }}-${{ inputs.cargo-build-architecture }}-${{ hashFiles('rust/Cargo.lock', 'rust/**/Cargo.toml', 'rust/.cargo/**', 'scripts/build-rust-core.sh', 'scripts/build-database-*.sh') }}
+        restore-keys: |
+          macos-cargo-build-v1-${{ runner.arch }}-${{ steps.cargo_build_identity.outputs.identity }}-${{ inputs.cargo-build-architecture }}-
+          macos-cargo-build-v1-${{ runner.arch }}-${{ steps.cargo_build_identity.outputs.identity }}-universal-
+
+    - name: Discard incomplete Cargo compilation cache
+      if: inputs.cargo-build == 'true' && (steps.cargo_build.outcome == 'failure' || steps.cargo_build_restore.outcome == 'failure')
+      shell: bash
+      run: |
+        echo "::warning::Cargo compilation cache restore failed; rebuilding from verified crate archives."
+        rm -rf -- "$GITHUB_WORKSPACE/rust/target"

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -228,11 +228,17 @@ jobs:
         run: ./scripts/verify-rust-core.sh
 
   release-build:
-    name: Release package verification
+    name: Release package verification (${{ matrix.architecture }})
     needs: changes
     if: needs.changes.outputs.macos_release == 'true'
     runs-on: macos-14
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        # PRs compile each architecture concurrently. Main and manual runs also
+        # exercise the default universal assembly path and its negative checks.
+        architecture: ${{ fromJSON(github.event_name == 'pull_request' && '["arm64","x86_64"]' || '["universal"]') }}
 
     steps:
       - name: Check out source
@@ -246,13 +252,18 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
+          targets: ${{ matrix.architecture == 'arm64' && 'aarch64-apple-darwin' || matrix.architecture == 'x86_64' && 'x86_64-apple-darwin' || 'aarch64-apple-darwin,x86_64-apple-darwin' }}
 
       - name: Prepare verified dependency caches
         uses: ./.github/actions/prepare-macos-dependency-cache
         with:
           swiftpm: "true"
           cargo: "true"
+          cargo-build: "true"
+          cargo-build-architecture: ${{ matrix.architecture }}
+          jdtls: "true"
+          jdk: "true"
+          jdk-architecture: ${{ matrix.architecture }}
 
       - name: Check packaging scripts and metadata
         shell: zsh {0}
@@ -269,14 +280,80 @@ jobs:
           plutil -lint macos/Resources/Info.plist
 
       - name: Build and verify default universal package
+        if: matrix.architecture == 'universal'
         env:
           # Temporary: capture disk image state around create-dmg.sh while the
           # intermittent "hdiutil: create failed - Resource busy" is diagnosed.
           LITHE_DMG_DIAGNOSTICS: "1"
         run: |
           ./scripts/verify-macos-package.sh
+
+      - name: Verify Sparkle update packaging
+        run: |
           sparkle_tools=$(zsh scripts/prepare-sparkle-tools.sh)
           ruby scripts/test-sparkle-update.rb "$sparkle_tools"
+
+      - name: Build complete macOS test package
+        id: package
+        env:
+          LITHE_ARCH: ${{ matrix.architecture }}
+          LITHE_BUILD_NUMBER: ${{ github.run_number }}.${{ github.run_attempt }}
+        shell: bash
+        run: |
+          # The universal smoke test uses Java fixtures in a temporary folder.
+          # Assemble again with real tools, reusing its compiled Swift/Rust files.
+          ./scripts/package-app.sh
+          ./scripts/create-dmg.sh
+          version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' macos/Resources/Info.plist)
+          suffix="-$LITHE_ARCH"
+          if [[ "$LITHE_ARCH" == "universal" ]]; then suffix=""; fi
+          app_path="dist/Lithe${suffix}.app"
+          dmg_name="Lithe-${version}${suffix}.dmg"
+          codesign --verify --deep --strict "$app_path"
+          architectures=("$LITHE_ARCH")
+          if [[ "$LITHE_ARCH" == "universal" ]]; then architectures=(arm64 x86_64); fi
+          for executable in \
+            "$app_path/Contents/MacOS/Lithe" \
+            "$app_path/Contents/Frameworks/Sparkle.framework/Sparkle" \
+            "$app_path/Contents/Helpers/lithe-db-sidecar" \
+            "$app_path/Contents/Helpers/lithe-db-mcp"; do
+            test -x "$executable"
+            lipo "$executable" -verify_arch "${architectures[@]}"
+          done
+          hdiutil imageinfo "dist/$dmg_name" > /dev/null
+          test -s "dist/$dmg_name"
+          (cd dist && shasum -a 256 "$dmg_name" > "$dmg_name.sha256" && shasum -a 256 -c "$dmg_name.sha256")
+          echo "dmg=dist/$dmg_name" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload macOS test package
+        id: installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: Lithe-macos-${{ matrix.architecture }}-${{ github.run_number }}-${{ github.run_attempt }}
+          path: |
+            ${{ steps.package.outputs.dmg }}
+            ${{ steps.package.outputs.dmg }}.sha256
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+      - name: Add macOS download link
+        env:
+          ARTIFACT_URL: ${{ steps.installer.outputs.artifact-url }}
+          PACKAGE_ARCHITECTURE: ${{ matrix.architecture }}
+          SOURCE_SHA: ${{ steps.package.outputs.sha }}
+        shell: bash
+        run: |
+          {
+            echo "### macOS test download ($PACKAGE_ARCHITECTURE)"
+            echo "[Download DMG and SHA-256 checksum]($ARTIFACT_URL)"
+            echo ""
+            echo "Source: $SOURCE_SHA"
+            echo ""
+            echo "Requires GitHub sign-in. Retained for 14 days. Includes the bundled Java tools."
+            echo "The app is ad-hoc signed for testing. Check the CI gate for the combined test result."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   gate:
     name: macOS CI gate

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -218,10 +218,56 @@ jobs:
           }
           ./scripts/validate-windows-build-caches.ps1 @validation
 
-      - name: Build Windows Tauri application
+      - name: Build Windows test installer
+        id: package
         if: needs.changes.outputs.windows == 'true'
         shell: pwsh
-        run: ./scripts/build-windows.ps1 -Configuration Release
+        run: |
+          # NSIS packaging performs the same release build and frontend type
+          # check; do not compile once with --no-bundle and then rebuild it.
+          $config = Get-Content windows/tauri/src-tauri/tauri.conf.json -Raw | ConvertFrom-Json
+          Push-Location .
+          try {
+            ./scripts/package-windows.ps1 -Configuration Release -Version $config.version
+          } finally {
+            Pop-Location
+          }
+          $installer = "dist/Lithe-$($config.version)-windows-x64.exe"
+          $expected = ((Get-Content "$installer.sha256" -Raw) -split '\s+')[0]
+          $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $installer).Hash.ToLowerInvariant()
+          if ($expected -ne $actual) { throw "Installer checksum mismatch" }
+          "installer=$installer" >> $env:GITHUB_OUTPUT
+          "sha=$((git rev-parse HEAD).Trim())" >> $env:GITHUB_OUTPUT
+
+      - name: Upload Windows test installer
+        id: installer
+        if: needs.changes.outputs.windows == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: Lithe-windows-x64-${{ github.run_number }}-${{ github.run_attempt }}
+          path: |
+            ${{ steps.package.outputs.installer }}
+            ${{ steps.package.outputs.installer }}.sha256
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+      - name: Add Windows download link
+        if: needs.changes.outputs.windows == 'true'
+        env:
+          ARTIFACT_URL: ${{ steps.installer.outputs.artifact-url }}
+          SOURCE_SHA: ${{ steps.package.outputs.sha }}
+        shell: pwsh
+        run: |
+          @"
+          ### Windows x64 test download
+          [Download installer and SHA-256 checksum]($env:ARTIFACT_URL)
+
+          Source: $env:SOURCE_SHA
+
+          Requires GitHub sign-in. Retained for 14 days. Includes the bundled Java tools.
+          The installer is unsigned for testing. Check the CI gate for the combined test result.
+          "@ >> $env:GITHUB_STEP_SUMMARY
 
       - name: Verify Windows boundaries
         if: needs.changes.outputs.windows == 'true'

--- a/.github/workflows/release-preview-macos.yml
+++ b/.github/workflows/release-preview-macos.yml
@@ -85,6 +85,8 @@ jobs:
         with:
           swiftpm: "true"
           cargo: "true"
+          cargo-build: "true"
+          cargo-build-architecture: ${{ matrix.architecture }}
           jdtls: "true"
           jdk: "true"
           jdk-architecture: ${{ matrix.architecture }}
@@ -134,6 +136,7 @@ jobs:
         run: zsh scripts/create-sparkle-update.sh
 
       - name: Upload preview artifacts
+        id: artifacts
         uses: actions/upload-artifact@v7
         with:
           name: macos-preview-${{ matrix.architecture }}
@@ -142,7 +145,24 @@ jobs:
             dist/Lithe-${{ env.PREVIEW_VERSION }}-${{ matrix.architecture }}.dmg.sha256
             dist/sparkle-${{ matrix.architecture }}/*
           if-no-files-found: error
+          compression-level: 0
           retention-days: 14
+
+      - name: Add preview download link
+        env:
+          ARTIFACT_URL: ${{ steps.artifacts.outputs.artifact-url }}
+          PACKAGE_ARCHITECTURE: ${{ matrix.architecture }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.sha }}
+        shell: bash
+        run: |
+          {
+            echo "### macOS preview ($PACKAGE_ARCHITECTURE)"
+            echo "[Download this build]($ARTIFACT_URL)"
+            echo ""
+            echo "Source: $SOURCE_SHA"
+            echo ""
+            echo "Requires GitHub sign-in; retained for 14 days. Available before the rolling Release finishes publishing."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   publish:
     name: Publish rolling macOS preview

--- a/docs/ci-builds.md
+++ b/docs/ci-builds.md
@@ -1,0 +1,80 @@
+# CI builds and test downloads
+
+macOS CI and Windows CI upload complete test packages whenever their product
+build lane is selected. Open the workflow run's **Summary** and use the
+**macOS test download** or **Windows x64 test download** link. The same files
+appear in the run's **Artifacts** list.
+
+- macOS PRs produce separate Apple Silicon (`arm64`) and Intel (`x86_64`) DMGs.
+  The two jobs run concurrently when runners are available.
+- macOS pushes to `main` and manual runs verify the default universal package,
+  then assemble a universal DMG with the real Java tools using the same compiled
+  outputs. The packaging smoke test's temporary Java fixtures are never uploaded.
+- Windows produces an NSIS `.exe` installer. Packaging performs the Release
+  build and frontend type check once; there is no preceding `--no-bundle` build.
+- Each package includes a SHA-256 checksum and the bundled Java tools. macOS
+  apps are ad-hoc signed, and Windows CI installers are unsigned.
+- Artifact links require GitHub sign-in and expire after 14 days. Downloading
+  an artifact gives a ZIP containing the installer and checksum. The archive
+  uses compression level 0 because DMGs and NSIS installers are already compressed.
+
+The summary records the exact checked-out revision. For a pull request this is
+normally GitHub's test merge commit. An artifact can become available before
+the remaining jobs finish, so check **macOS CI gate** or **Windows CI gate** for
+the combined test result. A failed architecture still fails the macOS gate;
+`fail-fast: false` lets the other architecture finish and upload its package.
+Documentation-only changes can skip packaging. To request a complete validation
+and package for a branch, select **Run workflow** in the corresponding CI workflow.
+
+The GitHub CLI can also download a particular run's packages:
+
+```bash
+gh run download <run-id> --repo 1lck/Lithe-IDEA --pattern 'Lithe-macos-*'
+gh run download <run-id> --repo 1lck/Lithe-IDEA --pattern 'Lithe-windows-x64-*'
+```
+
+Rolling previews also have public, stable download URLs after publication:
+
+- [Apple Silicon preview DMG](https://github.com/1lck/Lithe-IDEA/releases/download/preview-0.3.0/Lithe-0.3.0-arm64.dmg)
+- [Intel preview DMG](https://github.com/1lck/Lithe-IDEA/releases/download/preview-0.3.0/Lithe-0.3.0-x86_64.dmg)
+- [Windows x64 preview installer](https://github.com/1lck/Lithe-IDEA/releases/download/preview-0.3.0/Lithe-0.3.0-windows-x64.exe)
+
+These URLs follow the current `PREVIEW_TAG` and `PREVIEW_VERSION` in the preview
+workflows. They identify the latest published preview, rather than an arbitrary
+PR. macOS preview jobs additionally expose their own artifact links before the
+combined rolling Release publishes.
+
+## Build time and caches
+
+The September 12, 2026 investigation found two separate sources of delay:
+
+| Observed run | Total elapsed | Main cost |
+| --- | --- | --- |
+| [macOS CI 34677881176](https://github.com/1lck/Lithe-IDEA/actions/runs/34677881176) | 37m 25s | Universal packaging 34m 37s; Swift tests ran concurrently and finished in about 10m |
+| [macOS CI 34667794413](https://github.com/1lck/Lithe-IDEA/actions/runs/34667794413) | 43m 52s | Packaging job started about 10m after the run began, then ran for about 34m |
+| [macOS Preview 34577516401](https://github.com/1lck/Lithe-IDEA/actions/runs/34577516401) | 54m 03s | Intel job started about 32m after source preparation, then ran for about 20m |
+
+The first CI run compiled the Swift product twice (about 11m 27s and 9m 54s)
+and spent another 12m compiling Rust Core and database helpers. Download caches
+were already hitting, but macOS had no cache for compiled Rust dependencies.
+
+The macOS package CI and preview workflows now cache Cargo fingerprints, build
+script outputs, and dependency outputs for both `rust/target/macos` (Core) and
+`rust/target` (database helpers). Keys include runner architecture, compiler,
+Xcode/SDK/macOS versions, build flags, dependency manifests, and build scripts.
+An architecture-specific job can restore the universal cache from its base
+branch. Final executables are not cached; Cargo still runs before packaging.
+An interrupted cache restore is discarded, leaving the existing verified
+download cache as the fallback. Swift compilation products are not cached.
+
+Cold builds, compiler changes, and dependency changes still require compilation.
+PR concurrency shortens the serial build path without promising the same
+reduction in total runner minutes. It also needs two available macOS runners.
+GitHub queue delays remain outside these build steps. Compare warm-cache runs
+with these baselines before claiming a measured improvement. A runner pool
+change should be evaluated separately if queueing continues to dominate.
+
+The artifact behavior and compression setting follow
+[actions/upload-artifact](https://github.com/actions/upload-artifact), and cache
+reuse follows GitHub's
+[branch access restrictions](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching).


### PR DESCRIPTION
macOS CI 原先在同一台 runner 上串行编译两种架构，最近一次通用包验证耗时 34 分 37 秒；验证包使用临时 Java 资源，构建成功后也没有可供完整测试的下载包。

本 PR 将 macOS PR 打包拆为 arm64/x86_64 并行任务，并为 macOS CI 和 Preview 增加按编译器、SDK、架构及依赖区分的 Cargo 编译缓存。main 和手动运行继续验证默认通用包。macOS 和 Windows CI 生成包含真实 Java 工具的安装包及 SHA-256 文件，在运行 Summary 提供下载链接，保留 14 天。Windows 直接执行 NSIS 打包，复用同一轮 Release 编译；任一必需任务失败仍会阻止 CI gate 通过。

下载需要登录 GitHub；macOS CI 包使用 ad-hoc 签名，Windows CI 安装包未签名。PR 下载对应实际 checkout 的测试合并提交。并行构建需要可用 runner，排队时间不在编译优化范围内。

验证：
- actionlint、复合 action YAML 和 shell 语法检查通过。
- 变更分类器、下载缓存校验、Sparkle 打包、更新 manifest、测试稳定性基础设施测试通过。
- Windows 边界检查、56 个 macOS gate 成功/失败组合、下载摘要检查及 git diff --check 通过。
- GitHub 上所有必需检查均通过：macOS CI（两轮）、Windows CI、Plugin CI 和 Database CI。


实测（2026-09-12，PR 提交 `a3fc9606`，测试合并提交 `afd6c2b07994`）：

| 流程 | 安装包可下载时间 | 完整 CI 耗时 |
| --- | --- | --- |
| [macOS 首轮：新 Cargo 编译缓存未命中](https://github.com/1lck/Lithe-IDEA/actions/runs/34680357059/attempts/1) | arm64 21m 18s；Intel 21m 17s | 21m 49s |
| [macOS 同提交复测：两个 Cargo 编译缓存均命中](https://github.com/1lck/Lithe-IDEA/actions/runs/34680357059/attempts/2) | arm64 12m 31s；Intel 12m 33s | 12m 42s |
| [Windows 安装包及全部选中测试](https://github.com/1lck/Lithe-IDEA/actions/runs/34680357064) | 19m 27s | 29m 41s |

两轮 macOS 的下载依赖缓存均命中；“首轮未命中”仅指新加的 Cargo 编译缓存。arm64 的 Rust 编译累计从约 6m 52s 降到 2m 14s。Swift 编译也从约 10m 38s 变为 7m 07s，但本 PR 没有缓存 Swift 编译产物，因此不能把全链路约 42% 的差异全部归因于 Cargo 缓存。历史普通 macOS CI 的 37m 25s 仅作参考，并非同提交对照实验。

两个 Cargo 缓存分别约 363/365 MiB，已确认成功保存和复测命中。首轮实际出现 5 个 macOS 任务运行、第 6 个排队；数据库任务完成后，桥接测试开始执行。

最新测试包（需登录 GitHub，保留 14 天）：
- [macOS Apple Silicon](https://github.com/1lck/Lithe-IDEA/actions/runs/34680357059/artifacts/10294665071)
- [macOS Intel](https://github.com/1lck/Lithe-IDEA/actions/runs/34680357059/artifacts/10294169258)
- [Windows x64](https://github.com/1lck/Lithe-IDEA/actions/runs/34680357064/artifacts/10293739245)

下载验证：首轮两份 DMG 已实际下载、校验 SHA-256、只读挂载，并通过代码签名、主程序/数据库辅助程序/JDK/插件架构、真实 Java JAR 和提交身份检查，随后已卸载挂载点。Windows 安装包已实际下载并通过 SHA-256 和 PE 格式检查。未在本机安装或启动这些应用。复测两份 macOS 产物也通过工作流内的签名、架构及校验检查。

本次远端实测覆盖 PR 的分架构路径；main/手动 universal 路径未另行触发，也未发布滚动 Preview 或稳定版。
