### PR TITLE
feat(macos): 服务窗口三栏分组与批量启动

### DIFF
--- a/macos/Resources/en.lproj/Localizable.strings
+++ b/macos/Resources/en.lproj/Localizable.strings
@@ -807,3 +807,20 @@
 "Collapse long graph edges" = "Collapse long graph edges";
 "Go to parent commit %@" = "Go to parent commit %@";
 "Go to child commit %@" = "Go to child commit %@";
+
+/* Services browser */
+"All configurations" = "All configurations";
+"Application types" = "Application types";
+"No configurations in this scope" = "No configurations in this scope";
+"Run selected" = "Run selected";
+"Stop selected" = "Stop selected";
+"Clear selection" = "Clear selection";
+"%lld selected" = "%lld selected";
+"Run checked configurations without restarting running services" = "Run checked configurations without restarting running services";
+"Select configurations for batch actions" = "Select configurations for batch actions";
+"Select %@" = "Select %@";
+"Partially selected" = "Partially selected";
+"Not selected" = "Not selected";
+"Start this configuration to see its output here." = "Start this configuration to see its output here.";
+"Could not save service selection" = "Could not save service selection";
+"Selected" = "Selected";

--- a/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -1831,3 +1831,20 @@
 "Collapse long graph edges" = "收束长连线";
 "Go to parent commit %@" = "跳转到父提交 %@";
 "Go to child commit %@" = "跳转到子提交 %@";
+
+/* Services browser */
+"All configurations" = "全部配置";
+"Application types" = "应用类型";
+"No configurations in this scope" = "当前范围内没有配置";
+"Run selected" = "启动所选配置";
+"Stop selected" = "停止所选配置";
+"Clear selection" = "清除勾选";
+"%lld selected" = "已勾选 %lld 项";
+"Run checked configurations without restarting running services" = "启动勾选的配置，已运行的服务保持运行";
+"Select configurations for batch actions" = "勾选配置以批量操作";
+"Select %@" = "勾选 %@";
+"Partially selected" = "部分勾选";
+"Not selected" = "未勾选";
+"Start this configuration to see its output here." = "启动此配置后，输出将显示在这里。";
+"Could not save service selection" = "无法保存服务勾选状态";
+"Selected" = "已勾选";

--- a/macos/Sources/Lithe/Application/Features/RunBrowserState.swift
+++ b/macos/Sources/Lithe/Application/Features/RunBrowserState.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Native Services navigation and checkbox selection. Focus and batch selection
+/// are independent so browsing another scope never discards checked services.
+struct RunBrowserState {
+    enum Scope: Hashable {
+        case all
+        case pinned
+        case execution(RunConfigurationExecution)
+    }
+
+    enum CheckState {
+        case unchecked
+        case mixed
+        case checked
+    }
+
+    struct ApplicationGroup: Identifiable {
+        let id: String
+        let title: String
+        let iconKind: RunConfigurationKind
+        let configurations: [RunConfiguration]
+    }
+
+    var scope: Scope = .all
+    private(set) var checkedIDs: Set<String> = []
+    var collapsedGroupIDs: Set<String> = []
+
+    func configurations(
+        in scope: Scope,
+        from configurations: [RunConfiguration],
+        pinnedIDs: Set<String>
+    ) -> [RunConfiguration] {
+        configurations.filter { configuration in
+            guard !configuration.usesCurrentEditorFile else { return false }
+            switch scope {
+            case .all: return true
+            case .pinned: return pinnedIDs.contains(configuration.id)
+            case .execution(let execution): return configuration.execution == execution
+            }
+        }
+    }
+
+    func checkState(for configurations: [RunConfiguration]) -> CheckState {
+        let ids = Set(configurations.map(\.id))
+        let selected = ids.intersection(checkedIDs)
+        if selected.isEmpty { return .unchecked }
+        return selected == ids ? .checked : .mixed
+    }
+
+    mutating func toggle(_ configurations: [RunConfiguration]) {
+        let ids = Set(configurations.filter { !$0.usesCurrentEditorFile }.map(\.id))
+        if ids.isSubset(of: checkedIDs) {
+            checkedIDs.subtract(ids)
+        } else {
+            checkedIDs.formUnion(ids)
+        }
+    }
+
+    mutating func restoreSelection(_ ids: [String], configurations: [RunConfiguration]) {
+        checkedIDs = Set(ids)
+        retainConfigurations(configurations)
+    }
+
+    mutating func clearSelection() {
+        checkedIDs.removeAll()
+    }
+
+    mutating func retainConfigurations(_ configurations: [RunConfiguration]) {
+        checkedIDs.formIntersection(configurations.filter { !$0.usesCurrentEditorFile }.map(\.id))
+    }
+
+    /// Group by the provider's presentation family; all JVM entry points share
+    /// Java while unfamiliar providers keep their own visible group.
+    static func groups(for configurations: [RunConfiguration]) -> [ApplicationGroup] {
+        let grouped = Dictionary(grouping: configurations.filter { !$0.usesCurrentEditorFile }) {
+            $0.kind.capabilities.contains(.javaRuntime) ? "java" : $0.kind.providerID
+        }
+        return grouped.map { id, configurations in
+            let sorted = configurations.sorted {
+                let comparison = $0.name.localizedStandardCompare($1.name)
+                return comparison == .orderedSame ? $0.id < $1.id : comparison == .orderedAscending
+            }
+            let kind = sorted[0].kind
+            return ApplicationGroup(
+                id: id,
+                title: id == "java" ? "Java" : kind.title,
+                iconKind: id == "java" ? .javaMain : kind,
+                configurations: sorted
+            )
+        }.sorted {
+            let comparison = $0.title.localizedStandardCompare($1.title)
+            return comparison == .orderedSame ? $0.id < $1.id : comparison == .orderedAscending
+        }
+    }
+}

--- a/macos/Sources/Lithe/Application/Features/RunWorkflowCoordinator.swift
+++ b/macos/Sources/Lithe/Application/Features/RunWorkflowCoordinator.swift
@@ -17,6 +17,7 @@ struct PendingRunAction: Equatable {
         case debug
         case startConfiguration(RunConfiguration)
         case startSelectedServices([RunConfiguration])
+        case startConfigurations([String])
         case runAllServices
         case restart
     }
@@ -368,6 +369,8 @@ final class RunWorkflowCoordinator {
             actions.startRunConfiguration(configuration)
         case .startSelectedServices(let configurations):
             actions.startSelectedServiceConfigurations(configurations)
+        case .startConfigurations(let configurationIDs):
+            actions.startRunConfigurations(configurationIDs)
         case .runAllServices:
             actions.runAllServiceConfigurations()
         case .restart:

--- a/macos/Sources/Lithe/Application/Features/WorkflowActionPorts.swift
+++ b/macos/Sources/Lithe/Application/Features/WorkflowActionPorts.swift
@@ -35,6 +35,7 @@ protocol RunWorkflowActions: EditorDocumentSaving {
     func startDebugging()
     func startRunConfiguration(_ configuration: RunConfiguration)
     func startSelectedServiceConfigurations(_ configurations: [RunConfiguration])
+    func startRunConfigurations(_ configurationIDs: [String])
     func runAllServiceConfigurations()
     func restartSelectedRun()
 }

--- a/macos/Sources/Lithe/Models/AppModel/AppModel+RunConfiguration.swift
+++ b/macos/Sources/Lithe/Models/AppModel/AppModel+RunConfiguration.swift
@@ -433,6 +433,49 @@ extension AppModel {
         showToolWindow(.run)
     }
 
+    func startRunConfigurations(_ configurationIDs: [String]) {
+        Task { [weak self] in
+            await self?.performStartRunConfigurations(configurationIDs)
+        }
+    }
+
+    /// A batch is one deferred intent. Launches use the current inventory and
+    /// retain existing sessions, including output from already running services.
+    func performStartRunConfigurations(_ configurationIDs: [String]) async {
+        let ids = Set(configurationIDs).sorted()
+        guard !ids.isEmpty, let identity = currentWorkspaceIdentity else { return }
+        guard let runFeature = await activateExecutionModule()?.runFeature else { return }
+        guard isCurrentWorkspace(identity) else { return }
+        switch await ensureRunProjectReady(runFeature, for: identity) {
+        case .ready:
+            clearPendingRunAction(for: identity)
+        case .waitingForSnapshot(let waitingIdentity):
+            deferRunAction(.startConfigurations(ids), for: waitingIdentity)
+            return
+        case .stale:
+            return
+        }
+        for id in ids {
+            guard isCurrentWorkspace(identity) else { return }
+            guard let configuration = runFeature.configurations.first(where: { $0.id == id }),
+                  !configuration.usesCurrentEditorFile,
+                  !runFeature.moduleSessions.contains(where: { $0.id == id && $0.isRunning })
+            else { continue }
+            let activated = await activateLanguageRunExtensionIfNeeded(
+                for: configuration,
+                currentFileURL: nil,
+                runFeature: runFeature
+            )
+            guard isCurrentWorkspace(identity) else { return }
+            guard activated,
+                  let current = runFeature.configurations.first(where: { $0.id == id }),
+                  !runFeature.moduleSessions.contains(where: { $0.id == id && $0.isRunning })
+            else { continue }
+            runFeature.startConfiguration(current)
+        }
+        showToolWindow(.run)
+    }
+
     func runAllServiceConfigurations() {
         Task { [weak self] in
             guard let self else { return }

--- a/macos/Sources/Lithe/Views/Run/RunServicesSplitView.swift
+++ b/macos/Sources/Lithe/Views/Run/RunServicesSplitView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// Keeps both resize states inside the existing split containers. Persisted
+/// widths change only on commit, so pointer events do not rebuild RunView.
+struct RunServicesSplitView<Scopes: View, Configurations: View, Content: View>: View {
+    let isScopeCollapsed: Bool
+    let scopes: Scopes
+    let configurations: Configurations
+    let content: Content
+
+    @AppStorage("lithe.run.scopeListWidth") private var scopeWidth = 170.0
+    @AppStorage("lithe.run.configurationListWidth") private var configurationWidth = 280.0
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = max(geometry.size.width, minimumWidth)
+            if geometry.size.width < minimumWidth {
+                // Narrow docked windows retain usable columns with horizontal
+                // navigation instead of negative sizes or overlapping controls.
+                ScrollView(.horizontal) {
+                    panes(width: width)
+                        .frame(width: width, height: geometry.size.height)
+                }
+            } else {
+                panes(width: width)
+            }
+        }
+    }
+
+    private var minimumWidth: CGFloat {
+        RunServicesLayout.minimumWidth(isScopeCollapsed: isScopeCollapsed)
+    }
+
+    @ViewBuilder
+    private func panes(width: CGFloat) -> some View {
+        if isScopeCollapsed {
+            HStack(spacing: 0) {
+                scopes.frame(width: RunServicesLayout.collapsedScopeWidth)
+                Rectangle().fill(LitheTheme.divider).frame(width: 1)
+                configurationSplit
+            }
+        } else {
+            LitheSplitPaneView(
+                axis: .horizontal,
+                placement: .leading,
+                defaultSize: CGFloat(scopeWidth),
+                minimum: RunServicesLayout.scopeMinimum,
+                maximum: RunServicesLayout.scopeMaximum(in: width),
+                flexibleMinimum: RunServicesLayout.configurationMinimum
+                    + SplitHandleView.thickness + RunServicesLayout.outputMinimum,
+                onCommit: { scopeWidth = Double($0) },
+                sized: { scopes },
+                flexible: { configurationSplit }
+            )
+        }
+    }
+
+    private var configurationSplit: some View {
+        GeometryReader { geometry in
+            LitheSplitPaneView(
+                axis: .horizontal,
+                placement: .leading,
+                defaultSize: CGFloat(configurationWidth),
+                minimum: RunServicesLayout.configurationMinimum,
+                maximum: RunServicesLayout.configurationMaximum(in: geometry.size.width),
+                flexibleMinimum: RunServicesLayout.outputMinimum,
+                onCommit: { configurationWidth = Double($0) },
+                sized: { configurations },
+                flexible: { content }
+            )
+        }
+    }
+}
+
+enum RunServicesLayout {
+    static let scopeMinimum: CGFloat = 140
+    static let configurationMinimum: CGFloat = 240
+    static let outputMinimum: CGFloat = 320
+    static let collapsedScopeWidth: CGFloat = 32
+
+    static func minimumWidth(isScopeCollapsed: Bool) -> CGFloat {
+        (isScopeCollapsed ? collapsedScopeWidth + 1 : scopeMinimum + SplitHandleView.thickness)
+            + configurationMinimum + SplitHandleView.thickness + outputMinimum
+    }
+
+    static func scopeMaximum(in width: CGFloat) -> CGFloat {
+        max(scopeMinimum, min(280, width - configurationMinimum - outputMinimum - 2 * SplitHandleView.thickness))
+    }
+
+    static func configurationMaximum(in width: CGFloat) -> CGFloat {
+        max(configurationMinimum, min(480, width - outputMinimum - SplitHandleView.thickness))
+    }
+}

--- a/macos/Sources/Lithe/Views/Run/RunView.swift
+++ b/macos/Sources/Lithe/Views/Run/RunView.swift
@@ -8,25 +8,18 @@ struct RunView: View {
         get { feature.selectedProjectSessionID }
         nonmutating set { feature.selectedConfigurationID = newValue ?? RunConfiguration.currentFileID }
     }
-    @AppStorage("lithe.run.collapsedExecutions") private var collapsedExecutionIDs = ""
+    @State private var browser = RunBrowserState()
+    @State private var contentTab: ContentTab = .console
+    @State private var selectionWorkspacePath: String?
+    @AppStorage("lithe.run.selectedServiceIDs") private var selectedConfigurationTokens = ""
+
+    private enum ContentTab { case console, details }
     @AppStorage("lithe.run.pinnedConfigurationIDs") private var pinnedConfigurationTokens = ""
-    @AppStorage("lithe.run.configurationListWidth") private var configurationListWidth = 230.0
     @AppStorage("lithe.run.configurationListCollapsed") private var isConfigurationListCollapsed = false
-    @AppStorage("lithe.run.otherConfigurationsCollapsed") private var areOtherConfigurationsCollapsed = true
-    @AppStorage("lithe.run.selectedServiceIDs") private var selectedServiceTokens = ""
-    /// Separate caches: the two raw strings change independently, and one box
-    /// memoizes a single raw value.
-    @State private var collapsedExecutionCache = RunConfigurationTokenCache()
     @State private var pinnedConfigurationCache = RunConfigurationTokenCache()
     /// The configuration whose editor popover is open. Held separately from the list
     /// selection so opening an editor does not switch which log is shown.
     @State private var editingConfigurationID: String?
-    /// Services selected in the header menu for the next multi-service launch.
-    /// The first project service is selected when a workspace has no prior choice.
-    @State private var selectedServiceIDs: Set<String> = []
-    @State private var selectedServicesWorkspacePath = ""
-    @State private var hasHydratedServiceSelection = false
-    @State private var isServiceLaunchConfirmationPresented = false
 
     var body: some View {
         let _ = LitheSignpost.bodyEvaluated("RunView")
@@ -55,56 +48,36 @@ struct RunView: View {
                     model.openSourceLocation(url: url, line: line, column: column)
                 }
             } else {
-                GeometryReader { geometry in
-                    let minimumListWidth: CGFloat = 180
-                    let minimumContentWidth: CGFloat = 320
-                    let maximumListWidth = max(
-                        minimumListWidth,
-                        min(420, geometry.size.width - SplitHandleView.thickness - minimumContentWidth)
-                    )
-                    if isConfigurationListCollapsed {
-                        HStack(spacing: 0) {
-                            collapsedConfigurationListBar
-                                .frame(width: 32)
-                            Rectangle()
-                                .fill(LitheTheme.divider)
-                                .frame(width: 1)
-                            selectedConfigurationContent
-                        }
-                    } else {
-                        LitheSplitPaneView(
-                            axis: .horizontal,
-                            placement: .leading,
-                            defaultSize: CGFloat(configurationListWidth),
-                            minimum: minimumListWidth,
-                            maximum: maximumListWidth,
-                            onCommit: { configurationListWidth = Double($0) },
-                            sized: { moduleSessionList },
-                            flexible: { selectedConfigurationContent }
-                        )
-                    }
-                }
+                RunServicesSplitView(
+                    isScopeCollapsed: isConfigurationListCollapsed,
+                    scopes: scopeList,
+                    configurations: applicationTypeList,
+                    content: selectedConfigurationContent
+                )
             }
         }
         .litheWorkbenchSurface(LitheTheme.editor)
-        .confirmationDialog(
-            "Run all services?",
-            isPresented: $isServiceLaunchConfirmationPresented,
-            titleVisibility: .visible
-        ) {
-            Button("Run all services") {
-                model.runAllServiceConfigurations()
-                selectedSessionID = serviceConfigurations.first?.id
+        .onAppear { synchronizeCheckedConfigurations() }
+        .onChange(of: feature.configurations) { _ in synchronizeCheckedConfigurations() }
+        .onChange(of: feature.projectLoadState) { _ in synchronizeCheckedConfigurations() }
+        .onChange(of: browser.checkedIDs) { _ in persistCheckedConfigurations() }
+        .onChange(of: feature.selectedConfigurationID) { _ in contentTab = .console }
+        .onChange(of: selectedModuleSession?.isRunning) { isRunning in
+            if isRunning == true { contentTab = .console }
+        }
+        .onChange(of: model.workspaceFeature.workspaceGeneration) { _ in
+            selectionWorkspacePath = nil
+            browser = RunBrowserState()
+            editingConfigurationID = nil
+            contentTab = .console
+        }
+        .popover(isPresented: Binding(
+            get: { editingConfigurationID != nil },
+            set: { if !$0 { editingConfigurationID = nil } }
+        )) {
+            if let configuration = feature.configurations.first(where: { $0.id == editingConfigurationID }) {
+                RunConfigurationEditorView(feature: feature, configuration: configuration)
             }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This will start \(serviceConfigurations.count) detected services.")
-        }
-        .onChange(of: feature.configurations) { _ in
-            synchronizeSelectedServices()
-        }
-        .onAppear {
-            synchronizeSelectedServices()
         }
     }
 
@@ -271,7 +244,7 @@ struct RunView: View {
             title: "Run",
             systemImage: "play.rectangle",
             ideaAssetPath: "toolwindows/toolWindowRun.svg",
-            subtitle: selectedModuleSession?.title ?? feature.runningTitle,
+            subtitle: selectedRunnableConfiguration?.name ?? feature.runningTitle,
             onMinimize: { model.workbenchFeature.setVisibility(.run, isVisible: false) }
         ) {
             if let session = selectedModuleSession {
@@ -279,52 +252,49 @@ struct RunView: View {
             } else if feature.isLoadingProject {
                 ProgressView()
                     .controlSize(.mini)
-            } else if feature.isRunning {
+            } else if selectedSessionID == nil, feature.isRunning {
                 Label("Running", systemImage: "circle.fill")
                     .font(.system(size: 11.5, weight: .medium))
                     .foregroundStyle(LitheTheme.success)
-            } else if let exitCode = feature.lastExitCode {
+            } else if selectedSessionID == nil, let exitCode = feature.lastExitCode {
                 sessionStatus(isRunning: false, exitCode: exitCode)
             }
 
-            if hasServiceConfigurations {
-                Menu {
-                    Section("Services") {
-                        ForEach(serviceConfigurations) { configuration in
-                            Toggle(isOn: serviceSelectionBinding(for: configuration)) {
-                                Label(configuration.name, systemImage: "server.rack")
-                            }
-                        }
-                    }
-                    Divider()
-                    Button {
-                        runSelectedServices()
-                    } label: {
-                        Label("Run selected services", systemImage: "play.fill")
-                    }
-                    .disabled(selectedServiceConfigurations.isEmpty)
-                    Button {
-                        isServiceLaunchConfirmationPresented = true
-                    } label: {
-                        Label("Run all services", systemImage: "square.stack.3d.up.fill")
-                    }
-                    if feature.moduleSessions.contains(where: \.isRunning) {
-                        Button(action: feature.stopAllServices) {
-                            Label("Stop all services", systemImage: "stop.circle")
-                        }
+            if !browser.checkedIDs.isEmpty {
+                Text(String(format: String(localized: "%lld selected"), Int64(browser.checkedIDs.count)))
+                    .font(.system(size: 11))
+                    .foregroundStyle(LitheTheme.secondaryText)
+                Button(action: runCheckedConfigurations) {
+                    Label("Run selected", systemImage: "play.fill")
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(LitheTheme.success)
+                .help("Run checked configurations without restarting running services")
+                .disabled(feature.configurationStatus != .ready || feature.isLoadingProject)
+
+                Button {
+                    for session in feature.moduleSessions where browser.checkedIDs.contains(session.configurationID) && session.isRunning {
+                        feature.stopModule(session)
                     }
                 } label: {
-                    Image(systemName: "square.stack.3d.up.fill")
+                    Image(systemName: "stop.fill")
                 }
                 .litheIconButton()
-                .help("Choose services to run")
-                .disabled(feature.configurationStatus != .ready || feature.isLoadingProject)
+                .help("Stop selected")
+                .disabled(!feature.moduleSessions.contains { browser.checkedIDs.contains($0.configurationID) && $0.isRunning })
+
+                Button { browser.clearSelection() } label: {
+                    Image(systemName: "xmark")
+                }
+                .litheIconButton()
+                .help("Clear selection")
             }
 
             Button {
                 if let session = selectedModuleSession, session.isRunning {
                     feature.stopModule(session)
                 } else if let configuration = selectedRunnableConfiguration {
+                    contentTab = .console
                     model.startRunConfiguration(configuration)
                 } else if feature.isRunning {
                     model.stopSelectedRun()
@@ -341,6 +311,7 @@ struct RunView: View {
 
             Button {
                 if let configuration = selectedRunnableConfiguration {
+                    contentTab = .console
                     model.startRunConfiguration(configuration)
                 } else {
                     model.restartSelectedRun()
@@ -349,7 +320,9 @@ struct RunView: View {
                 LitheSystemIcon(systemImage: "arrow.clockwise")
             }
             .litheIconButton()
-            .disabled(selectedModuleSession == nil && feature.runningTitle == nil && feature.lastExitCode == nil)
+            .disabled(selectedSessionID != nil
+                ? selectedModuleSession == nil
+                : feature.runningTitle == nil && feature.lastExitCode == nil)
             .help("Restart run")
 
             Button {
@@ -364,7 +337,7 @@ struct RunView: View {
             Button {
                 if let session = selectedModuleSession {
                     feature.clearModuleOutput(session)
-                } else {
+                } else if selectedSessionID == nil {
                     feature.clearOutput()
                 }
             } label: {
@@ -372,97 +345,13 @@ struct RunView: View {
             }
             .litheIconButton()
             .help("Clear run output")
+            .disabled(selectedSessionID != nil && selectedModuleSession == nil)
 
         }
     }
 
     private var runnableConfigurations: [RunConfiguration] {
         feature.configurations.filter { $0.kind != .currentFile }
-    }
-
-    private var serviceConfigurations: [RunConfiguration] {
-        runnableConfigurations.filter { $0.execution == .service }
-    }
-
-    private var hasServiceConfigurations: Bool {
-        !serviceConfigurations.isEmpty
-    }
-
-    private var selectedServiceConfigurations: [RunConfiguration] {
-        serviceConfigurations.filter { selectedServiceIDs.contains($0.id) }
-    }
-
-    private func synchronizeSelectedServices() {
-        guard !serviceConfigurations.isEmpty else { return }
-        let serviceIDs = Set(serviceConfigurations.map(\.id))
-        let workspacePath = model.workspaceURL?.standardizedFileURL.path ?? ""
-        if selectedServicesWorkspacePath != workspacePath {
-            selectedServicesWorkspacePath = workspacePath
-            selectedServiceIDs = []
-            hasHydratedServiceSelection = false
-        }
-        let persistedSelections = persistedServiceSelections()
-        let hasPersistedSelection = persistedSelections.keys.contains(workspacePath)
-        let persistedIDs = Set(persistedSelections[workspacePath] ?? [])
-        let retained = (hasHydratedServiceSelection ? selectedServiceIDs :
-            (selectedServiceIDs.isEmpty ? persistedIDs : selectedServiceIDs))
-            .intersection(serviceIDs)
-        if hasHydratedServiceSelection || hasPersistedSelection || !retained.isEmpty {
-            selectedServiceIDs = retained
-            hasHydratedServiceSelection = true
-            return
-        }
-
-        let preferred = serviceConfigurations.first(where: { $0.id == feature.selectedConfigurationID })
-            ?? serviceConfigurations.first
-        selectedServiceIDs = preferred.map { [$0.id] } ?? []
-        hasHydratedServiceSelection = true
-        persistSelectedServices()
-    }
-
-    private func serviceSelectionBinding(for configuration: RunConfiguration) -> Binding<Bool> {
-        Binding(
-            get: { selectedServiceIDs.contains(configuration.id) },
-            set: { isSelected in
-                if isSelected {
-                    selectedServiceIDs.insert(configuration.id)
-                } else {
-                    selectedServiceIDs.remove(configuration.id)
-                }
-                hasHydratedServiceSelection = true
-                persistSelectedServices()
-            }
-        )
-    }
-
-    private func persistSelectedServices() {
-        guard let workspacePath = model.workspaceURL?.standardizedFileURL.path else { return }
-        var selections = persistedServiceSelections()
-        selections[workspacePath] = selectedServiceIDs.sorted()
-        guard let data = try? JSONSerialization.data(withJSONObject: selections, options: [.sortedKeys]),
-              let encoded = String(data: data, encoding: .utf8) else { return }
-        selectedServiceTokens = encoded
-    }
-
-    private func persistedServiceSelections() -> [String: [String]] {
-        guard let data = selectedServiceTokens.data(using: .utf8),
-              let object = try? JSONSerialization.jsonObject(with: data),
-              let selections = object as? [String: [String]] else {
-            // Accept the pre-JSON format once so existing users keep their choices.
-            let prefix = (model.workspaceURL?.standardizedFileURL.path ?? "") + "::"
-            let ids = selectedServiceTokens.split(separator: "\n").map(String.init)
-                .filter { $0.hasPrefix(prefix) }.map { String($0.dropFirst(prefix.count)) }
-            return ids.isEmpty ? [:] : [String(prefix.dropLast(2)): ids]
-        }
-        return selections
-    }
-
-    private func runSelectedServices() {
-        let services = selectedServiceConfigurations
-        guard !services.isEmpty else { return }
-        model.startSelectedServiceConfigurations(services)
-        model.selectRunConfiguration(services[0])
-        selectedSessionID = services.first?.id
     }
 
     private var hasRunnableConfigurations: Bool {
@@ -508,16 +397,7 @@ struct RunView: View {
 
     @ViewBuilder
     private var selectedConfigurationContent: some View {
-        if let session = selectedModuleSession {
-            OutputTextView(
-                output: session.output,
-                searchRoots: feature.sourceSearchRoots,
-                fileExists: { model.fileExists(at: $0) },
-                emptyMessage: String(localized: "Process output will appear here.")
-            ) { url, line, column in
-                model.openSourceLocation(url: url, line: line, column: column)
-            }
-        } else if let configuration = selectedRunnableConfiguration {
+        if let configuration = selectedRunnableConfiguration {
             configurationContent(configuration)
         } else {
             OutputTextView(
@@ -529,10 +409,6 @@ struct RunView: View {
                 model.openSourceLocation(url: url, line: line, column: column)
             }
         }
-    }
-
-    private var collapsedExecutions: Set<String> {
-        collapsedExecutionCache.tokens(from: collapsedExecutionIDs, separator: ",")
     }
 
     private var pinnedConfigurationTokenSet: Set<String> {
@@ -548,16 +424,6 @@ struct RunView: View {
         pinnedConfigurationTokenSet.contains(pinToken(for: configuration))
     }
 
-    private func toggleCollapsed(_ execution: RunConfigurationExecution) {
-        var values = collapsedExecutions
-        if values.contains(execution.rawValue) {
-            values.remove(execution.rawValue)
-        } else {
-            values.insert(execution.rawValue)
-        }
-        collapsedExecutionIDs = values.sorted().joined(separator: ",")
-    }
-
     private func togglePinned(_ configuration: RunConfiguration) {
         var values = pinnedConfigurationTokenSet
         let token = pinToken(for: configuration)
@@ -571,141 +437,229 @@ struct RunView: View {
         }
     }
 
-    private var pinnedRunnableConfigurations: [RunConfiguration] {
-        runnableConfigurations
-            .filter(isPinned)
-            .sorted(by: configurationNamePrecedes)
+    private var pinnedIDs: Set<String> {
+        Set(runnableConfigurations.filter(isPinned).map(\.id))
     }
 
-    private func unpinnedConfigurations(
-        for execution: RunConfigurationExecution
-    ) -> [RunConfiguration] {
-        runnableConfigurations
-            .filter { $0.execution == execution && !isPinned($0) }
-            .sorted(by: configurationNamePrecedes)
+    private func configurations(in scope: RunBrowserState.Scope) -> [RunConfiguration] {
+        browser.configurations(in: scope, from: runnableConfigurations, pinnedIDs: pinnedIDs)
     }
 
-    private func configurationNamePrecedes(
-        _ left: RunConfiguration,
-        _ right: RunConfiguration
-    ) -> Bool {
-        left.name.localizedStandardCompare(right.name) == .orderedAscending
-    }
-
-    private var moduleSessionList: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 6) {
-                Text(hasServiceConfigurations ? "Services" : "Run configurations")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(LitheTheme.secondaryText)
-                Spacer(minLength: 0)
-                Button {
-                    isConfigurationListCollapsed = true
-                } label: {
-                    Image(systemName: "chevron.left")
+    @ViewBuilder
+    private var scopeList: some View {
+        if isConfigurationListCollapsed {
+            collapsedConfigurationListBar
+        } else {
+            VStack(spacing: 0) {
+                HStack(spacing: 6) {
+                    Text("Services").font(.system(size: 11, weight: .semibold))
+                    Spacer(minLength: 0)
+                    Button { isConfigurationListCollapsed = true } label: {
+                        Image(systemName: "chevron.left")
+                    }
+                    .litheIconButton()
+                    .help("Hide configuration list")
                 }
-                .litheIconButton()
-                .help("Hide configuration list")
-                .accessibilityLabel("Hide configuration list")
+                .padding(.horizontal, 8)
+                .frame(height: 30)
+                Rectangle().fill(LitheTheme.divider).frame(height: 1)
+                ScrollView(.vertical) {
+                    VStack(spacing: 3) {
+                        scopeRow(.all, title: "All configurations", systemImage: "square.stack.3d.up")
+                        scopeRow(.pinned, title: "Pinned", systemImage: "pin")
+                        ForEach(RunConfigurationExecution.displayOrder, id: \.self) { execution in
+                            if !configurations(in: .execution(execution)).isEmpty {
+                                scopeRow(
+                                    .execution(execution),
+                                    title: String(localized: String.LocalizationValue(execution.sectionTitle)),
+                                    systemImage: execution == .service ? "server.rack" : "play.rectangle"
+                                )
+                            }
+                        }
+                        Rectangle().fill(LitheTheme.divider).frame(height: 1).padding(.vertical, 5)
+                        sessionRow(
+                            title: String(localized: "Current run"),
+                            subtitle: feature.runningTitle ?? String(localized: "Current File"),
+                            isRunning: feature.isRunning,
+                            exitCode: feature.lastExitCode,
+                            isSelected: selectedSessionID == nil,
+                            onToggle: nil
+                        ) {
+                            selectedSessionID = nil
+                            contentTab = .console
+                            feature.select(.currentFile)
+                        }
+                    }
+                    .padding(6)
+                }
             }
-            .padding(.leading, 12)
-            .padding(.trailing, 5)
+            .litheWorkbenchSurface(LitheTheme.sidebar)
+        }
+    }
+
+    private func scopeRow(_ scope: RunBrowserState.Scope, title: String, systemImage: String) -> some View {
+        let entries = configurations(in: scope)
+        return HStack(spacing: 6) {
+            selectionCheckbox(entries, title: String(localized: String.LocalizationValue(title)))
+            Button {
+                browser.scope = scope
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: systemImage).frame(width: 16)
+                    Text(String(localized: String.LocalizationValue(title))).lineLimit(1)
+                    Spacer(minLength: 0)
+                    Text(String(entries.count)).foregroundStyle(LitheTheme.secondaryText)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .lithePointer()
+        }
+        .font(.system(size: 11.5))
+        .padding(.horizontal, 6)
+        .frame(height: 30)
+        .background(browser.scope == scope ? LitheTheme.subtleSelection : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+
+    private var applicationTypeList: some View {
+        let entries = configurations(in: browser.scope)
+        let groups = RunBrowserState.groups(for: entries)
+        return VStack(spacing: 0) {
+            HStack(spacing: 6) {
+                selectionCheckbox(entries, title: String(localized: "Application types"))
+                Text("Application types")
+                Spacer(minLength: 0)
+                Text(String(entries.count)).foregroundStyle(LitheTheme.secondaryText)
+            }
+            .font(.system(size: 11, weight: .semibold))
+            .padding(.horizontal, 12)
             .frame(height: 30)
-
-            Rectangle()
-                .fill(LitheTheme.divider)
-                .frame(height: 1)
-
-            ScrollView(.vertical) {
-                VStack(alignment: .leading, spacing: 2) {
-                    let pinnedConfigurations = pinnedRunnableConfigurations
-                    if !pinnedConfigurations.isEmpty {
-                        pinnedSectionHeader(count: pinnedConfigurations.count)
-
-                        ForEach(pinnedConfigurations) { configuration in
-                            configurationRow(configuration)
-                        }
-                    }
-
-                    let services = unpinnedConfigurations(for: .service)
-                    if !services.isEmpty {
-                        sectionHeader(.service, count: services.count)
-                        if !collapsedExecutions.contains(RunConfigurationExecution.service.rawValue) {
-                            ForEach(services) { configuration in
-                                configurationRow(configuration)
-                            }
-                        }
-                    }
-
-                    let otherExecutions = RunConfigurationExecution.displayOrder.filter { $0 != .service }
-                    let otherCount = otherExecutions.reduce(0) { partial, execution in
-                        partial + unpinnedConfigurations(for: execution).count
-                    }
-                    if otherCount > 0 {
-                        Button {
-                            withAnimation(.easeInOut(duration: 0.18)) {
-                                areOtherConfigurationsCollapsed.toggle()
-                            }
-                        } label: {
-                            HStack(spacing: 5) {
-                                Image(systemName: areOtherConfigurationsCollapsed ? "chevron.right" : "chevron.down")
-                                    .font(.system(size: 9, weight: .bold))
-                                    .frame(width: 10)
-                                Text("Other run configurations")
-                                Spacer(minLength: 0)
-                                Text(String(otherCount))
-                                    .font(.system(size: 10))
-                                    .foregroundStyle(LitheTheme.secondaryText)
-                            }
-                            .font(.system(size: 10.5, weight: .semibold))
-                            .foregroundStyle(LitheTheme.secondaryText)
-                            .padding(.horizontal, 6)
-                            .padding(.top, 8)
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .lithePointer()
-                        .help(areOtherConfigurationsCollapsed ? "Expand" : "Collapse")
-                        .accessibilityLabel("Other run configurations")
-                        .accessibilityValue(areOtherConfigurationsCollapsed ? "Collapsed" : "Expanded")
-
-                        if !areOtherConfigurationsCollapsed {
-                            ForEach(otherExecutions, id: \.self) { execution in
-                                let configurations = unpinnedConfigurations(for: execution)
-                                if !configurations.isEmpty {
-                                    sectionHeader(execution, count: configurations.count)
-                                    if !collapsedExecutions.contains(execution.rawValue) {
-                                        ForEach(configurations) { configuration in
-                                            configurationRow(configuration)
-                                        }
-                                    }
+            Rectangle().fill(LitheTheme.divider).frame(height: 1)
+            if entries.isEmpty {
+                Text("No configurations in this scope")
+                    .font(.system(size: 11))
+                    .foregroundStyle(LitheTheme.secondaryText)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(12)
+            } else {
+                ScrollView(.vertical) {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(groups) { group in
+                            applicationGroupHeader(group)
+                            if !browser.collapsedGroupIDs.contains(group.id) {
+                                ForEach(group.configurations) { configuration in
+                                    configurationRow(configuration)
                                 }
                             }
                         }
                     }
+                    .padding(6)
                 }
             }
-                .padding(7)
         }
         .litheWorkbenchSurface(LitheTheme.sidebar)
     }
 
-    private func pinnedSectionHeader(count: Int) -> some View {
-        HStack(spacing: 5) {
-            Image(systemName: "pin.fill")
-                .font(.system(size: 9, weight: .semibold))
-                .frame(width: 10)
-            Text("Pinned")
-            Spacer(minLength: 0)
-            Text(String(count))
-                .font(.system(size: 10))
-                .foregroundStyle(LitheTheme.secondaryText)
+    private func applicationGroupHeader(_ group: RunBrowserState.ApplicationGroup) -> some View {
+        let isCollapsed = browser.collapsedGroupIDs.contains(group.id)
+        return HStack(spacing: 6) {
+            selectionCheckbox(group.configurations, title: group.title)
+            Button {
+                if isCollapsed {
+                    browser.collapsedGroupIDs.remove(group.id)
+                } else {
+                    browser.collapsedGroupIDs.insert(group.id)
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                    RunConfigurationIcon(kind: group.iconKind, size: 14)
+                    Text(String(localized: String.LocalizationValue(group.title)))
+                    Spacer(minLength: 0)
+                    Text(String(group.configurations.count)).foregroundStyle(LitheTheme.secondaryText)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .lithePointer()
+            .help(isCollapsed ? "Expand" : "Collapse")
+            .accessibilityValue(isCollapsed ? "Collapsed" : "Expanded")
         }
-        .font(.system(size: 10.5, weight: .semibold))
-        .foregroundStyle(LitheTheme.accent)
+        .font(.system(size: 11, weight: .semibold))
         .padding(.horizontal, 6)
-        .padding(.top, 2)
-        .accessibilityElement(children: .combine)
+        .frame(height: 28)
+    }
+
+    private func selectionCheckbox(_ entries: [RunConfiguration], title: String) -> some View {
+        let state = browser.checkState(for: entries)
+        return Button { browser.toggle(entries) } label: {
+            Image(systemName: state == .checked ? "checkmark.square.fill" : state == .mixed ? "minus.square.fill" : "square")
+                .font(.system(size: 13))
+                .foregroundStyle(state == .unchecked ? LitheTheme.secondaryText : LitheTheme.accent)
+                .frame(width: 18, height: 24)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .lithePointer()
+        .disabled(entries.isEmpty || feature.isLoadingProject)
+        .help("Select configurations for batch actions")
+        .accessibilityLabel(String(format: String(localized: "Select %@"), title))
+        .accessibilityValue(state == .checked ? "Selected" : state == .mixed ? "Partially selected" : "Not selected")
+    }
+
+    private func synchronizeCheckedConfigurations() {
+        guard let workspace = model.workspaceURL?.standardizedFileURL,
+              feature.hasReadyInventory(for: workspace) else { return }
+        if selectionWorkspacePath != workspace.path {
+            browser.restoreSelection(
+                persistedConfigurationSelections()[workspace.path] ?? [],
+                configurations: runnableConfigurations
+            )
+            selectionWorkspacePath = workspace.path
+        } else {
+            browser.retainConfigurations(runnableConfigurations)
+        }
+    }
+
+    private func persistCheckedConfigurations() {
+        guard let path = model.workspaceURL?.standardizedFileURL.path,
+              selectionWorkspacePath == path else { return }
+        var selections = persistedConfigurationSelections()
+        selections[path] = browser.checkedIDs.sorted()
+        do {
+            let data = try JSONSerialization.data(withJSONObject: selections, options: [.sortedKeys])
+            selectedConfigurationTokens = String(decoding: data, as: UTF8.self)
+        } catch {
+            model.showNotification("Could not save service selection")
+        }
+    }
+
+    private func persistedConfigurationSelections() -> [String: [String]] {
+        if let data = selectedConfigurationTokens.data(using: .utf8),
+           let selections = try? JSONSerialization.jsonObject(with: data) as? [String: [String]] {
+            return selections
+        }
+        // Keep the legacy workspace-prefixed format readable during migration.
+        let path = model.workspaceURL?.standardizedFileURL.path ?? ""
+        let prefix = path + "::"
+        let ids = selectedConfigurationTokens.split(separator: "\n").map(String.init)
+            .filter { $0.hasPrefix(prefix) }.map { String($0.dropFirst(prefix.count)) }
+        return ids.isEmpty ? [:] : [path: ids]
+    }
+
+    private func runCheckedConfigurations() {
+        let checked = runnableConfigurations.filter { browser.checkedIDs.contains($0.id) }
+        guard !checked.isEmpty else { return }
+        if let configuration = checked.first(where: { candidate in
+            !feature.moduleSessions.contains { $0.id == candidate.id && $0.isRunning }
+        }) ?? checked.first {
+            selectedSessionID = configuration.id
+            feature.select(configuration)
+        }
+        contentTab = .console
+        model.startRunConfigurations(checked.map(\.id))
     }
 
     private func configurationRow(_ configuration: RunConfiguration) -> some View {
@@ -722,29 +676,21 @@ struct RunView: View {
             isSelected: selectedSessionID == configuration.id,
             isPinned: isPinned(configuration),
             onPin: { togglePinned(configuration) },
-            onEdit: {
-                editingConfigurationID = configuration.id
-            },
-            isEditing: Binding(
-                get: { editingConfigurationID == configuration.id },
-                set: { isPresented in
-                    if !isPresented, editingConfigurationID == configuration.id {
-                        editingConfigurationID = nil
-                    }
-                }
-            ),
-            editorConfiguration: configuration,
+            onEdit: { editingConfigurationID = configuration.id },
+            checkedConfiguration: configuration,
             onToggle: {
                 if let session, session.isRunning {
                     feature.stopModule(session)
                 } else {
                     feature.select(configuration)
+                    contentTab = .console
                     model.startRunConfiguration(configuration)
                     selectedSessionID = configuration.id
                 }
             }
         ) {
             selectedSessionID = configuration.id
+            contentTab = .console
             feature.select(configuration)
         }
     }
@@ -768,38 +714,65 @@ struct RunView: View {
 
     private func configurationContent(_ configuration: RunConfiguration) -> some View {
         let session = feature.moduleSessions.first { $0.id == configuration.id }
-
         return VStack(spacing: 0) {
-            configurationDetail(configuration, session: session)
-                .frame(maxHeight: session == nil ? .infinity : 220, alignment: .top)
-
-            if let session {
-                Rectangle()
-                    .fill(LitheTheme.divider)
-                    .frame(height: 1)
-
-                HStack(spacing: 6) {
-                    Image(systemName: "terminal")
-                    Text("Process output")
-                    Spacer(minLength: 0)
+            HStack(spacing: 8) {
+                RunConfigurationIcon(kind: configuration.kind, size: 16)
+                Text(configuration.name)
+                    .font(.system(size: 12, weight: .semibold))
+                    .lineLimit(1)
+                    .help(configuration.name)
+                Spacer(minLength: 8)
+                statusLabel(for: session)
+                Button { editingConfigurationID = configuration.id } label: {
+                    Image(systemName: "gearshape")
                 }
-                .font(.system(size: 10.5, weight: .semibold))
-                .foregroundStyle(LitheTheme.secondaryText)
-                .padding(.horizontal, 12)
-                .frame(height: 28)
-                .background(LitheTheme.sidebar.opacity(0.45))
-
+                .litheIconButton()
+                .help("Edit run configuration")
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 34)
+            HStack(spacing: 12) {
+                contentTabButton("Console", tab: .console, systemImage: "terminal")
+                contentTabButton("Configuration details", tab: .details, systemImage: "slider.horizontal.3")
+                Spacer(minLength: 0)
+                if session?.isRunning == true, let url = feature.serviceURL(for: configuration) {
+                    Link(destination: url) { Image(systemName: "arrow.up.right.square") }
+                        .help(url.absoluteString)
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 30)
+            Rectangle().fill(LitheTheme.divider).frame(height: 1)
+            if contentTab == .details {
+                configurationDetail(configuration, session: session)
+            } else {
                 OutputTextView(
-                    output: session.output,
+                    output: session?.output ?? "",
                     searchRoots: feature.sourceSearchRoots,
                     fileExists: { model.fileExists(at: $0) },
-                    emptyMessage: String(localized: "Process output will appear here.")
+                    emptyMessage: String(localized: "Start this configuration to see its output here.")
                 ) { url, line, column in
                     model.openSourceLocation(url: url, line: line, column: column)
                 }
+                .id(configuration.id)
             }
         }
         .litheWorkbenchSurface(LitheTheme.editor)
+    }
+
+    private func contentTabButton(_ title: LocalizedStringKey, tab: ContentTab, systemImage: String) -> some View {
+        Button { contentTab = tab } label: {
+            Label(title, systemImage: systemImage)
+                .font(.system(size: 11, weight: contentTab == tab ? .semibold : .regular))
+                .foregroundStyle(contentTab == tab ? LitheTheme.accent : LitheTheme.secondaryText)
+                .frame(height: 30)
+                .overlay(alignment: .bottom) {
+                    if contentTab == tab { Rectangle().fill(LitheTheme.accent).frame(height: 2) }
+                }
+        }
+        .buttonStyle(.plain)
+        .lithePointer()
+        .accessibilityAddTraits(contentTab == tab ? .isSelected : [])
     }
 
     private func configurationDetail(
@@ -817,29 +790,6 @@ struct RunView: View {
 
         return ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: 14) {
-                HStack(spacing: 11) {
-                    RunConfigurationIcon(kind: configuration.kind, size: 22)
-                        .frame(width: 34, height: 34)
-                        .background(LitheTheme.accent.opacity(0.10))
-                        .clipShape(RoundedRectangle(cornerRadius: 7))
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(configuration.name)
-                            .font(.system(size: 14, weight: .semibold))
-                            .textSelection(.enabled)
-                        Text(String(localized: String.LocalizationValue(configuration.kind.title)))
-                            .font(.system(size: 11))
-                            .foregroundStyle(LitheTheme.secondaryText)
-                    }
-
-                    Spacer(minLength: 10)
-                    statusLabel(for: session)
-                }
-
-                Rectangle()
-                    .fill(LitheTheme.divider)
-                    .frame(height: 1)
-
                 HStack(alignment: .firstTextBaseline) {
                     Text("Configuration details")
                         .font(.system(size: 11.5, weight: .semibold))
@@ -1018,33 +968,6 @@ struct RunView: View {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private func sectionHeader(_ execution: RunConfigurationExecution, count: Int) -> some View {
-        Button {
-            toggleCollapsed(execution)
-        } label: {
-            HStack(spacing: 5) {
-                Image(systemName: collapsedExecutions.contains(execution.rawValue) ? "chevron.right" : "chevron.down")
-                    .font(.system(size: 9, weight: .bold))
-                    .frame(width: 10)
-                Text(String(localized: String.LocalizationValue(execution.sectionTitle)))
-                Spacer(minLength: 0)
-                Text(String(count))
-                    .font(.system(size: 10))
-                    .foregroundStyle(LitheTheme.secondaryText)
-            }
-            .font(.system(size: 10.5, weight: .semibold))
-            .foregroundStyle(LitheTheme.secondaryText)
-            .padding(.horizontal, 6)
-            .padding(.top, 8)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .lithePointer()
-        .help(collapsedExecutions.contains(execution.rawValue) ? "Expand" : "Collapse")
-        .accessibilityLabel(String(localized: String.LocalizationValue(execution.sectionTitle)))
-        .accessibilityValue(collapsedExecutions.contains(execution.rawValue) ? "Collapsed" : "Expanded")
-    }
-
     private func sessionStatus(isRunning: Bool, exitCode: Int32?) -> some View {
         Group {
             if isRunning {
@@ -1071,12 +994,14 @@ struct RunView: View {
         isPinned: Bool = false,
         onPin: (() -> Void)? = nil,
         onEdit: (() -> Void)? = nil,
-        isEditing: Binding<Bool> = .constant(false),
-        editorConfiguration: RunConfiguration? = nil,
+        checkedConfiguration: RunConfiguration? = nil,
         onToggle: (() -> Void)?,
         action: @escaping () -> Void
     ) -> some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 6) {
+                if let checkedConfiguration {
+                    selectionCheckbox([checkedConfiguration], title: checkedConfiguration.name)
+                }
                 ZStack(alignment: .bottomTrailing) {
                     if let configurationKind {
                         RunConfigurationIcon(kind: configurationKind, size: 16)
@@ -1138,7 +1063,7 @@ struct RunView: View {
                     .help(isPinned ? "Unpin configuration" : "Pin configuration")
                     .accessibilityLabel(isPinned ? "Unpin configuration" : "Pin configuration")
                 }
-                if let onEdit, let editorConfiguration {
+                if let onEdit {
                     Button(action: onEdit) {
                         Image(systemName: "gearshape")
                     }
@@ -1146,12 +1071,7 @@ struct RunView: View {
                     .foregroundStyle(LitheTheme.secondaryText)
                     .help("Edit run configuration")
                     .disabled(feature.configurationStatus != .ready || feature.isLoadingProject)
-                    .popover(isPresented: isEditing, arrowEdge: .trailing) {
-                        RunConfigurationEditorView(
-                            feature: feature,
-                            configuration: editorConfiguration
-                        )
-                    }
+
                 }
                 if let onToggle {
                     Button(action: onToggle) {

--- a/macos/Tests/LitheTests/RunBrowserStateTests.swift
+++ b/macos/Tests/LitheTests/RunBrowserStateTests.swift
@@ -1,0 +1,80 @@
+import Testing
+@testable import Lithe
+
+@Suite("Services browser selection and layout")
+struct RunBrowserStateTests {
+    private let node = RunConfiguration(id: "npm:web", name: "web", kind: .process(provider: "npm.script"), execution: .service, modulePath: nil, mainClass: nil)
+    private let rust = RunConfiguration(id: "cargo:worker", name: "worker", kind: .process(provider: "cargo.run"), modulePath: nil, mainClass: nil)
+    private let java = RunConfiguration(id: "java:api", name: "api", kind: .javaMain, modulePath: nil, mainClass: "demo.Api")
+    private let spring = RunConfiguration(id: "spring:api", name: "api", kind: .springBoot, modulePath: nil, mainClass: "demo.Api")
+
+    @Test func groupsApplicationFamiliesAcrossExecutionCategories() {
+        let groups = RunBrowserState.groups(for: [spring, rust, .currentFile, node, java])
+        #expect(groups.map(\.title) == ["Java", "Node", "Rust"])
+        #expect(groups[0].configurations.map(\.id) == [java.id, spring.id])
+        #expect(groups[1].configurations == [node])
+        #expect(groups[2].configurations == [rust])
+        #expect(RunBrowserState.groups(for: [java, node, rust, spring]).map(\.id) == groups.map(\.id))
+    }
+
+    @Test func unknownProvidersRemainVisible() {
+        let unknown = RunConfiguration(id: "custom:run", name: "run", kind: .process(provider: "custom.launch"), modulePath: nil, mainClass: nil)
+        let groups = RunBrowserState.groups(for: [unknown, node])
+        #expect(groups.map(\.title) == ["Custom", "Node"])
+        #expect(groups[0].configurations == [unknown])
+    }
+
+    @Test func overlappingScopesShareSelectionAndMixedState() {
+        var browser = RunBrowserState()
+        let all = [node, rust, java, spring, .currentFile]
+        let services = browser.configurations(in: .execution(.service), from: all, pinnedIDs: [node.id])
+        browser.toggle(services)
+        #expect(browser.checkedIDs == [node.id, spring.id])
+        #expect(browser.checkState(for: [java, spring]) == .mixed)
+        browser.scope = .pinned
+        let pinned = browser.configurations(in: .pinned, from: all, pinnedIDs: [node.id])
+        #expect(browser.checkState(for: pinned) == .checked)
+        browser.toggle([java, spring])
+        #expect(browser.checkedIDs == [node.id, java.id, spring.id])
+        browser.toggle(pinned)
+        #expect(browser.checkedIDs == [java.id, spring.id])
+        #expect(browser.checkState(for: services) == .mixed)
+    }
+
+    @Test func restoringSavedChoicesDropsRemovedConfigurations() {
+        var browser = RunBrowserState()
+        browser.restoreSelection([node.id, rust.id, "removed", RunConfiguration.currentFileID], configurations: [node, rust, .currentFile])
+        #expect(browser.checkedIDs == [node.id, rust.id])
+        #expect(browser.checkState(for: [node]) == .checked)
+        browser.restoreSelection([], configurations: [node, rust])
+        #expect(browser.checkedIDs.isEmpty)
+    }
+
+    @Test func pruningAndEmptyScopesNeverSelectCurrentFile() {
+        var browser = RunBrowserState()
+        browser.toggle([node, rust, .currentFile])
+        browser.retainConfigurations([rust, java, .currentFile])
+        #expect(browser.checkedIDs == [rust.id])
+        browser.toggle([])
+        #expect(browser.checkState(for: []) == .unchecked)
+        browser.clearSelection()
+        #expect(browser.checkedIDs.isEmpty)
+    }
+
+    @Test @MainActor func splitBoundsReserveUsableAdjacentColumns() {
+        for collapsed in [false, true] {
+            let minimum = RunServicesLayout.minimumWidth(isScopeCollapsed: collapsed)
+            for available in [0.0, 320, 710, 1024, 1920] {
+                let canvas = max(available, minimum)
+                let scope = collapsed ? RunServicesLayout.collapsedScopeWidth : RunServicesLayout.scopeMaximum(in: canvas)
+                let separator = collapsed ? 1.0 : SplitHandleView.thickness
+                let remaining = canvas - scope - separator
+                let configurations = RunServicesLayout.configurationMaximum(in: remaining)
+                let output = remaining - configurations - SplitHandleView.thickness
+                #expect(configurations >= RunServicesLayout.configurationMinimum)
+                #expect(output >= RunServicesLayout.outputMinimum)
+                #expect(scope >= (collapsed ? RunServicesLayout.collapsedScopeWidth : RunServicesLayout.scopeMinimum))
+            }
+        }
+    }
+}

--- a/macos/Tests/LitheTests/RunEntryPointTests.swift
+++ b/macos/Tests/LitheTests/RunEntryPointTests.swift
@@ -283,6 +283,32 @@ struct RunEntryPointTests {
         #expect(model.pendingRunAction == nil)
     }
 
+    @Test
+    func checkedBatchDefersTogetherAndAttemptsEveryUniqueConfiguration() async throws {
+        let workspace = try JavaWorkspaceFixture()
+        defer { workspace.remove() }
+        let operations = SequencedWorkspaceOperations.unavailableThenReady(workspace.snapshot)
+        let runConfigurations = ReadyRunConfigurationOperations()
+        let model = makeAppModel(workspaceOperations: operations, runConfigurationOperations: runConfigurations)
+        defer { model.closeProject() }
+        let ids = [ReadyRunConfigurationOperations.entryPoint.id, ReadyRunConfigurationOperations.serviceEntryPoint.id]
+
+        model.openProjectDirectly(workspace.root)
+        await model.performStartRunConfigurations(ids + [ids[0]])
+        #expect(model.pendingRunAction?.kind == .startConfigurations(ids.sorted()))
+        #expect(runConfigurations.launchPlanCallCount == 0)
+
+        await model.workspaceFeature.refreshCurrent()
+        #expect(await runConfigurations.launchPlanRequested(2))
+        #expect(model.pendingRunAction == nil)
+        #expect(runConfigurations.launchPlanCallCount == 2)
+        // The stub fails each launch plan: one failure must not prevent the
+        // remaining checked configuration from receiving its own output session.
+        let feature = try #require(model.runFeatureIfActive)
+        #expect(Set(feature.moduleSessions.map(\.configurationID)) == Set(ids))
+        #expect(feature.moduleSessions.allSatisfy { $0.exitCode == 1 && !$0.output.isEmpty })
+    }
+
     /// The Run panel's "Run All Services" button calls `runAllServiceConfigurations`,
     /// which must defer under a provisional inventory and remember that batch
     /// intent — not collapse into a generic `.run`.

--- a/macos/Tests/LitheTests/RunWorkflowCoordinatorTests.swift
+++ b/macos/Tests/LitheTests/RunWorkflowCoordinatorTests.swift
@@ -96,9 +96,10 @@ struct RunWorkflowCoordinatorTests {
         )
 
         coordinator.performDeferredAction(.startConfiguration(configuration))
+        coordinator.performDeferredAction(.startConfigurations(["java-main", "npm:web"]))
         coordinator.performDeferredAction(.restart)
 
-        #expect(actions.events == ["start:java-main", "restart"])
+        #expect(actions.events == ["start:java-main", "batch:java-main,npm:web", "restart"])
     }
 
     /// The pending action belongs to the opening that recorded it. A resume for

--- a/macos/Tests/LitheTests/WorkflowActionsSpy.swift
+++ b/macos/Tests/LitheTests/WorkflowActionsSpy.swift
@@ -73,6 +73,10 @@ final class WorkflowActionsSpy: DebugSessionCleanupActions, RunWorkflowActions {
         events.append("start-selected-services:\(configurations.map(\.id).joined(separator: ","))")
     }
 
+    func startRunConfigurations(_ configurationIDs: [String]) {
+        events.append("batch:" + configurationIDs.joined(separator: ","))
+    }
+
     func runAllServiceConfigurations() {
         events.append("run-all-services")
     }


### PR DESCRIPTION
PR #641 was based on the wrong history, so this branch cherry-picks its single feature commit onto the current `preview` head. The resulting Services window provides three-column grouping, shared checkbox selection, batch starts, constrained resizable panes, and matching English and Simplified Chinese strings.

Validation:
- `./.agents/skills/write-stable-tests/scripts/verify-test-stability.sh`
- Timed changed tests: 6 `RunBrowserStateTests`, the batch entry-point test, and the deferred-action dispatch test all passed
- `./scripts/verify-service-boundaries.sh`
- `./scripts/test-macos.sh --no-parallel --filter 'RunBrowserStateTests|RunEntryPointTests|RunWorkflowCoordinatorTests|RunConfigurationIntegrationTests'` (149 tests passed)
- `git diff --check origin/preview..HEAD`

The full parallel `./scripts/test-macos.sh` run executed 1,275 tests. All affected tests passed, while unrelated Git, module-shutdown, media, and stable-rollback tests reported 32 existing parallel-run issues.
